### PR TITLE
More synthesized_table features, enable_copying_prior_year_data flag in JSON

### DIFF
--- a/docs/section-schemas/backend-json-section-0.json
+++ b/docs/section-schemas/backend-json-section-0.json
@@ -36,7 +36,7 @@
                   "readonly": true,
                   "entry": null,
                   "options": {
-                    "Combination (Medicaid Expansion CHIP and Separate CHIP)": "combo",
+                    "Combination": "combo",
                     "Medicaid Expansion CHIP only": "medicaid_exp_chip",
                     "Separate CHIP only": "separate_chip"
                   }

--- a/docs/section-schemas/backend-json-section-0.json
+++ b/docs/section-schemas/backend-json-section-0.json
@@ -20,7 +20,7 @@
               {
                 "id": "2020-00-a-01-01",
                 "label": "State or territory name:",
-                "type": "text_long",
+                "type": "text_short",
                 "answer": {
                   "prepopulated": true,
                   "readonly": true,
@@ -44,7 +44,7 @@
               },
               {
                 "id": "2020-00-a-01-03",
-                "label": "CHIP program name(s): ",
+                "label": "CHIP program name(s):",
                 "type": "text_long",
                 "answer": {
                   "prepopulated": true,

--- a/docs/section-schemas/backend-json-structure-documentation.rst
+++ b/docs/section-schemas/backend-json-structure-documentation.rst
@@ -714,15 +714,16 @@ This is an example of using both ``identity`` and ``sum`` in a table:
           {"contents": "Total number of loosely-defined tales of the fantastical"},
         ],
         "rows": [
-            {"targets": ["$..*[?(@.id=='2020-02-b-01-01-01-01')].answer.entry"]},
-            {"targets": ["$..*[?(@.id=='2020-02-b-01-01-01-02')].answer.entry"]},
-            {
-              "targets": [
-                "$..*[?(@.id=='2020-02-b-01-01-01-01')].answer.entry",
-                "$..*[?(@.id=='2020-02-b-01-01-01-02')].answer.entry",
-              ],
-              "actions": ["sum"]
-            }
+          {"targets": ["$..*[?(@.id=='2020-02-b-01-01-01-01')].answer.entry"]},
+          {"targets": ["$..*[?(@.id=='2020-02-b-01-01-01-02')].answer.entry"]},
+          {
+            "targets": [
+              "$..*[?(@.id=='2020-02-b-01-01-01-01')].answer.entry",
+              "$..*[?(@.id=='2020-02-b-01-01-01-02')].answer.entry",
+            ],
+            "actions": ["sum"]
+          }
+        ]
       }
     }
 

--- a/docs/section-schemas/backend-json-structure-documentation.rst
+++ b/docs/section-schemas/backend-json-structure-documentation.rst
@@ -501,11 +501,11 @@ Example of ``sum``:
       "fieldset_type": "synthesized_value",
       "label": "Total number of loosely-defined tales of the fantastical",
       "fieldset_info": {
-          "targets": [
-            "$..*[?(@.id=='2020-02-b-01-01-01-01')].answer.entry",
-            "$..*[?(@.id=='2020-02-b-01-01-01-02')].answer.entry"
-          ]
-          "actions": ["sum"]
+        "targets": [
+          "$..*[?(@.id=='2020-02-b-01-01-01-01')].answer.entry",
+          "$..*[?(@.id=='2020-02-b-01-01-01-02')].answer.entry"
+        ],
+        "actions": ["sum"]
       }
     }
 

--- a/docs/section-schemas/backend-json-structure-documentation.rst
+++ b/docs/section-schemas/backend-json-structure-documentation.rst
@@ -242,7 +242,7 @@ Parts are contained by subsections.
     Comment directed at developer or admin users.
 
 ``context_data``
-
+----------------
 A property that contains data about whether and/or how the segment should be displayed.
 
 ``bullet_text`` (optional)
@@ -253,6 +253,10 @@ A property that contains data about whether and/or how the segment should be dis
     Boolean.
 
     Present and ``true`` if the UI is supposed to display data from the prior year as an aid to data entry.
