### PR TITLE
Remove class instead of toggle when closing dropdown nav

### DIFF
--- a/app/react/src/components/layout/Header.js
+++ b/app/react/src/components/layout/Header.js
@@ -18,8 +18,8 @@ class Header extends Component {
     root.addEventListener(
       "click",
       () => {
-        document.getElementById("menu-block").classList.toggle("open");
-        document.getElementById("nav-user").classList.toggle("open");
+        document.getElementById("menu-block").classList.remove("open");
+        document.getElementById("nav-user").classList.remove("open");
       },
       false
     );


### PR DESCRIPTION
Issue #81 : Navigation closed when clicking away from dropdown, reopened is clicked again.
Swapped classList.toggle() for classList.remove()