### PR TITLE
Add optional SSL support.  Adds SSL for demo environment

### DIFF
--- a/.jenkins/Jenkinsfile.dev
+++ b/.jenkins/Jenkinsfile.dev
@@ -99,6 +99,9 @@ pipeline {
       steps {
         script {
           withCredentials([usernamePassword(credentialsId: env.POSTGRES_CREDENTIAL_NAME, passwordVariable: 'TF_VAR_postgres_password', usernameVariable: 'TF_VAR_postgres_user')]) {
+            if (env.BRANCH_NAME == 'master-cert') {
+              env.TF_VAR_acm_certificate_domain_ui = "cartsdemo.cms.gov"
+            }
             sh '''
               set -e
 

--- a/.jenkins/Jenkinsfile.dev
+++ b/.jenkins/Jenkinsfile.dev
@@ -99,7 +99,7 @@ pipeline {
       steps {
         script {
           withCredentials([usernamePassword(credentialsId: env.POSTGRES_CREDENTIAL_NAME, passwordVariable: 'TF_VAR_postgres_password', usernameVariable: 'TF_VAR_postgres_user')]) {
-            if (env.BRANCH_NAME == 'master-cert') {
+            if (env.BRANCH_NAME == 'master') {
               env.TF_VAR_acm_certificate_domain_ui = "cartsdemo.cms.gov"
             }
             sh '''

--- a/infra/ecs_task_api.tf
+++ b/infra/ecs_task_api.tf
@@ -139,7 +139,7 @@ data "aws_acm_certificate" "api" {
 
 resource "aws_alb_listener" "https_forward_api" {
   count             = var.acm_certificate_domain_api == "" ? 0 : 1
-  load_balancer_arn = aws_alb.alb_api.id
+  load_balancer_arn = aws_alb.api.id
   port              = "443"
   protocol          = "HTTPS"
   certificate_arn   = data.aws_acm_certificate.api.arn
@@ -151,7 +151,7 @@ resource "aws_alb_listener" "https_forward_api" {
 
 resource "aws_alb_listener" "http_forward_api" {
   count             = var.acm_certificate_domain_api == "" ? 1 : 0
-  load_balancer_arn = aws_alb.alb_api.id
+  load_balancer_arn = aws_alb.api.id
   port              = "80"
   protocol          = "HTTP"
   default_action {
@@ -162,7 +162,7 @@ resource "aws_alb_listener" "http_forward_api" {
 
 resource "aws_alb_listener" "http_to_https_redirect_api" {
   count             = var.acm_certificate_domain_api == "" ? 0 : 1
-  load_balancer_arn = aws_alb.alb_api.id
+  load_balancer_arn = aws_alb.api.id
   port              = "80"
   protocol          = "HTTP"
   default_action {

--- a/infra/ecs_task_api.tf
+++ b/infra/ecs_task_api.tf
@@ -94,10 +94,10 @@ resource "aws_security_group_rule" "alb_api_egress" {
   security_group_id        = aws_security_group.alb_api.id
 }
 
-resource "aws_security_group_rule" "alb_api_ingress_80" {
+resource "aws_security_group_rule" "alb_api_ingress_8000" {
   type              = "ingress"
-  from_port         = 80
-  to_port           = 80
+  from_port         = 8000
+  to_port           = 8000
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.alb_api.id
@@ -152,7 +152,7 @@ resource "aws_alb_listener" "https_forward_api" {
 resource "aws_alb_listener" "http_forward_api" {
   count             = var.acm_certificate_domain_api == "" ? 1 : 0
   load_balancer_arn = aws_alb.api.id
-  port              = "80"
+  port              = "8000"
   protocol          = "HTTP"
   default_action {
     target_group_arn = aws_alb_target_group.api.id
@@ -163,7 +163,7 @@ resource "aws_alb_listener" "http_forward_api" {
 resource "aws_alb_listener" "http_to_https_redirect_api" {
   count             = var.acm_certificate_domain_api == "" ? 0 : 1
   load_balancer_arn = aws_alb.api.id
-  port              = "80"
+  port              = "8000"
   protocol          = "HTTP"
   default_action {
     target_group_arn = aws_alb_target_group.api.id

--- a/infra/ecs_task_api.tf
+++ b/infra/ecs_task_api.tf
@@ -1,3 +1,6 @@
+locals {
+  endpoint_api = var.acm_certificate_domain_api == "" ? "http://${aws_alb.api.dns_name}:8000" : "https://${aws_alb.api.dns_name}"
+}
 
 resource "aws_ecs_task_definition" "api" {
   family                   = "api-${terraform.workspace}"

--- a/infra/ecs_task_api.tf
+++ b/infra/ecs_task_api.tf
@@ -142,7 +142,7 @@ resource "aws_alb_listener" "https_forward_api" {
   load_balancer_arn = aws_alb.api.id
   port              = "443"
   protocol          = "HTTPS"
-  certificate_arn   = data.aws_acm_certificate.api.arn
+  certificate_arn   = data.aws_acm_certificate.api[0].arn
   default_action {
     target_group_arn = aws_alb_target_group.api.id
     type             = "forward"

--- a/infra/ecs_task_ui.tf
+++ b/infra/ecs_task_ui.tf
@@ -127,7 +127,7 @@ data "aws_acm_certificate" "ui" {
 
 resource "aws_alb_listener" "https_forward_ui" {
   count             = var.acm_certificate_domain_ui == "" ? 0 : 1
-  load_balancer_arn = aws_alb.alb_ui.id
+  load_balancer_arn = aws_alb.ui.id
   port              = "443"
   protocol          = "HTTPS"
   certificate_arn   = data.aws_acm_certificate.ui.arn
@@ -139,7 +139,7 @@ resource "aws_alb_listener" "https_forward_ui" {
 
 resource "aws_alb_listener" "http_forward_ui" {
   count             = var.acm_certificate_domain_ui == "" ? 1 : 0
-  load_balancer_arn = aws_alb.alb_ui.id
+  load_balancer_arn = aws_alb.ui.id
   port              = "80"
   protocol          = "HTTP"
   default_action {
@@ -150,7 +150,7 @@ resource "aws_alb_listener" "http_forward_ui" {
 
 resource "aws_alb_listener" "http_to_https_redirect_ui" {
   count             = var.acm_certificate_domain_ui == "" ? 0 : 1
-  load_balancer_arn = aws_alb.alb_ui.id
+  load_balancer_arn = aws_alb.ui.id
   port              = "80"
   protocol          = "HTTP"
   default_action {

--- a/infra/ecs_task_ui.tf
+++ b/infra/ecs_task_ui.tf
@@ -1,5 +1,5 @@
 locals {
-  endpoint_ui = var.acm_certificate_domain_ui == "" ? "http://${aws_alb.ui.dns_name}:8000" : "https://${aws_alb.ui.dns_name}"
+  endpoint_ui = var.acm_certificate_domain_ui == "" ? "http://${aws_alb.ui.dns_name}" : "https://${aws_alb.ui.dns_name}"
 }
 
 resource "aws_ecs_task_definition" "ui" {

--- a/infra/ecs_task_ui.tf
+++ b/infra/ecs_task_ui.tf
@@ -12,7 +12,7 @@ resource "aws_ecs_task_definition" "ui" {
   execution_role_arn       = aws_iam_role.ecs_execution_role.arn
   container_definitions = templatefile("templates/ecs_task_def_ui.json.tpl", {
     image   = "${var.ecr_repository_url_ui}:${var.application_version}",
-    api_url = "http://${aws_alb.api.dns_name}:${aws_alb_listener.http_forward_api.port}"
+    api_url = local.endpoint_api
   })
 }
 
@@ -130,7 +130,7 @@ resource "aws_alb_listener" "https_forward_ui" {
   load_balancer_arn = aws_alb.ui.id
   port              = "443"
   protocol          = "HTTPS"
-  certificate_arn   = data.aws_acm_certificate.ui.arn
+  certificate_arn   = data.aws_acm_certificate.ui[0].arn
   default_action {
     target_group_arn = aws_alb_target_group.ui.id
     type             = "forward"

--- a/infra/ecs_task_ui.tf
+++ b/infra/ecs_task_ui.tf
@@ -1,3 +1,6 @@
+locals {
+  endpoint_ui = var.acm_certificate_domain_ui == "" ? "http://${aws_alb.ui.dns_name}:8000" : "https://${aws_alb.ui.dns_name}"
+}
 
 resource "aws_ecs_task_definition" "ui" {
   family                   = "ui-${terraform.workspace}"

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,8 +1,8 @@
 
 output "application_endpoint" {
-  value = "http://${aws_alb.ui.dns_name}"
+  value = local.endpoint_ui
 }
 
 output "api_endpoint" {
-  value = "http://${aws_alb.api.dns_name}:${aws_alb_listener.http_forward_api.port}"
+  value = local.endpoint_api
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -5,3 +5,9 @@ variable "ecr_repository_url_api" {}
 variable "postgres_user" {}
 variable "postgres_password" {}
 variable "vpc_name" {}
+variable "acm_certificate_domain_ui" {
+  default = ""
+}
+variable "acm_certificate_domain_api" {
+  default = ""
+}


### PR DESCRIPTION
These are largely terraform changes that allow the UI and/or the API to be put behind SSL.

The Jenkins change is project specific, and puts the current demo environment ( cartsdemo.cms.gov ) behind SSL

Check https://cartsdemo.cms.gov a few minutes after this merges; note https 

Closes ENABLE-78
https://qmacbis.atlassian.net/secure/RapidBoard.jspa?rapidView=166&modal=detail&selectedIssue=ENABLE-78&assignee=5c8a6ea240b156730417e600