### PR TITLE
Bugfix/2b disabled check

### DIFF
--- a/app/react/src/components/Utils/helperFunctions.js
+++ b/app/react/src/components/Utils/helperFunctions.js
@@ -1,4 +1,5 @@
-// This function extracts just the unique ID from all objectives & goals, stopping at the underscore
+// This function extracts just the unique ID
+// from all objectives & goals, stopping at the underscore
 const sliceId = (id) => {
   let idString = id.toString();
   let num = idString.slice(idString.indexOf("_", idString.length - 1));

--- a/app/react/src/components/Utils/helperFunctions.js
+++ b/app/react/src/components/Utils/helperFunctions.js
@@ -1,0 +1,7 @@
+const sliceId = (id) => {
+  let idString = id.toString();
+  let num = idString.slice(idString.indexOf("_", idString.length - 1));
+  return num;
+};
+
+export { sliceId };

--- a/app/react/src/components/Utils/helperFunctions.js
+++ b/app/react/src/components/Utils/helperFunctions.js
@@ -1,3 +1,4 @@
+// This function extracts just the unique ID from all objectives & goals, stopping at the underscore
 const sliceId = (id) => {
   let idString = id.toString();
   let num = idString.slice(idString.indexOf("_", idString.length - 1));

--- a/app/react/src/components/sections/section2b/Section2B.js
+++ b/app/react/src/components/sections/section2b/Section2B.js
@@ -32,17 +32,14 @@ class Section2b extends Component {
       component: <Objective2b objectiveCount={1} />,
     };
 
-    let dummyDataArray = [];
-    for (let i = 1; i < 4; i++) {
-      dummyDataArray.push({
-        id: i,
-        component: <Objective2b objectiveCount={i} previousEntry="true" />,
-      });
-    }
+    let dummyDataArray = {
+      id: 2,
+      component: <Objective2b objectiveCount={2} previousEntry="true" />,
+    };
 
     this.setState({
       objectiveArray: [initialObjective],
-      previousObjectivesArray: dummyDataArray,
+      previousObjectivesArray: [dummyDataArray],
     });
   }
 

--- a/app/react/src/components/sections/section2b/Section2B.js
+++ b/app/react/src/components/sections/section2b/Section2B.js
@@ -29,30 +29,20 @@ class Section2b extends Component {
 
   componentDidMount() {
     const initialObjective = {
-      id: "2020_1",
-      component: <Objective2b objectiveCount={"2020_1"} />,
+      id: `${this.props.year}_1`,
+      component: <Objective2b objectiveCount={`${this.props.year}_1`} />,
     };
 
-    let dummyDataArray = [
-      {
-        id: "2019_1",
+    let dummyDataArray = [];
+
+    for (let i = 1; i < 3; i++) {
+      dummyDataArray.push({
+        id: `2019_${i}`,
         component: (
-          <Objective2b objectiveCount={"2019_1"} previousEntry="true" />
+          <Objective2b objectiveCount={`2019_${i}`} previousEntry="true" />
         ),
-      },
-      {
-        id: "2019_2",
-        component: (
-          <Objective2b objectiveCount={"2019_2"} previousEntry="true" />
-        ),
-      },
-      {
-        id: "2019_3",
-        component: (
-          <Objective2b objectiveCount={"2019_3"} previousEntry="true" />
-        ),
-      },
-    ];
+      });
+    }
 
     this.setState({
       objectiveArray: [initialObjective],
@@ -63,8 +53,10 @@ class Section2b extends Component {
   newObjective() {
     let newObjectiveId = this.state.objectiveCount + 1;
     let newObjective = {
-      id: `2020_${newObjectiveId}`,
-      component: <Objective2b objectiveCount={`2020_${newObjectiveId}`} />,
+      id: `${this.props.year}_${newObjectiveId}`,
+      component: (
+        <Objective2b objectiveCount={`${this.props.year}_${newObjectiveId}`} />
+      ),
     };
 
     this.setState({
@@ -74,7 +66,6 @@ class Section2b extends Component {
   }
 
   render() {
-    console.log("JUST THE NUMBER?", sliceId(2019_2));
     return (
       <div className="section-2b">
         <div className="ds-l-container">
@@ -179,6 +170,7 @@ class Section2b extends Component {
 
 const mapStateToProps = (state) => ({
   name: state.name,
+  year: state.formYear,
 });
 
 export default connect(mapStateToProps)(Section2b);

--- a/app/react/src/components/sections/section2b/Section2B.js
+++ b/app/react/src/components/sections/section2b/Section2B.js
@@ -72,77 +72,85 @@ class Section2b extends Component {
               <PageInfo />
               <Tabs>
                 <TabPanel id="section2b" tab="Section 2B: Performance Goals">
-                  <div className="section-content">
-                    <p>
-                      Your performance goals should match those reflected in
-                      your CHIP State Plan, Section 9. If your goals are
-                      different, submit a State Plan Amendment (SPA) to
-                      reconcile any differences
-                    </p>
-                    <div className="objective-accordiion">
-                      <Accordion multiple defaultIndex={[...Array(100).keys()]}>
-                        {this.state.objectiveArray.map((element) => (
-                          <AccordionItem key={element.id}>
-                            <div className="accordion-header">
-                              <h3>
-                                <AccordionButton>
-                                  <div className="title">
-                                    Objective {element.id}:
-                                  </div>
-                                  <div className="arrow"></div>
-                                </AccordionButton>
-                              </h3>
-                            </div>
-                            <AccordionPanel>{element.component}</AccordionPanel>
-                          </AccordionItem>
-                        ))}
-                      </Accordion>
-                    </div>
+                  <form>
+                    <div className="section-content">
+                      <p>
+                        Your performance goals should match those reflected in
+                        your CHIP State Plan, Section 9. If your goals are
+                        different, submit a State Plan Amendment (SPA) to
+                        reconcile any differences
+                      </p>
+                      <div className="objective-accordiion">
+                        <Accordion
+                          multiple
+                          defaultIndex={[...Array(100).keys()]}
+                        >
+                          {this.state.objectiveArray.map((element) => (
+                            <AccordionItem key={element.id}>
+                              <div className="accordion-header">
+                                <h3>
+                                  <AccordionButton>
+                                    <div className="title">
+                                      Objective {element.id}:
+                                    </div>
+                                    <div className="arrow"></div>
+                                  </AccordionButton>
+                                </h3>
+                              </div>
+                              <AccordionPanel>
+                                {element.component}
+                              </AccordionPanel>
+                            </AccordionItem>
+                          ))}
+                        </Accordion>
+                      </div>
 
-                    <div>
-                      <h3> Add another objective</h3>
-                      <p className="ds-base color-gray-light">Optional</p>
-                      <button
-                        onClick={this.newObjective}
-                        type="button"
-                        className="ds-c-button ds-c-button--primary"
-                      >
-                        Add another objective
-                        <FontAwesomeIcon icon={faPlus} />
-                      </button>
+                      <div>
+                        <h3> Add another objective</h3>
+                        <p className="ds-base color-gray-light">Optional</p>
+                        <button
+                          onClick={this.newObjective}
+                          type="button"
+                          className="ds-c-button ds-c-button--primary"
+                        >
+                          Add another objective
+                          <FontAwesomeIcon icon={faPlus} />
+                        </button>
+                      </div>
                     </div>
-                  </div>
+                  </form>
                 </TabPanel>
 
                 <TabPanel className="section2b-previous" tab="FY2019 answers">
-                  <div className="section-content">
-                    <div className="objective-accordiion">
-                      <Accordion>
-                        {this.state.previousObjectivesArray.map((element) => (
-                          <AccordionItem key={element.id}>
-                            <div className="accordion-header">
-                              <h3>
-                                <AccordionButton>
-                                  <div className="title">
-                                    Objective {element.id}:
-                                  </div>
-                                  <div className="arrow"></div>
-                                </AccordionButton>
-                              </h3>
-                            </div>
-                            <AccordionPanel>{element.component}</AccordionPanel>
-                          </AccordionItem>
-                        ))}
-                      </Accordion>
+                  <form>
+                    <div className="section-content">
+                      <div className="objective-accordiion">
+                        <Accordion>
+                          {this.state.previousObjectivesArray.map((element) => (
+                            <AccordionItem key={element.id}>
+                              <div className="accordion-header">
+                                <h3>
+                                  <AccordionButton>
+                                    <div className="title">
+                                      Objective {element.id}:
+                                    </div>
+                                    <div className="arrow"></div>
+                                  </AccordionButton>
+                                </h3>
+                              </div>
+                              <AccordionPanel>
+                                {element.component}
+                              </AccordionPanel>
+                            </AccordionItem>
+                          ))}
+                        </Accordion>
+                      </div>
                     </div>
-                  </div>
+                  </form>
                 </TabPanel>
               </Tabs>
               <div className="nav-buttons">
-                <NavigationButton
-                  direction="Previous"
-                  destination="/2a"
-                />
+                <NavigationButton direction="Previous" destination="/2a" />
 
                 <NavigationButton direction="Next" destination="/3c" />
               </div>

--- a/app/react/src/components/sections/section2b/Section2B.js
+++ b/app/react/src/components/sections/section2b/Section2B.js
@@ -38,10 +38,13 @@ class Section2b extends Component {
 
     for (let i = 1; i < 3; i++) {
       dummyDataArray.push({
-        id: `2019_${i}`,
+        id: `${this.props.year - 1}_${i}`,
         // this creates dummy data for the previous year tab, each tagged as a previous entry using props
         component: (
-          <Objective2b objectiveId={`2019_${i}`} previousEntry="true" />
+          <Objective2b
+            objectiveId={`${this.props.year - 1}_${i}`}
+            previousEntry="true"
+          />
         ),
       });
     }
@@ -133,7 +136,10 @@ class Section2b extends Component {
                   </div>
                 </TabPanel>
 
-                <TabPanel className="section2b-previous" tab="FY2019 answers">
+                <TabPanel
+                  className="section2b-previous"
+                  tab={`FY${this.props.year - 1} answers`}
+                >
                   <div className="section-content">
                     <div className="objective-accordiion">
                       {/* This builds an accordion that maps through the array of prevoous Objectives in state */}

--- a/app/react/src/components/sections/section2b/Section2B.js
+++ b/app/react/src/components/sections/section2b/Section2B.js
@@ -72,8 +72,8 @@ class Section2b extends Component {
               <PageInfo />
               <Tabs>
                 <TabPanel id="section2b" tab="Section 2B: Performance Goals">
-                  <form>
-                    <div className="section-content">
+                  <div className="section-content">
+                    <form>
                       <p>
                         Your performance goals should match those reflected in
                         your CHIP State Plan, Section 9. If your goals are
@@ -117,14 +117,14 @@ class Section2b extends Component {
                           <FontAwesomeIcon icon={faPlus} />
                         </button>
                       </div>
-                    </div>
-                  </form>
+                    </form>
+                  </div>
                 </TabPanel>
 
                 <TabPanel className="section2b-previous" tab="FY2019 answers">
-                  <form>
-                    <div className="section-content">
-                      <div className="objective-accordiion">
+                  <div className="section-content">
+                    <div className="objective-accordiion">
+                      <form>
                         <Accordion>
                           {this.state.previousObjectivesArray.map((element) => (
                             <AccordionItem key={element.id}>
@@ -144,9 +144,9 @@ class Section2b extends Component {
                             </AccordionItem>
                           ))}
                         </Accordion>
-                      </div>
+                      </form>
                     </div>
-                  </form>
+                  </div>
                 </TabPanel>
               </Tabs>
               <div className="nav-buttons">

--- a/app/react/src/components/sections/section2b/Section2B.js
+++ b/app/react/src/components/sections/section2b/Section2B.js
@@ -28,9 +28,10 @@ class Section2b extends Component {
   }
 
   componentDidMount() {
+    // This sets up an inital, blank objective
     const initialObjective = {
       id: `${this.props.year}_1`,
-      component: <Objective2b objectiveCount={`${this.props.year}_1`} />,
+      component: <Objective2b objectiveId={`${this.props.year}_1`} />,
     };
 
     let dummyDataArray = [];
@@ -38,8 +39,9 @@ class Section2b extends Component {
     for (let i = 1; i < 3; i++) {
       dummyDataArray.push({
         id: `2019_${i}`,
+        // this creates dummy data for the previous year tab, each tagged as a previous entry using props
         component: (
-          <Objective2b objectiveCount={`2019_${i}`} previousEntry="true" />
+          <Objective2b objectiveId={`2019_${i}`} previousEntry="true" />
         ),
       });
     }
@@ -54,8 +56,9 @@ class Section2b extends Component {
     let newObjectiveId = this.state.objectiveCount + 1;
     let newObjective = {
       id: `${this.props.year}_${newObjectiveId}`,
+      // This builds a new component with an ID taken from the current year and the next available ID
       component: (
-        <Objective2b objectiveCount={`${this.props.year}_${newObjectiveId}`} />
+        <Objective2b objectiveId={`${this.props.year}_${newObjectiveId}`} />
       ),
     };
 
@@ -87,6 +90,7 @@ class Section2b extends Component {
                         reconcile any differences
                       </p>
                       <div className="objective-accordiion">
+                        {/* This builds an accordion that maps through the array of Objectives in state */}
                         <Accordion
                           multiple
                           defaultIndex={[...Array(100).keys()]}
@@ -97,6 +101,7 @@ class Section2b extends Component {
                                 <h3>
                                   <AccordionButton>
                                     <div className="title">
+                                      {/* The sliceId utility function gets just the number of each objective, removes the year */}
                                       Objective {sliceId(element.id)}:
                                     </div>
                                     <div className="arrow"></div>
@@ -104,6 +109,7 @@ class Section2b extends Component {
                                 </h3>
                               </div>
                               <AccordionPanel>
+                                {/* This is where the component is being rendered*/}
                                 {element.component}
                               </AccordionPanel>
                             </AccordionItem>
@@ -130,6 +136,7 @@ class Section2b extends Component {
                 <TabPanel className="section2b-previous" tab="FY2019 answers">
                   <div className="section-content">
                     <div className="objective-accordiion">
+                      {/* This builds an accordion that maps through the array of prevoous Objectives in state */}
                       <form>
                         <Accordion>
                           {this.state.previousObjectivesArray.map((element) => (
@@ -138,6 +145,7 @@ class Section2b extends Component {
                                 <h3>
                                   <AccordionButton>
                                     <div className="title">
+                                      {/* The sliceId utility function gets just the number of each objective, removes the year */}
                                       Objective {sliceId(element.id)}:
                                     </div>
                                     <div className="arrow"></div>
@@ -145,6 +153,7 @@ class Section2b extends Component {
                                 </h3>
                               </div>
                               <AccordionPanel>
+                                {/* This is where the component is being rendered*/}
                                 {element.component}
                               </AccordionPanel>
                             </AccordionItem>

--- a/app/react/src/components/sections/section2b/Section2B.js
+++ b/app/react/src/components/sections/section2b/Section2B.js
@@ -14,6 +14,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import "@reach/accordion/styles.css";
+import { sliceId } from "../../Utils/helperFunctions";
 
 class Section2b extends Component {
   constructor(props) {
@@ -28,26 +29,42 @@ class Section2b extends Component {
 
   componentDidMount() {
     const initialObjective = {
-      id: 1,
-      component: <Objective2b objectiveCount={1} />,
+      id: "2020_1",
+      component: <Objective2b objectiveCount={"2020_1"} />,
     };
 
-    let dummyDataArray = {
-      id: 2,
-      component: <Objective2b objectiveCount={2} previousEntry="true" />,
-    };
+    let dummyDataArray = [
+      {
+        id: "2019_1",
+        component: (
+          <Objective2b objectiveCount={"2019_1"} previousEntry="true" />
+        ),
+      },
+      {
+        id: "2019_2",
+        component: (
+          <Objective2b objectiveCount={"2019_2"} previousEntry="true" />
+        ),
+      },
+      {
+        id: "2019_3",
+        component: (
+          <Objective2b objectiveCount={"2019_3"} previousEntry="true" />
+        ),
+      },
+    ];
 
     this.setState({
       objectiveArray: [initialObjective],
-      previousObjectivesArray: [dummyDataArray],
+      previousObjectivesArray: dummyDataArray,
     });
   }
 
   newObjective() {
     let newObjectiveId = this.state.objectiveCount + 1;
     let newObjective = {
-      id: newObjectiveId,
-      component: <Objective2b objectiveCount={newObjectiveId} />,
+      id: `2020_${newObjectiveId}`,
+      component: <Objective2b objectiveCount={`2020_${newObjectiveId}`} />,
     };
 
     this.setState({
@@ -57,6 +74,7 @@ class Section2b extends Component {
   }
 
   render() {
+    console.log("JUST THE NUMBER?", sliceId(2019_2));
     return (
       <div className="section-2b">
         <div className="ds-l-container">
@@ -88,7 +106,7 @@ class Section2b extends Component {
                                 <h3>
                                   <AccordionButton>
                                     <div className="title">
-                                      Objective {element.id}:
+                                      Objective {sliceId(element.id)}:
                                     </div>
                                     <div className="arrow"></div>
                                   </AccordionButton>
@@ -129,7 +147,7 @@ class Section2b extends Component {
                                 <h3>
                                   <AccordionButton>
                                     <div className="title">
-                                      Objective {element.id}:
+                                      Objective {sliceId(element.id)}:
                                     </div>
                                     <div className="arrow"></div>
                                   </AccordionButton>

--- a/app/react/src/components/sections/section2b/objectives/Objective2b.js
+++ b/app/react/src/components/sections/section2b/objectives/Objective2b.js
@@ -30,9 +30,11 @@ class Objective2b extends Component {
     const initialGoal = [
       {
         id: `${this.props.year}_1`,
+        // Each goal has an ID with the format: year_objectiveId_goalId
+        // The sliceId() helper function extracts just the year from the parent objective
         component: (
           <Goal
-            goalCount={`${this.props.year}_1_${this.props.objectiveCount}`}
+            goalId={`${this.props.year}_${sliceId(this.props.objectiveId)}_1`}
           />
         ),
       },
@@ -42,9 +44,11 @@ class Objective2b extends Component {
     for (let i = 1; i < 3; i++) {
       dummyDataArray.push({
         id: `2019_${i}`,
+        // Each goal has an ID with the format <year>_<the objective it belongs to>_ <the goal's own ID>
+        // The sliceId() helper function extracts just the year from the parent objective
         component: (
           <Goal
-            goalCount={`2019_${i}_${this.props.objectiveCount}`}
+            goalId={`2019_${sliceId(this.props.objectiveId)}_${i}`}
             previousEntry="true"
           />
         ),
@@ -63,9 +67,13 @@ class Objective2b extends Component {
     let newGoalId = this.state.goalCount + 1;
     let newGoal = {
       id: `${this.props.year}_${newGoalId}`,
+      // Each goal has an ID with the format <year>_<the objective it belongs to>_ <the goal's own ID>
+      // The sliceId() helper function extracts just the year from the parent objective
       component: (
         <Goal
-          goalCount={`${this.props.year}_${newGoalId}_${this.props.objectiveCount}`}
+          goalId={`${this.props.year}_${sliceId(
+            this.props.objectiveId
+          )}_${newGoalId}`}
         />
       ),
     };
@@ -84,7 +92,7 @@ class Objective2b extends Component {
             hint="For example: Our objective is to increase enrollment in our CHIP program."
             label="What is your first objective as listed in your CHIP State Plan?"
             multiline
-            name={"objective_" + this.props.objectiveCount + "_text"}
+            name={"objective_" + this.props.objectiveId + "_text"}
             value={
               this.props.previousEntry === "true"
                 ? this.state.objective2bDummyData
@@ -92,28 +100,36 @@ class Objective2b extends Component {
             }
           />
           <div className="goals">
+            {/* This builds an accordion that maps through the array of Goals in state */}
+            {/* If the props include previousEntry==="true", it will render the previous year's data, located in state */}
             {this.props.previousEntry === "true" ? (
               <Accordion multiple defaultIndex={[...Array(100).keys()]}>
                 {this.state.previousGoalsArray.map((element) => (
                   <AccordionItem key={element.id}>
                     <h3>
                       <AccordionButton>
+                        {/* The sliceId helper function slices off just the number from the goal's ID */}
                         Goal {sliceId(element.id)}:
                       </AccordionButton>
                     </h3>
+                    {/* This is where the component is being rendered*/}
                     <AccordionPanel>{element.component}</AccordionPanel>
                   </AccordionItem>
                 ))}
               </Accordion>
             ) : (
+              //  This builds an accordion that maps through the array of Goals in state.
+              // The newGoal method adds to that array so the new goal is also mapped through
               <Accordion multiple defaultIndex={[...Array(100).keys()]}>
                 {this.state.goalArray.map((element) => (
                   <AccordionItem key={element.id}>
                     <h3>
                       <AccordionButton>
+                        {/* The sliceId helper function slices off just the number from the goal's ID */}
                         Goal {sliceId(element.id)}:
                       </AccordionButton>
                     </h3>
+                    {/* This is where the component is being rendered*/}
                     <AccordionPanel>{element.component}</AccordionPanel>
                   </AccordionItem>
                 ))}

--- a/app/react/src/components/sections/section2b/objectives/Objective2b.js
+++ b/app/react/src/components/sections/section2b/objectives/Objective2b.js
@@ -30,7 +30,7 @@ class Objective2b extends Component {
     const initialGoal = [
       {
         id: `${this.props.year}_1`,
-        // Each goal has an ID with the format: year_objectiveId_goalId
+        // Each goal has a goalID with the format '<year>_<the objective it belongs to>_ <the goal's own ID>'
         // The sliceId() helper function extracts just the year from the parent objective
         component: (
           <Goal
@@ -43,12 +43,14 @@ class Objective2b extends Component {
     let dummyDataArray = [];
     for (let i = 1; i < 3; i++) {
       dummyDataArray.push({
-        id: `2019_${i}`,
-        // Each goal has an ID with the format <year>_<the objective it belongs to>_ <the goal's own ID>
+        id: `${this.props.year - 1}_${i}`,
+        // Each goal has a goalID with the format '<year>_<the objective it belongs to>_ <the goal's own ID>'
         // The sliceId() helper function extracts just the year from the parent objective
         component: (
           <Goal
-            goalId={`2019_${sliceId(this.props.objectiveId)}_${i}`}
+            goalId={`${this.props.year - 1}_${sliceId(
+              this.props.objectiveId
+            )}_${i}`}
             previousEntry="true"
           />
         ),
@@ -100,36 +102,40 @@ class Objective2b extends Component {
             }
           />
           <div className="goals">
-            {/* This builds an accordion that maps through the array of Goals in state */}
-            {/* If the props include previousEntry==="true", it will render the previous year's data, located in state */}
+            {/**
+             * Maps through array of Previous Goals in state
+             * If the props include previousEntry==="true", render previous year's data
+             */}
             {this.props.previousEntry === "true" ? (
               <Accordion multiple defaultIndex={[...Array(100).keys()]}>
                 {this.state.previousGoalsArray.map((element) => (
                   <AccordionItem key={element.id}>
                     <h3>
                       <AccordionButton>
-                        {/* The sliceId helper function slices off just the number from the goal's ID */}
+                        {/**
+                         * Returns ID from longer string
+                         */}
                         Goal {sliceId(element.id)}:
                       </AccordionButton>
                     </h3>
-                    {/* This is where the component is being rendered*/}
                     <AccordionPanel>{element.component}</AccordionPanel>
                   </AccordionItem>
                 ))}
               </Accordion>
             ) : (
-              //  This builds an accordion that maps through the array of Goals in state.
-              // The newGoal method adds to that array so the new goal is also mapped through
+              //  Alternatively,  This maps through the current goals in state
+
               <Accordion multiple defaultIndex={[...Array(100).keys()]}>
                 {this.state.goalArray.map((element) => (
                   <AccordionItem key={element.id}>
                     <h3>
                       <AccordionButton>
-                        {/* The sliceId helper function slices off just the number from the goal's ID */}
+                        {/**
+                         * Returns ID from longer string
+                         */}
                         Goal {sliceId(element.id)}:
                       </AccordionButton>
                     </h3>
-                    {/* This is where the component is being rendered*/}
                     <AccordionPanel>{element.component}</AccordionPanel>
                   </AccordionItem>
                 ))}

--- a/app/react/src/components/sections/section2b/objectives/Objective2b.js
+++ b/app/react/src/components/sections/section2b/objectives/Objective2b.js
@@ -30,16 +30,14 @@ class Objective2b extends Component {
       component: <Goal goalCount={1} />,
     };
 
-    let dummyDataArray = [];
-    for (let i = 1; i < 4; i++) {
-      dummyDataArray.push({
-        id: i,
-        component: <Goal goalCount={i} previousEntry="true" />,
-      });
-    }
+    let dummyDataArray = {
+      id: 2,
+      component: <Goal goalCount={2} previousEntry="true" />,
+    };
+
     this.setState({
       goalArray: [initialGoal],
-      previousGoalsArray: dummyDataArray,
+      previousGoalsArray: [dummyDataArray],
       objective2bDummyData:
         "This is what you wrote last year. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam quis varius odio, vel maximus enim.",
     });

--- a/app/react/src/components/sections/section2b/objectives/Objective2b.js
+++ b/app/react/src/components/sections/section2b/objectives/Objective2b.js
@@ -25,19 +25,36 @@ class Objective2b extends Component {
   }
 
   componentDidMount() {
-    const initialGoal = {
-      id: 1,
-      component: <Goal goalCount={1} />,
-    };
+    const initialGoal = [
+      {
+        id: 1,
+        component: <Goal goalCount={1} />,
+      },
 
-    let dummyDataArray = {
-      id: 2,
-      component: <Goal goalCount={2} previousEntry="true" />,
-    };
+      {
+        id: 111,
+        component: <Goal goalCount={111} />,
+      },
+    ];
+
+    let dummyDataArray = [
+      {
+        id: 22,
+        component: <Goal goalCount={22} previousEntry="true" />,
+      },
+      {
+        id: 33,
+        component: <Goal goalCount={33} previousEntry="true" />,
+      },
+      {
+        id: 44,
+        component: <Goal goalCount={44} previousEntry="true" />,
+      },
+    ];
 
     this.setState({
-      goalArray: [initialGoal],
-      previousGoalsArray: [dummyDataArray],
+      goalArray: initialGoal,
+      previousGoalsArray: dummyDataArray,
       objective2bDummyData:
         "This is what you wrote last year. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam quis varius odio, vel maximus enim.",
     });

--- a/app/react/src/components/sections/section2b/objectives/Objective2b.js
+++ b/app/react/src/components/sections/section2b/objectives/Objective2b.js
@@ -1,4 +1,5 @@
 import React, { Component, Fragment } from "react";
+import { connect } from "react-redux";
 import Goal from "./goals/Goal2b";
 import { TextField } from "@cmsgov/design-system-core";
 import {
@@ -10,6 +11,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import "@reach/accordion/styles.css";
+import { sliceId } from "../../../Utils/helperFunctions";
 
 class Objective2b extends Component {
   constructor(props) {
@@ -27,30 +29,27 @@ class Objective2b extends Component {
   componentDidMount() {
     const initialGoal = [
       {
-        id: 1,
-        component: <Goal goalCount={1} />,
-      },
-
-      {
-        id: 111,
-        component: <Goal goalCount={111} />,
-      },
-    ];
-
-    let dummyDataArray = [
-      {
-        id: 22,
-        component: <Goal goalCount={22} previousEntry="true" />,
-      },
-      {
-        id: 33,
-        component: <Goal goalCount={33} previousEntry="true" />,
-      },
-      {
-        id: 44,
-        component: <Goal goalCount={44} previousEntry="true" />,
+        id: `${this.props.year}_1`,
+        component: (
+          <Goal
+            goalCount={`${this.props.year}_1_${this.props.objectiveCount}`}
+          />
+        ),
       },
     ];
+
+    let dummyDataArray = [];
+    for (let i = 1; i < 3; i++) {
+      dummyDataArray.push({
+        id: `2019_${i}`,
+        component: (
+          <Goal
+            goalCount={`2019_${i}_${this.props.objectiveCount}`}
+            previousEntry="true"
+          />
+        ),
+      });
+    }
 
     this.setState({
       goalArray: initialGoal,
@@ -63,8 +62,12 @@ class Objective2b extends Component {
   newGoal() {
     let newGoalId = this.state.goalCount + 1;
     let newGoal = {
-      id: newGoalId,
-      component: <Goal goalCount={newGoalId} />,
+      id: `${this.props.year}_${newGoalId}`,
+      component: (
+        <Goal
+          goalCount={`${this.props.year}_${newGoalId}_${this.props.objectiveCount}`}
+        />
+      ),
     };
 
     this.setState({
@@ -94,7 +97,9 @@ class Objective2b extends Component {
                 {this.state.previousGoalsArray.map((element) => (
                   <AccordionItem key={element.id}>
                     <h3>
-                      <AccordionButton>Goal {element.id}:</AccordionButton>
+                      <AccordionButton>
+                        Goal {sliceId(element.id)}:
+                      </AccordionButton>
                     </h3>
                     <AccordionPanel>{element.component}</AccordionPanel>
                   </AccordionItem>
@@ -105,7 +110,9 @@ class Objective2b extends Component {
                 {this.state.goalArray.map((element) => (
                   <AccordionItem key={element.id}>
                     <h3>
-                      <AccordionButton>Goal {element.id}:</AccordionButton>
+                      <AccordionButton>
+                        Goal {sliceId(element.id)}:
+                      </AccordionButton>
                     </h3>
                     <AccordionPanel>{element.component}</AccordionPanel>
                   </AccordionItem>
@@ -132,4 +139,8 @@ class Objective2b extends Component {
   }
 }
 
-export default Objective2b;
+const mapStateToProps = (state) => ({
+  year: state.formYear,
+});
+
+export default connect(mapStateToProps)(Objective2b);

--- a/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
+++ b/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from "react";
 import { TextField, ChoiceList, DateField } from "@cmsgov/design-system-core";
+
 class Goal extends Component {
   constructor(props) {
     super(props);
@@ -100,26 +101,26 @@ class Goal extends Component {
               {
                 label: "New goal",
                 value: "new",
-                // disabled: renderPreviousEntry ? true : false,
-                disabled: true,
+                disabled: renderPreviousEntry ? true : false,
+                // disabled: true,
               },
               {
                 label: "Continuing goal",
                 value: "continuing",
-                disabled: true,
-                defaultChecked: true,
-                // disabled: renderPreviousEntry ? true : false,
-                // defaultChecked: renderPreviousEntry ? true : false,
+                // disabled: true,
+                // defaultChecked: true,
+                disabled: renderPreviousEntry ? true : false,
+                defaultChecked: renderPreviousEntry ? true : false,
               },
               {
                 label: "Discontinued goal",
                 value: "discontinued",
-                disabled: true,
-                // disabled: renderPreviousEntry ? true : false,
+                // disabled: true,
+                disabled: renderPreviousEntry ? true : false,
               },
             ]}
             label="What type of goal is it?"
-            name={`goal_type${this.props.goalCount}`}
+            name={`goal_type${this.props.goalCount}`} // each question in tabs needs to have their own names or the defaultChecked property WILL be overwritten by the last one rendered
             type="radio"
           />
         </div>
@@ -311,7 +312,7 @@ class Goal extends Component {
           ]}
           className="ds-u-margin-top--5"
           label="Which data source did you use?"
-          name="data_source"
+          name={`data_source${this.props.goalCount}`}
         />
 
         <div className="question-container">

--- a/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
+++ b/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
@@ -119,7 +119,7 @@ class Goal extends Component {
               },
             ]}
             label="What type of goal is it?"
-            name="goal_type"
+            name={`goal_type${this.props.goalCount}`}
             type="radio"
           />
         </div>

--- a/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
+++ b/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
@@ -77,7 +77,7 @@ class Goal extends Component {
   render() {
     let renderPreviousEntry =
       this.props.previousEntry === "true" ? true : false;
-    console.log("value??", renderPreviousEntry);
+
     return (
       <Fragment>
         <div className="question-container">
@@ -95,39 +95,41 @@ class Goal extends Component {
         </div>
 
         <div className="question-container">
-          <ChoiceList
-            choices={[
-              {
-                label: "New goal",
-                value: "new",
-                // disabled: renderPreviousEntry ? true : false,
-                disabled: true,
-              },
-              {
-                label: "Continuing goal",
-                value: "continuing",
-                // disabled: renderPreviousEntry ? true : false,
-                // defaultChecked: renderPreviousEntry ? true : false,
-                defaultChecked: true,
-                // renderPreviousEntry
-                //   ? true
-                //   : // ? this.state.goal_type_value === "continuing"
-                //     //   ? true
-                //     //   : false
-                //     false,
-                disabled: true,
-              },
-              {
-                label: "Discontinued goal",
-                value: "discontinued",
-                // disabled: renderPreviousEntry ? true : false,
-                disabled: true,
-              },
-            ]}
-            label="What type of goal is it?"
-            name="goal_type"
-            type="radio"
-          />
+          <form>
+            <ChoiceList
+              choices={[
+                {
+                  label: "New goal",
+                  value: "new",
+                  disabled: renderPreviousEntry ? true : false,
+                  // disabled: true,
+                },
+                {
+                  label: "Continuing goal",
+                  value: "continuing",
+                  disabled: renderPreviousEntry ? true : false,
+                  defaultChecked: renderPreviousEntry ? true : false,
+                  // defaultChecked: true,
+                  // renderPreviousEntry
+                  //   ? true
+                  //   : // ? this.state.goal_type_value === "continuing"
+                  //     //   ? true
+                  //     //   : false
+                  //     false,
+                  // disabled: true,
+                },
+                {
+                  label: "Discontinued goal",
+                  value: "discontinued",
+                  disabled: renderPreviousEntry ? true : false,
+                  // disabled: true,
+                },
+              ]}
+              label="What type of goal is it?"
+              name="goal_type"
+              type="radio"
+            />
+          </form>
         </div>
 
         <div className="question-container">
@@ -201,56 +203,54 @@ class Goal extends Component {
         </div>
 
         <div className="ds-u-border--2">
-          <form>
-            <div className="ds-1-row percentages-info">
-              <div className="ds-l--auto">
-                <h3>Percentage</h3>
-                <h4>Auto-calculated</h4>
-              </div>
+          <div className="ds-1-row percentages-info">
+            <div className="ds-l--auto">
+              <h3>Percentage</h3>
+              <h4>Auto-calculated</h4>
             </div>
-            <div className="ds-1-row percentages">
-              <div>
-                <TextField
-                  label="Numerator"
-                  name="goal_numerator_digit"
-                  size="small"
-                  className="ds-l--auto"
-                  value={
-                    this.props.previousEntry === "true"
-                      ? this.state.goal2bDummyDigit
-                      : this.state.goal_numerator_digit
-                  }
-                />
-              </div>
-              <div>
-                <div className="divide">&divide;</div>
-                <TextField
-                  label="Denominator"
-                  name="goal_denominator_digit"
-                  size="small"
-                  className="ds-l--auto"
-                  value={
-                    this.props.previousEntry === "true"
-                      ? this.state.goal2bDummyDigit
-                      : this.state.goal_denominator_digit
-                  }
-                />
-              </div>
-              <div>
-                <div className="divide"> &#61; </div>
-                <TextField
-                  label="Percentage"
-                  name="goal_percentage"
-                  size="small"
-                  value={
-                    this.props.previousEntry === "true"
-                      ? this.state.goal2bDummyDigit
-                      : `${this.state.percentage}%`
-                  }
-                />
-              </div>
+          </div>
+          <div className="ds-1-row percentages">
+            <div>
+              <TextField
+                label="Numerator"
+                name="goal_numerator_digit"
+                size="small"
+                className="ds-l--auto"
+                value={
+                  this.props.previousEntry === "true"
+                    ? this.state.goal2bDummyDigit
+                    : this.state.goal_numerator_digit
+                }
+              />
             </div>
-          </form>
+            <div>
+              <div className="divide">&divide;</div>
+              <TextField
+                label="Denominator"
+                name="goal_denominator_digit"
+                size="small"
+                className="ds-l--auto"
+                value={
+                  this.props.previousEntry === "true"
+                    ? this.state.goal2bDummyDigit
+                    : this.state.goal_denominator_digit
+                }
+              />
+            </div>
+            <div>
+              <div className="divide"> &#61; </div>
+              <TextField
+                label="Percentage"
+                name="goal_percentage"
+                size="small"
+                value={
+                  this.props.previousEntry === "true"
+                    ? this.state.goal2bDummyDigit
+                    : `${this.state.percentage}%`
+                }
+              />
+            </div>
+          </div>
         </div>
 
         <div className="question-container">
@@ -297,30 +297,31 @@ class Goal extends Component {
             />
           </div>
         </div>
-
-        <ChoiceList
-          choices={[
-            {
-              label: "Eligibility or enrollment data",
-              value: "enrollment_data",
-              disabled: renderPreviousEntry ? true : false,
-              defaultChecked: true,
-            },
-            {
-              label: "Survey data",
-              value: "survey_data",
-              disabled: renderPreviousEntry ? true : false,
-            },
-            {
-              label: "Another data source",
-              value: "other_data",
-              disabled: renderPreviousEntry ? true : false,
-            },
-          ]}
-          className="ds-u-margin-top--5"
-          label="Which data source did you use?"
-          name="data_source"
-        />
+        <form>
+          <ChoiceList
+            choices={[
+              {
+                label: "Eligibility or enrollment data",
+                value: "enrollment_data",
+                disabled: renderPreviousEntry ? true : false,
+                defaultChecked: renderPreviousEntry ? true : false,
+              },
+              {
+                label: "Survey data",
+                value: "survey_data",
+                disabled: renderPreviousEntry ? true : false,
+              },
+              {
+                label: "Another data source",
+                value: "other_data",
+                disabled: renderPreviousEntry ? true : false,
+              },
+            ]}
+            className="ds-u-margin-top--5"
+            label="Which data source did you use?"
+            name="data_source"
+          />
+        </form>
         <div className="question-container">
           <TextField
             label="How did your progress last year compare to your previous year's progress towards your goal?"
@@ -369,6 +370,8 @@ class Goal extends Component {
             hint="Optional"
             name="supporting_documentation"
             className="ds-u-margin-top--0"
+            disabled={renderPreviousEntry ? true : false}
+            value={renderPreviousEntry ? "SomeFile2019.docx" : ""}
           />
           <button className="ds-c-button">Browse</button>
         </div>

--- a/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
+++ b/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
@@ -76,6 +76,8 @@ class Goal extends Component {
   }
 
   render() {
+    // This boolean establishes if the component should be rendering a previous entry or not
+    // Its use here is jus to shorten some ternary statements
     let renderPreviousEntry =
       this.props.previousEntry === "true" ? true : false;
 
@@ -113,12 +115,11 @@ class Goal extends Component {
               {
                 label: "Discontinued goal",
                 value: "discontinued",
-
                 disabled: renderPreviousEntry ? true : false,
               },
             ]}
             label="What type of goal is it?"
-            name={`goal_type${this.props.goalCount}`} // each question in tabs needs to have their own names or the defaultChecked property WILL be overwritten by the last one rendered
+            name={`goal_type${this.props.goalId}`} //choiceLists in Tab components need unique names or their defaultChecked values will be overwritten
             type="radio"
           />
         </div>
@@ -310,7 +311,7 @@ class Goal extends Component {
           ]}
           className="ds-u-margin-top--5"
           label="Which data source did you use?"
-          name={`data_source${this.props.goalCount}`}
+          name={`data_source${this.props.goalId}`} //choiceLists in Tab components need unique names or their defaultChecked values will be overwritten
         />
 
         <div className="question-container">

--- a/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
+++ b/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
@@ -102,20 +102,18 @@ class Goal extends Component {
                 label: "New goal",
                 value: "new",
                 disabled: renderPreviousEntry ? true : false,
-                // disabled: true,
               },
               {
                 label: "Continuing goal",
                 value: "continuing",
-                // disabled: true,
-                // defaultChecked: true,
+
                 disabled: renderPreviousEntry ? true : false,
                 defaultChecked: renderPreviousEntry ? true : false,
               },
               {
                 label: "Discontinued goal",
                 value: "discontinued",
-                // disabled: true,
+
                 disabled: renderPreviousEntry ? true : false,
               },
             ]}

--- a/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
+++ b/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
@@ -76,8 +76,6 @@ class Goal extends Component {
   }
 
   render() {
-    // This boolean establishes if the component should be rendering a previous entry or not
-    // Its use here is jus to shorten some ternary statements
     let renderPreviousEntry =
       this.props.previousEntry === "true" ? true : false;
 
@@ -119,7 +117,8 @@ class Goal extends Component {
               },
             ]}
             label="What type of goal is it?"
-            name={`goal_type${this.props.goalId}`} //choiceLists in Tab components need unique names or their defaultChecked values will be overwritten
+            name={`goal_type${this.props.goalId}`}
+            //choiceLists in Tab components need unique names or their defaultChecked values will be overwritten
             type="radio"
           />
         </div>
@@ -311,7 +310,8 @@ class Goal extends Component {
           ]}
           className="ds-u-margin-top--5"
           label="Which data source did you use?"
-          name={`data_source${this.props.goalId}`} //choiceLists in Tab components need unique names or their defaultChecked values will be overwritten
+          name={`data_source${this.props.goalId}`}
+          //choiceLists in Tab components need unique names or their defaultChecked values will be overwritten
         />
 
         <div className="question-container">

--- a/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
+++ b/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
@@ -8,12 +8,20 @@ class Goal extends Component {
       goal_denominator_digit: 0,
       percentage: 0,
       shouldCalculate: true,
+      goal2bDummyBoolean: true,
       goal2bDummyData:
         "This is what you wrote last year. Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
       goal2bDummyDigit: 10,
     };
     this.addDivisors = this.addDivisors.bind(this);
     this.percentageCalculator = this.percentageCalculator.bind(this);
+  }
+
+  componentDidMount() {
+    this.setState({
+      goal_type_value: "continuing",
+      goal_source_value: "enrollment_data",
+    });
   }
 
   // Validate the input before returning calculated percentage
@@ -67,6 +75,9 @@ class Goal extends Component {
   }
 
   render() {
+    let renderPreviousEntry =
+      this.props.previousEntry === "true" ? true : false;
+    console.log("value??", renderPreviousEntry);
     return (
       <Fragment>
         <div className="question-container">
@@ -86,12 +97,36 @@ class Goal extends Component {
         <div className="question-container">
           <ChoiceList
             choices={[
-              { label: "New goal", value: "new" },
-              { label: "Continuing goal", value: "continuing" },
-              { label: "Discontinued goal", value: "discontinued" },
+              {
+                label: "New goal",
+                value: "new",
+                // disabled: renderPreviousEntry ? true : false,
+                disabled: true,
+              },
+              {
+                label: "Continuing goal",
+                value: "continuing",
+                // disabled: renderPreviousEntry ? true : false,
+                // defaultChecked: renderPreviousEntry ? true : false,
+                defaultChecked: true,
+                // renderPreviousEntry
+                //   ? true
+                //   : // ? this.state.goal_type_value === "continuing"
+                //     //   ? true
+                //     //   : false
+                //     false,
+                disabled: true,
+              },
+              {
+                label: "Discontinued goal",
+                value: "discontinued",
+                // disabled: renderPreviousEntry ? true : false,
+                disabled: true,
+              },
             ]}
             label="What type of goal is it?"
             name="goal_type"
+            type="radio"
           />
         </div>
 
@@ -268,9 +303,19 @@ class Goal extends Component {
             {
               label: "Eligibility or enrollment data",
               value: "enrollment_data",
+              disabled: renderPreviousEntry ? true : false,
+              defaultChecked: true,
             },
-            { label: "Survey data", value: "survey_data" },
-            { label: "Another data source", value: "other_data" },
+            {
+              label: "Survey data",
+              value: "survey_data",
+              disabled: renderPreviousEntry ? true : false,
+            },
+            {
+              label: "Another data source",
+              value: "other_data",
+              disabled: renderPreviousEntry ? true : false,
+            },
           ]}
           className="ds-u-margin-top--5"
           label="Which data source did you use?"

--- a/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
+++ b/app/react/src/components/sections/section2b/objectives/goals/Goal2b.js
@@ -95,41 +95,33 @@ class Goal extends Component {
         </div>
 
         <div className="question-container">
-          <form>
-            <ChoiceList
-              choices={[
-                {
-                  label: "New goal",
-                  value: "new",
-                  disabled: renderPreviousEntry ? true : false,
-                  // disabled: true,
-                },
-                {
-                  label: "Continuing goal",
-                  value: "continuing",
-                  disabled: renderPreviousEntry ? true : false,
-                  defaultChecked: renderPreviousEntry ? true : false,
-                  // defaultChecked: true,
-                  // renderPreviousEntry
-                  //   ? true
-                  //   : // ? this.state.goal_type_value === "continuing"
-                  //     //   ? true
-                  //     //   : false
-                  //     false,
-                  // disabled: true,
-                },
-                {
-                  label: "Discontinued goal",
-                  value: "discontinued",
-                  disabled: renderPreviousEntry ? true : false,
-                  // disabled: true,
-                },
-              ]}
-              label="What type of goal is it?"
-              name="goal_type"
-              type="radio"
-            />
-          </form>
+          <ChoiceList
+            choices={[
+              {
+                label: "New goal",
+                value: "new",
+                // disabled: renderPreviousEntry ? true : false,
+                disabled: true,
+              },
+              {
+                label: "Continuing goal",
+                value: "continuing",
+                disabled: true,
+                defaultChecked: true,
+                // disabled: renderPreviousEntry ? true : false,
+                // defaultChecked: renderPreviousEntry ? true : false,
+              },
+              {
+                label: "Discontinued goal",
+                value: "discontinued",
+                disabled: true,
+                // disabled: renderPreviousEntry ? true : false,
+              },
+            ]}
+            label="What type of goal is it?"
+            name="goal_type"
+            type="radio"
+          />
         </div>
 
         <div className="question-container">
@@ -297,31 +289,31 @@ class Goal extends Component {
             />
           </div>
         </div>
-        <form>
-          <ChoiceList
-            choices={[
-              {
-                label: "Eligibility or enrollment data",
-                value: "enrollment_data",
-                disabled: renderPreviousEntry ? true : false,
-                defaultChecked: renderPreviousEntry ? true : false,
-              },
-              {
-                label: "Survey data",
-                value: "survey_data",
-                disabled: renderPreviousEntry ? true : false,
-              },
-              {
-                label: "Another data source",
-                value: "other_data",
-                disabled: renderPreviousEntry ? true : false,
-              },
-            ]}
-            className="ds-u-margin-top--5"
-            label="Which data source did you use?"
-            name="data_source"
-          />
-        </form>
+
+        <ChoiceList
+          choices={[
+            {
+              label: "Eligibility or enrollment data",
+              value: "enrollment_data",
+              disabled: renderPreviousEntry ? true : false,
+              defaultChecked: renderPreviousEntry ? true : false,
+            },
+            {
+              label: "Survey data",
+              value: "survey_data",
+              disabled: renderPreviousEntry ? true : false,
+            },
+            {
+              label: "Another data source",
+              value: "other_data",
+              disabled: renderPreviousEntry ? true : false,
+            },
+          ]}
+          className="ds-u-margin-top--5"
+          label="Which data source did you use?"
+          name="data_source"
+        />
+
         <div className="question-container">
           <TextField
             label="How did your progress last year compare to your previous year's progress towards your goal?"


### PR DESCRIPTION
-Goals and Objectives given a unique ID 
( Note: For all ChoiceLists, particiarly those rendered in separate tabs on the same page-- if they do not have a unique name, their defaultChecked properties will overwrite eachother) 
-goalCount and objectiveCount props now changed to goalId and objectiveId 
-Comments added to make section 2b more legible
-Helper function added to isolate unique IDs from Goal and Objective props