### PR TITLE
Correct subnet placement for the app

### DIFF
--- a/data/aws/vpc.tf
+++ b/data/aws/vpc.tf
@@ -9,6 +9,10 @@ data "aws_subnet_ids" "private" {
   tags = {
     Type = "private"
   }
+  filter {
+    name   = "tag:vpc-conf-layer"
+    values = ["data"]
+  }
 }
 
 data "aws_subnet_ids" "public" {

--- a/frontend/aws/vpc.tf
+++ b/frontend/aws/vpc.tf
@@ -9,6 +9,10 @@ data "aws_subnet_ids" "private" {
   tags = {
     Type = "private"
   }
+  filter {
+    name   = "tag:vpc-conf-layer"
+    values = ["data"]
+  }
 }
 
 data "aws_subnet_ids" "public" {

--- a/frontend/aws/vpc.tf
+++ b/frontend/aws/vpc.tf
@@ -11,7 +11,7 @@ data "aws_subnet_ids" "private" {
   }
   filter {
     name   = "tag:vpc-conf-layer"
-    values = ["data"]
+    values = ["app"]
   }
 }
 


### PR DESCRIPTION

The effect of this change is to constrain frontend components (the ui and apis) to subnets tagged vpc-conf-layer:app and to constrain RDS placement to subnets tagged vpc-conf-layer:data

