### PR TITLE
Add basic styles for mobile views

### DIFF
--- a/react/src/App.scss
+++ b/react/src/App.scss
@@ -5,6 +5,7 @@
 @import "./scss/mixins";
 @import "./scss/fonts";
 @import "./scss/globals";
+@import "./scss/layout";
 @import "./scss/icons";
 @import "./scss/header";
 @import "./scss/footer";

--- a/react/src/components/Homepage.js
+++ b/react/src/components/Homepage.js
@@ -16,7 +16,7 @@ class Homepage extends Component {
       <div class="homepage">
         <div className="ds-l-container">
           <div className="ds-l-row">
-            <div className="page-title">
+            <div className="page-title ds-l-col--12">
               <h1>
                 Children's Health Insurance Program Annual Report Template
                 System (CARTS)
@@ -24,7 +24,7 @@ class Homepage extends Component {
             </div>
           </div>
           <div className="ds-l-row">
-            <div className="updates">
+            <div className="updates ds-l-col--12">
               <h4>Updates from Central Office</h4>
               <div className="update ds-l-row">
                 <div className="icon ds-l-col--2">
@@ -58,7 +58,7 @@ class Homepage extends Component {
             </div>
           </div>
           <div className="ds-l-row">
-            <div className="reports">
+            <div className="reports ds-l-col--12">
               <h3>CARTS reports</h3>
               <table className="ds-c-table ds-c-table--borderless">
                 <thead>
@@ -180,12 +180,14 @@ class Homepage extends Component {
             </div>
           </div>
           <div className="ds-l-row">
-            <div class="omb-info">
-              The OMB control number for this information is OMB 0938-1148. The
-              time required to complete this information collection is estimated
-              to 40 hours per response, including the time to review
-              instructions, search existing data resources, gather data, and
-              review and submit the information.
+            <div class="omb-info ds-l-col--12">
+              <p>
+                The OMB control number for this information is OMB 0938-1148.
+                The time required to complete this information collection is
+                estimated to 40 hours per response, including the time to review
+                instructions, search existing data resources, gather data, and
+                review and submit the information.
+              </p>
             </div>
           </div>
         </div>

--- a/react/src/scss/_footer.scss
+++ b/react/src/scss/_footer.scss
@@ -5,6 +5,11 @@
   background: $color-gray-lightest;
   font-size: 0.85rem;
   color: $color-gray;
+  text-align: center;
+
+  @media only screen and (min-width: 768px) {
+    text-align: left;
+  }
 
   .adverts {
     padding: ($padding * 6) $padding;
@@ -18,6 +23,7 @@
   .cms-copy {
     display: inline-block;
     padding-left: ($padding * 2);
+    text-align: left;
     vertical-align: top;
     width: calc(100% - 86px);
   }
@@ -52,7 +58,12 @@
     }
 
     .address {
-      text-align: right;
+      margin-top: $margin;
+
+      @media only screen and (min-width: 768px) {
+        margin-top: 0;
+        text-align: right;
+      }
     }
   }
 }

--- a/react/src/scss/_form.scss
+++ b/react/src/scss/_form.scss
@@ -11,7 +11,6 @@
 
 .question-container {
   margin-bottom: ($padding * 4);
-  padding-right: ($padding * 3);
   position: relative;
 
   .fill-form.active,
@@ -21,7 +20,7 @@
     overflow: hidden;
     position: relative;
     right: 0;
-    top: 0;
+    top: 28px;
     width: 30px;
 
     a {

--- a/react/src/scss/_globals.scss
+++ b/react/src/scss/_globals.scss
@@ -1,6 +1,10 @@
 /**********************
   GLOBALS
 **********************/
+* {
+  box-sizing: border-box;
+}
+
 h1 {
   font-weight: $font-weight-normal;
 }

--- a/react/src/scss/_header.scss
+++ b/react/src/scss/_header.scss
@@ -6,6 +6,10 @@
   background: $brand-tertiary;
   color: $white;
 
+  @media only screen and (max-width: 767px) {
+    text-align: center;
+  }
+
   &:after {
     content: "";
     clear: both;
@@ -26,14 +30,23 @@
   .site-title {
     font-weight: $font-weight-bold;
     text-transform: uppercase;
+    font-size: 1rem;
+
+    @media only screen and (max-width: 767px) {
+      font-size: 1.6rem;
+    }
   }
 
   .save-status {
-    border-right: 2px solid $white;
     font-size: 0.85rem;
     font-style: italic;
     padding-top: 0.1rem;
-    text-align: right;
+    text-align: center;
+
+    @media only screen and (min-width: 768px) {
+      border-right: 2px solid $white;
+      text-align: right;
+    }
   }
 
   .nav-user {
@@ -51,7 +64,11 @@
         padding: 0;
         padding-right: ($padding * 3);
         position: relative;
-        text-align: right;
+        text-align: center;
+
+        @media only screen and (min-width: 768px) {
+          text-align: right;
+        }
 
         a {
           &:after {

--- a/react/src/scss/_icons.scss
+++ b/react/src/scss/_icons.scss
@@ -5,6 +5,7 @@
 .fa-plus {
   border: 2px solid $white;
   border-radius: 50%;
+  box-sizing: initial;
   margin-left: ($margin * 2);
   padding: ($padding * 0.5);
 }

--- a/react/src/scss/_layout.scss
+++ b/react/src/scss/_layout.scss
@@ -1,0 +1,12 @@
+/**********************
+  Layout
+**********************/
+
+@media only screen and (max-width: 767px) {
+  div[class*="ds-l-col--"] {
+    max-width: 100%;
+    padding: 0 ($margin * 2);
+    min-width: 100%;
+    width: 100%;
+  }
+}

--- a/react/src/scss/_main.scss
+++ b/react/src/scss/_main.scss
@@ -6,7 +6,11 @@
 }
 
 .page-info {
-  margin-top: ($margin * 2);
+  margin-top: ($margin * 8);
+
+  @media only screen and (min-width: 768px) {
+    margin-top: ($margin * 2);
+  }
 
   .edit-info {
     color: $color-gray-light;
@@ -38,6 +42,7 @@
   font-size: 0.85rem;
   line-height: 1.6rem;
   margin: 64px 0;
+  text-align: center;
 }
 
 .reports {
@@ -82,8 +87,21 @@
   margin-top: ($margin * 3);
   width: 100%;
 
+  .displaying {
+    text-align: center;
+    margin-bottom: $margin;
+
+    @media only screen and (min-width: 768px) {
+      margin-bottom: 0;
+      text-align: left;
+    }
+  }
+
   .pager {
-    text-align: right;
+    text-align: center;
+    @media only screen and (min-width: 768px) {
+      text-align: right;
+    }
   }
   .count {
     color: $color-gray;
@@ -134,6 +152,11 @@
       border-right: none;
       color: $color-hint;
       padding: ($padding * 4) 0;
+      text-align: center;
+
+      @media only screen and (min-width: 768px) {
+        text-align: left;
+      }
 
       h3 {
         margin-bottom: 0;
@@ -152,8 +175,22 @@
           width: auto;
         }
       }
+
+      .title {
+        margin-top: ($margin * 2);
+        text-align: center;
+
+        @media only screen and (min-width: 768px) {
+          margin-top: 0;
+          text-align: left;
+        }
+      }
+
       .date {
-        text-align: right;
+        text-align: center;
+        @media only screen and (min-width: 768px) {
+          text-align: right;
+        }
       }
     }
   }


### PR DESCRIPTION
Make site full width when view at 768px and less.

- Set `box-sizing: border-box`
    - Adjust icon styles to account for this change
- Create new scss stub file: _layout.scss
- Adjust homepage html to allow for better styling
- Add a number of media queries focusing on 768 as a cut-off