### PR TITLE
Guard the downstream build triggers from disabled builds

### DIFF
--- a/.jenkins/Jenkinsfile.dev
+++ b/.jenkins/Jenkinsfile.dev
@@ -163,11 +163,15 @@ pipeline {
                 git tag $BUILD_TAG
                 git push https://$GIT_CREDENTIAL@$remote_url refs/tags/$BUILD_TAG
               '''
-              build job: 'staging',
-                parameters: [
-                  string(name: 'VERSION', value: "${BUILD_TAG}")
-                ],
-                wait: false
+              try {
+                build job: 'staging',
+                  parameters: [
+                    string(name: 'VERSION', value: "${BUILD_TAG}")
+                  ],
+                  wait: false
+              } catch (err) {
+                echo err.getMessage()
+              }
             }
           }
         }

--- a/.jenkins/Jenkinsfile.prod
+++ b/.jenkins/Jenkinsfile.prod
@@ -116,11 +116,15 @@ pipeline {
               git push https://$GIT_CREDENTIAL@$remote_url refs/tags/$JOB_NAME -f
             '''
             if (env.DOWNSTREAM_JOB) {
-              build job: "${DOWNSTREAM_JOB}",
-                parameters: [
-                  string(name: 'VERSION', value: "${VERSION}")
-                ],
-                wait: false
+              try {
+                build job: "${DOWNSTREAM_JOB}",
+                  parameters: [
+                    string(name: 'VERSION', value: "${VERSION}")
+                  ],
+                  wait: false
+              } catch (err) {
+                  echo err.getMessage()
+              }
             }
           }
         }


### PR DESCRIPTION
If a downstream build is disabled, triggering it will fail.
The build should not fail in that case.

closes https://qmacbis.atlassian.net/secure/RapidBoard.jspa?rapidView=166&modal=detail&selectedIssue=ENABLE-77&assignee=5c8a6ea240b156730417e600