### PR TITLE
Switch goals to repeatables, set up HSI programs and Section 3I

### DIFF
--- a/docs/section-schemas/backend-json-section-2.json
+++ b/docs/section-schemas/backend-json-section-2.json
@@ -345,11 +345,11 @@
                       },
                       {
                         "id": "2020-02-b-01-01-01-02",
-                        "type": "goals",
+                        "type": "repeatables",
                         "questions": [
                           {
                             "id": "2020-02-b-01-01-01-02-01",
-                            "type": "goal",
+                            "type": "repeatable",
                             "questions": [
                               {
                                 "id": "2020-02-b-01-01-01-02-01-01",

--- a/docs/section-schemas/backend-json-section-3.json
+++ b/docs/section-schemas/backend-json-section-3.json
@@ -1357,6 +1357,170 @@
             ]
           }
         ]
+      },
+      {
+        "id": "2020-03-g",
+        "title": "Section 3G; not yet implemented",
+        "type": "subsection",
+        "text": "",
+        "parts": []
+      },
+      {
+        "id": "2020-03-h",
+        "title": "Section 3H; not yet implemented",
+        "type": "subsection",
+        "text": "",
+        "parts": []
+      },
+      {
+        "id": "2020-03-i",
+        "title": "Health Service Initiative (HSI) Programs",
+        "type": "subsection",
+        "text": "States can use up to 10% of their actual or estimated federal expenditures to develop Health Services Initiatives (HSI) that provide direct services and other public health initiatives for low-income children. [See Section 2105(a)(1)(D)(ii) of the Social Security Act.] States can only develop HSI programs after funding other costs to administer their CHIP State Plan, as defined in regulations at 42 CFR 457.10.\n All states with approved HSI program(s) should complete this section.",
+        "parts": [
+          {
+            "id": "2020-03-i-01",
+            "type": "part",
+            "questions": [
+              {
+                "id": "2020-03-i-01-01",
+                "label": "Does your state operate Health Service Initiatives using CHIP (Title XXI) funds?",
+                "type": "radio",
+                "answer": {
+                  "entry": null,
+                  "options": {
+                    "Yes": "yes",
+                    "No": "no"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "id": "2020-03-i-02",
+            "type": "part",
+            "text": "Tell us about each of your HSI programs.",
+            "context_data": {
+              "conditional_display": {
+                "type": "conditional_display",
+                "comment": "Interactive: Hide if 2020-03-i-01-01 is no or unanswered; noninteractive: hide if that's no.",
+                "skip_text": "This section only applies to states with Health Service Initiatives. Skip to the next section.",
+                "hide_if": {
+                  "target": "$..*[?(@.id=='2020-03-i-01-01')].answer.entry",
+                  "values": {
+                    "interactive": [
+                      null,
+                      "no"
+                    ],
+                    "noninteractive": [
+                      "no"
+                    ]
+                  }
+                }
+              }
+            },
+            "questions": [
+              {
+                "id": "2020-03-i-02-01",
+                "type": "repeatables",
+                "questions": [
+                  {
+                    "id": "2020-03-i-02-01-01",
+                    "type": "repeatable",
+                    "questions": [
+                      {
+                        "id": "2020-03-i-02-01-01-01",
+                        "type": "text_long",
+                        "label": "What is the name of your HSI program?",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "id": "2020-03-i-02-01-01-02",
+                        "type": "text_long",
+                        "label": "Which populations are served by your HSI program?",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "id": "2020-03-i-02-01-01-03",
+                        "type": "integer",
+                        "label": "How many children do you estimate are served by your HSI program?",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "fieldset",
+                        "hint": "Skip the following sections if you're already reporting this information elsewhere to CMS.",
+                        "questions": []
+                      },
+                      {
+                        "id": "2020-03-i-02-01-01-04",
+                        "type": "integer",
+                        "label": "How many children in the HSI program are below your state's FPL threshold? ",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "id": "2020-03-i-02-01-01-05",
+                        "type": "text_long",
+                        "label": "How do you measure the HSI program’s impact on the health of low-income children in your state? Define a metric to measure the impact.",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "id": "2020-03-i-02-01-01-06",
+                        "type": "text_long",
+                        "label": "What outcomes have you found in measuring the impact?",
+                        "answer": {
+                          "entry": null
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "2020-03-i-03",
+            "type": "part",
+            "context_data": {
+              "conditional_display": {
+                "type": "conditional_display",
+                "comment": "Interactive: Hide if 2020-03-i-01-01 is no or unanswered; noninteractive: hide if that's no.",
+                "skip_text": "This section only applies to states with Health Service Initiatives. Skip to the next section.",
+                "hide_if": {
+                  "target": "$..*[?(@.id=='2020-03-i-01-01')].answer.entry",
+                  "values": {
+                    "interactive": [
+                      null,
+                      "no"
+                    ],
+                    "noninteractive": [
+                      "no"
+                    ]
+                  }
+                }
+              }
+            },
+            "questions": [
+              {
+                "id": "2020-03-i-03-01",
+                "type": "text_long",
+                "label": "Anything else you’d like to add about your HSI programs?",
+                "answer": {
+                  "entry": "null"
+                }
+              }
+            ]
+          }        
+        ]
       }
     ]
   }

--- a/docs/section-schemas/backend-section.schema.json
+++ b/docs/section-schemas/backend-section.schema.json
@@ -106,6 +106,9 @@
                 "$ref": "#/definitions/fieldset"
               },
               {
+                "$ref": "#/definitions/repeatables"
+              },
+              {
                 "$ref": "#/definitions/objectives"
               },
               {
@@ -206,11 +209,11 @@
               "$ref": "#/definitions/question"
             },
             {
-              "$ref": "#/definitions/goals"
+              "$ref": "#/definitions/repeatables"
             }
           ],
           "additionalItems": {
-            "$ref": "#/definitions/goals"
+            "$ref": "#/definitions/repeatables"
           }
         }
       },
@@ -220,14 +223,14 @@
         "type"
       ]
     },
-    "goals": {
+    "repeatables": {
       "type": "object",
       "properties": {
         "id": {
           "type": "string"
         },
         "type": {
-          "const": "goals"
+          "const": "repeatables"
         },
         "comment": {
           "type": "string"
@@ -235,7 +238,7 @@
         "questions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/goal"
+            "$ref": "#/definitions/repeatable"
           }
         }
       },
@@ -245,14 +248,14 @@
         "type"
       ]
     },
-    "goal": {
+    "repeatable": {
       "type": "object",
       "properties": {
         "id": {
           "type": "string"
         },
         "type": {
-          "const": "goal"
+          "const": "repeatable"
         },
         "comment": {
           "type": "string"


### PR DESCRIPTION
They used to be “goals”
But now they're “repeatables”.
Names are everything.

Change the schema and documentation to reflect new nomenclature for repeatables, which was changed to accommodate the fact that HSI Programs in Section 3I function almost identically to goals in Section 2B.

Change other JSON files to reflect this.