### PR TITLE
Fix for broken pipeline

### DIFF
--- a/infra/postgres.tf
+++ b/infra/postgres.tf
@@ -4,7 +4,7 @@ module "db" {
   version                 = "~> 2.0"
   identifier              = "postgres-${terraform.workspace}"
   engine                  = "postgres"
-  engine_version          = "9.6.9"
+  engine_version          = "9.6"
   instance_class          = "db.t3.large"
   allocated_storage       = 50
   storage_encrypted       = true


### PR DESCRIPTION
auto upgrades are enabled for postgres, previously we had a minor ver…sion hard coded.  When the RDS instance upgraded the minor version our hard coded defined version was behind and threw an error. This fix should allow us to ignore minor version upgrades on terraform runs