### PR TITLE
removing the hardcoded minor version number from engine_version

### DIFF
--- a/data/aws/postgres.tf
+++ b/data/aws/postgres.tf
@@ -4,7 +4,7 @@ module "db" {
   version                 = "~> 2.0"
   identifier              = "postgres-rf-${terraform.workspace}"
   engine                  = "postgres"
-  engine_version          = "9.6.9"
+  engine_version          = "9.6"
   instance_class          = "db.t3.small"
   allocated_storage       = 50
   storage_encrypted       = true


### PR DESCRIPTION
removing the hardcoded minor version number from engine_version. rds upgrades minor versions on its own. so if we define a hardcoded minor version in the code the rds instance on its own moves forward from the version spelled out in code. so when we go to deploy we cant go back a version