+``enable_copying_prior_year_data`` (optional)
+    Boolean.
+
+    Present and ``true`` if the UI is supposed to help the user copy over data from the prior year.
 ``conditional_display`` (optional)
     Extremely limited logic mini-schema to control display of questions. See `Conditional display`_ below.
 ``interactive_conditional`` (optional)
@@ -449,6 +453,110 @@ Fieldsets do not have ``id`` properties, and the questions within them increment
 
 Special ``fieldset`` types
 **************************
+
+``synthesized_value``
+#####################
+Get values from elsewhere, defined in the ``targets`` property, perform some action(s) upon them, defined in the ``actions`` property, and display the result.
+
+Both ``targets`` and ``actions`` expect arrays.
+
+For convenience, there is also a ``contents`` property that can be used instead of the above if all that's desired is to display a literal value. This property isn't too useful on its own (because you could just put the literal value into the ``label`` property of a fieldset), but becomes useful with ``synthesized_table``, which expects objects of the same shape.
+
+The value of the ``contents`` property can be a string, integer, or float.
+
+Supported actions are:
+
+``identity``
+    Return the value unchanged, except that it's now in an array.
+``sum``
+    Add all of the values and return the result. This probably implies casting them to number types first.
+
+The property is called ``actions``, but hopefully we'll only ever need to have one action listed, and thus won't have to define what happens in what order if there are multiple values.
+
+If ``actions`` is empty, we should assume that this is equivalent to having a value of ``["identity"]``.
+
+Example of ``sum``:
+
+..  code:: json
+
+    {
+      "type": "fieldset",
+      "questions": [
+        {
+          "id": "2020-02-b-01-01-01-01",
+          "label": "How many fables were you told?",
+          "type": "integer",
+          "answer": { "entry": null }
+        },
+        {
+          "id": "2020-02-b-01-01-01-02",
+          "label": "How many fairy tales were you told?",
+          "type": "integer",
+          "answer": { "entry": null }
+        }
+      ]
+    },
+    {
+      "type": "fieldset",
+      "fieldset_type": "synthesized_value",
+      "label": "Total number of loosely-defined tales of the fantastical",
+      "fieldset_info": {
+          "targets": [
+            "$..*[?(@.id=='2020-02-b-01-01-01-01')].answer.entry",
+            "$..*[?(@.id=='2020-02-b-01-01-01-02')].answer.entry"
+          ]
+          "actions": ["sum"]
+      }
+    }
+
+
+The above would display the two questions, and below them a label followed by the sum of the two answers.
+
+Example of ``identity``:
+
+..  code:: json
+
+    {
+      "type": "fieldset",
+      "fieldset_type": "synthesized_value",
+      "label": "Your answer to Section 1A, Part 23, Question 147",
+      "fieldset_info": {
+        "targets": [
+          "$..*[?(@.id=='2020-01-a-23-147')].answer.entry",
+        ]
+        "actions": ["identity"]
+      },
+    },
+    {
+      "type": "fieldset",
+      "questions": [
+        {
+          "id": "2020-02-b-01-01-01-01",
+          "label": "Attempt to justify your above answer to Section 1A, Part 23, Question 147",
+          "type": "integer",
+          "answer": { "entry": null }
+        }
+      ]
+    }
+
+The above would display a question accompanied by the user's answer to the indicated question from another section.
+
+Example of using ``contents``:
+
+..  code:: json
+
+    {
+      "type": "fieldset",
+      "fieldset_type": "synthesized_value",
+      "label": "The temperature in Fahrenheit at 01:00 in St. Petersburg on Valentine's Day, 1998",
+      "fieldset_info": {
+        "contents": 12.2,
+      },
+    }
+
+The above would display ``The temperature in Fahrenheit at 01:00 in St. Petersburg on Valentine's Day, 1998`` and ``12.2``.
+
+
 ``percentage``
 ##############
 This displays a percentage field as an aid to the user, calculating it from two fields other fields. Those other fields are specified in the ``fieldset_info`` object.
