### PR TITLE
Fix deployDev on Windows... rework how we build/run the dev react image

### DIFF
--- a/app/docker-compose.dev.yml
+++ b/app/docker-compose.dev.yml
@@ -11,6 +11,7 @@ services:
       - backend_app
     environment:
       - API_URL=http://localhost:8000 # This is how a browser would call the api
+      - CHOKIDAR_USEPOLLING=true
     stdin_open: true
     volumes:
       - ./react:/app

--- a/app/docker-compose.dev.yml
+++ b/app/docker-compose.dev.yml
@@ -13,7 +13,8 @@ services:
       - API_URL=http://localhost:8000 # This is how a browser would call the api
     stdin_open: true
     volumes:
-      - ./react:/app:cached
+      - ./react:/app
+      - /app/node_modules
   api:
     image: api:dev
     build:

--- a/app/react/Dockerfile.dev
+++ b/app/react/Dockerfile.dev
@@ -12,4 +12,4 @@ RUN npm install react-scripts@3.4.1 -g --silent
 
 COPY . .
 
-CMD ["/bin/bash", "-c", "chmod -R 777 * && npm start"]
+CMD ["npm", "start"]

--- a/app/react/Dockerfile.dev
+++ b/app/react/Dockerfile.dev
@@ -12,4 +12,4 @@ RUN npm install react-scripts@3.4.1 -g --silent
 
 COPY . .
 
-CMD ["npm", "start"]
+CMD ["/bin/bash", "-c", "chmod -R 777 * && npm start"]

--- a/app/react/Dockerfile.dev
+++ b/app/react/Dockerfile.dev
@@ -4,4 +4,12 @@ FROM node:14.4.0 as dev
 # Set working directory
 WORKDIR /app
 
-CMD ["/bin/bash", "-c", "npm install && ./env.sh && cp ./env-config.js ./public/ && npm run start"]
+COPY package*.json ./
+
+RUN npm install --silent
+
+RUN npm install react-scripts@3.4.1 -g --silent
+
+COPY . .
+
+CMD ["npm", "start"]


### PR DESCRIPTION
The deployDev workflow builds a local environment with mounted folders and live reloading of the react container.
This was broken on Windows.
Why it was broken just on Windows isn't known, and probably won't be.
In investigating this issue, a better pattern for building and running the dev react container was found.

We're moving the npm install from the image run time to the image build time. By using a data volume in addition to the react bind mount, it seems we can mount the react directory without the host node_modules overwriting the containers.
See here: https://stackoverflow.com/questions/30043872/docker-compose-node-modules-not-present-in-a-volume-after-npm-install-succeeds
The key piece here is in the top answer. "A workaround is to use a data volume to store all the node_modules, as data volumes copy in the data from the built docker image before the worker directory is mounted. "
Our data volume is /react/node_modules.

So, I really am not sure why npm install gets hungup when executing on a node container on windows. But it doesn't matter... with this change, we swerve that issue entirely.