@@ -458,7 +566,6 @@ The percentage value would be displayed at the end of wherever the fieldset is i
 The ``fieldset_info`` object for ``percentage`` has two properties, ``numerator`` and ``denominator``, each of which contains a string that is a JSON Path expression of the target. For example:
 
 ..  code:: json
-
 
       {
         "type": "fieldset",
@@ -524,11 +631,8 @@ The ``fieldset_info`` property contains two fields, ``headers`` and ``rows``.
 
 ``rows`` is a two-dimensional array; each item is an array containing the values for that row of the table.
 
-Values for those arrays are objects with either a ``contents`` property or a ``target`` property.
+Values for those arrays are objects with the same shape as those for ``synthesized_value``, that is, with either a ``contents`` property or both ``targets`` and ``actions`` properties.
 
-The value of the ``contents`` property can be a string, integer, or float.
-
-The value of the ``target`` property is a string representing the JSON Path of the location of the target value.
 
 An example:
 
@@ -554,8 +658,14 @@ An example:
       "fieldset_info": {
         "headers": [{"contents": "Contents"}, {"contents": "Targets"}],
         "rows": [
-          [{"contents": "From the server"}, {"target": "$..*[?(@.id=='2020-01-a-01')].answer.entry"}],
-          [{"contents": "Also from the server"}, {"target": "$..*[?(@.id=='2020-01-a-02')].answer.entry"}],
+          [
+            {"contents": "From the server"},
+            {"targets": ["$..*[?(@.id=='2020-01-a-01')].answer.entry"], "actions"=["identity"]}
+          ],
+          [
+            {"contents": "Also from the server"},
+            {"targets": ["$..*[?(@.id=='2020-01-a-02')].answer.entry"]}
+          ],
         ]
       },
       "questions": []
@@ -569,6 +679,64 @@ This would produce something like:
     From the server       I'm over here
     Also from the server  And I'm over here
     ====================  =================
+
+I omitted the ``actions`` property from the second row because ``["identity"]`` is its default value.
+
+This is an example of using both ``identity`` and ``sum`` in a table:
+
+..  code:: json
+
+    {
+      "type": "fieldset",
+      "questions": [
+        {
+          "id": "2020-02-b-01-01-01-01",
+          "label": "How many fables were you told?",
+          "type": "integer",
+          "answer": { "entry": null }
+        },
+        {
+          "id": "2020-02-b-01-01-01-02",
+          "label": "How many fairy tales were you told?",
+          "type": "integer",
+          "answer": { "entry": null }
+        }
+      ]
+    },
+    {
+      "type": "fieldset",
+      "fieldset_type": "synthesized_table",
+      "label": "Fantastical narratives data summary",
+      "fieldset_info": {
+        "headers": [
+          {"contents": "Fables"},
+          {"contents": "Fairy tales"},
+          {"contents": "Total number of loosely-defined tales of the fantastical"},
+        ],
+        "rows": [
+            {"targets": ["$..*[?(@.id=='2020-02-b-01-01-01-01')].answer.entry"]},
+            {"targets": ["$..*[?(@.id=='2020-02-b-01-01-01-02')].answer.entry"]},
+            {
+              "targets": [
+                "$..*[?(@.id=='2020-02-b-01-01-01-01')].answer.entry",
+                "$..*[?(@.id=='2020-02-b-01-01-01-02')].answer.entry",
+              ],
+              "actions": ["sum"]
+            }
+      }
+    }
+
+I omitted the ``actions`` property for brevity where it would have been the default value.
+
+Assuming the answers to the two questions were ``2`` and ``3``, the above would produce something like:
+
+    ..  table:: Fantastical narratives data summary
+
+        ======  ===========  ========================================================
+        Fables  Fairy tales  Total number of loosely-defined tales of the fantastical
+        ======  ===========  ========================================================
+             2            3                                                         5
+        ======  ===========  ========================================================
 
 
 ``noninteractive_table``
@@ -774,13 +942,17 @@ The frontend must allow users to create new objectives, and to create new goals 
 
 The API JSON representation of the first goal in the first objective is the template for any further goals, and the API JSON representation of the first objective is the template for any further objectives.
 
+There must be at least one of these in their arrays at any time: the ``objectives`` property must contain at least one ``objective``, and the ``repeatables`` property must contain at least one ``repeatable``.
+
+The first ``objective`` is a special case in that its first question isn't displayed; its displayed content begins with its first goal. That first question has ``answer.readonly`` and ``answer.default_entry`` properties set. Removing these is part of creating the structure for a new objective.
+
 When creating new goals and/or objectives, the frontend must
 
 +   Copy the last item in the corresponding array of objectives or goals.
 +   Set all ``entry`` properties at all levels of the new construct to be empty.
 +   For new objectives:
     +   Delete all but the first goal in the new construct.
-    +   For the first question, in addition to setting ``answer.entry`` to ``null``, delete the ``answer.readonly`` and ``default_entry`` properties.
+    +   For the first question, in addition to setting ``answer.entry`` to ``null``, delete the ``answer.readonly`` and ``answer.default_entry`` properties.
 
 +   Set the ``id`` properties at all levels of the new construct to the appropriate values.
 
@@ -807,7 +979,10 @@ This is one approach to the above process for adding a new objective (it assumes
 ..  code:: javascript
 
     const jp = require('jsonpath');
-    const lastObjective = jp.query(sectionTwo, "$..*[?(@.id=='2020-02-b-01-01')].questions[-1:]"); // Get objective by referring to id of objectives item and then getting the last thing in that item's questions array.
+
+    /* Get objective by referring to id of objectives item and then getting the last thing in that
+    item's questions array: */
+    const lastObjective = jp.query(sectionTwo, "$..*[?(@.id=='2020-02-b-01-01')].questions[-1:]");
 
     const priorId = lastObjective[0].id; // "2020-02-b-01-01-01"
     let deconstructedId = priorId.split("-");
@@ -815,7 +990,8 @@ This is one approach to the above process for adding a new objective (it assumes
     deconstructedId.push(last);
     const newId = deconstructedId.join("-"); // "2020-02-b-01-01-02"
 
-    // Convert it to string for two reasons. First reason: to ensure we're doing a deep copy, not a shallow copy.
+    // Convert it to string for two reasons.
+    // First reason: to ensure we're doing a deep copy, not a shallow copy.
     const stringifiedFirstObjective = JSON.stringify(lastObjective);
     // Second reason: replace all references to the prior ID with the new ID
     const stringifiedNewObjective = stringifiedFirstObjective.split(priorId).join(newId);

--- a/docs/section-schemas/backend-json-structure-documentation.rst
+++ b/docs/section-schemas/backend-json-structure-documentation.rst
@@ -523,7 +523,7 @@ Example of ``identity``:
       "fieldset_info": {
         "targets": [
           "$..*[?(@.id=='2020-01-a-23-147')].answer.entry",
-        ]
+        ],
         "actions": ["identity"]
       },
     },
@@ -660,7 +660,7 @@ An example:
         "rows": [
           [
             {"contents": "From the server"},
-            {"targets": ["$..*[?(@.id=='2020-01-a-01')].answer.entry"], "actions"=["identity"]}
+            {"targets": ["$..*[?(@.id=='2020-01-a-01')].answer.entry"], "actions": ["identity"]}
           ],
           [
             {"contents": "Also from the server"},

--- a/docs/section-schemas/backend-section.schema.json
+++ b/docs/section-schemas/backend-section.schema.json
@@ -136,6 +136,9 @@
         "display_prior_year_data": {
           "type": "boolean"
         },
+        "enable_copying_prior_year_data": {
+          "type": "boolean"
+        },
         "interactive_conditional": {
           "type": "string"
         },


### PR DESCRIPTION
How many functions
Do we need to add before
It's Turing-complete?

Add ways to represent that some values should be the sums of other values. Add `enable_copying_prior_year_data`. Change the answer type for the very first question.