### PR TITLE
JSON for Section 3C

### DIFF
--- a/docs/section-schemas/backend-json-section-2.json
+++ b/docs/section-schemas/backend-json-section-2.json
@@ -452,10 +452,10 @@
                               },
                               {
                                 "type": "fieldset",
-                                "fieldset_type": "percentage",
+                                "fieldset_type": "synthesized_value",
                                 "fieldset_info": {
-                                    "numerator": "$..*[?(@.id=='2020-02-b-01-01-01-02-01-04')].answer.entry",
-                                    "denominator": "$..*[?(@.id=='2020-02-b-01-01-01-02-01-06')].answer.entry"
+                                    "targets": ["$..*[?(@.id=='2020-02-b-01-01-01-02-01-04')].answer.entry", "$..*[?(@.id=='2020-02-b-01-01-01-02-01-06')].answer.entry"],
+                                    "actions": ["percentage"]
                                 },
                                 "questions": []
                               },

--- a/docs/section-schemas/backend-json-section-3.json
+++ b/docs/section-schemas/backend-json-section-3.json
@@ -781,6 +781,7 @@
                       },
                       {
                         "type": "fieldset",
+                        "fieldset_type": "datagrid",
                         "context_data": {
                           "skip_text": "1b–1e omitted because you indicated that you don't have the age range breakdown data available.",
                           "conditional_display": {
@@ -887,6 +888,7 @@
                       },
                       {
                         "type": "fieldset",
+                        "fieldset_type": "datagrid",
                         "context_data": {
                           "skip_text": "2b–2e omitted because you indicated that don't you have the age range breakdown data available.",
                           "conditional_display": {
@@ -985,6 +987,7 @@
                       },
                       {
                         "type": "fieldset",
+                        "fieldset_type": "datagrid",
                         "context_data": {
                           "skip_text": "3b–3e omitted because you indicated that you don't have the age range breakdown data available.",
                           "conditional_display": {
@@ -1079,6 +1082,7 @@
                               },
                               {
                                 "type": "fieldset",
+                                "fieldset_type": "datagrid",
                                 "context_data": {
                                   "skip_text": "3f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
                                   "conditional_display": {
@@ -1182,6 +1186,7 @@
                       },
                       {
                         "type": "fieldset",
+                        "fieldset_type": "datagrid",
                         "context_data": {
                           "skip_text": "4b–4e omitted because you indicated that you don't have the age range breakdown data available.",
                           "conditional_display": {
@@ -1276,6 +1281,7 @@
                               },
                               {
                                 "type": "fieldset",
+                                "fieldset_type": "datagrid",
                                 "context_data": {
                                   "skip_text": "4f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
                                   "conditional_display": {
@@ -1397,6 +1403,7 @@
                       },
                       {
                         "type": "fieldset",
+                        "fieldset_type": "datagrid",
                         "context_data": {
                           "skip_text": "6b–6e omitted because you indicated that don't you have the age range breakdown data available.",
                           "conditional_display": {
@@ -1495,6 +1502,7 @@
                       },
                       {
                         "type": "fieldset",
+                        "fieldset_type": "datagrid",
                         "context_data": {
                           "skip_text": "7b–7e omitted because you indicated that you don't have the age range breakdown data available.",
                           "conditional_display": {
@@ -1589,6 +1597,7 @@
                               },
                               {
                                 "type": "fieldset",
+                                "fieldset_type": "datagrid",
                                 "context_data": {
                                   "skip_text": "7f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
                                   "conditional_display": {
@@ -1670,7 +1679,7 @@
                           "entry": null
                         },
                         "context_data": {
-                          "skip_text": "4a omitted because you indicated that you have the age range breakdown data available.",
+                          "skip_text": "8a omitted because you indicated that you have the age range breakdown data available.",
                           "conditional_display": {
                             "type": "conditional_display",
                             "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
@@ -1692,8 +1701,9 @@
                       },
                       {
                         "type": "fieldset",
+                        "fieldset_type": "datagrid",
                         "context_data": {
-                          "skip_text": "4b–4e omitted because you indicated that you don't have the age range breakdown data available.",
+                          "skip_text": "8b–8e omitted because you indicated that you don't have the age range breakdown data available.",
                           "conditional_display": {
                             "type": "conditional_display",
                             "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
@@ -1764,7 +1774,7 @@
                                   "entry": null
                                 },
                                 "context_data": {
-                                  "skip_text": "4f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                  "skip_text": "8f 1 omitted because you indicated that you have the age range breakdown data available.",
                                   "conditional_display": {
                                     "type": "conditional_display",
                                     "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
@@ -1786,8 +1796,9 @@
                               },
                               {
                                 "type": "fieldset",
+                                "fieldset_type": "datagrid",
                                 "context_data": {
-                                  "skip_text": "4f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
+                                  "skip_text": "8f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
                                   "conditional_display": {
                                     "type": "conditional_display",
                                     "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
@@ -1875,7 +1886,7 @@
                           "entry": null
                         },
                         "context_data": {
-                          "skip_text": "6a omitted because you indicated that you have the age range breakdown data available.",
+                          "skip_text": "9a omitted because you indicated that you have the age range breakdown data available.",
                           "conditional_display": {
                             "type": "conditional_display",
                             "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
@@ -1897,8 +1908,9 @@
                       },
                       {
                         "type": "fieldset",
+                        "fieldset_type": "datagrid",
                         "context_data": {
-                          "skip_text": "6b–6e omitted because you indicated that don't you have the age range breakdown data available.",
+                          "skip_text": "9b–9e omitted because you indicated that don't you have the age range breakdown data available.",
                           "conditional_display": {
                             "type": "conditional_display",
                             "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
@@ -1973,7 +1985,7 @@
                           "entry": null
                         },
                         "context_data": {
-                          "skip_text": "7a omitted because you indicated that you have the age range breakdown data available.",
+                          "skip_text": "10a omitted because you indicated that you have the age range breakdown data available.",
                           "conditional_display": {
                             "type": "conditional_display",
                             "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
@@ -1995,8 +2007,9 @@
                       },
                       {
                         "type": "fieldset",
+                        "fieldset_type": "datagrid",
                         "context_data": {
-                          "skip_text": "7b–7e omitted because you indicated that you don't have the age range breakdown data available.",
+                          "skip_text": "10b–10e omitted because you indicated that you don't have the age range breakdown data available.",
                           "conditional_display": {
                             "type": "conditional_display",
                             "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
@@ -2067,7 +2080,7 @@
                                   "entry": null
                                 },
                                 "context_data": {
-                                  "skip_text": "7f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                  "skip_text": "10f 1 omitted because you indicated that you have the age range breakdown data available.",
                                   "conditional_display": {
                                     "type": "conditional_display",
                                     "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
@@ -2089,8 +2102,9 @@
                               },
                               {
                                 "type": "fieldset",
+                                "fieldset_type": "datagrid",
                                 "context_data": {
-                                  "skip_text": "7f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
+                                  "skip_text": "10f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
                                   "conditional_display": {
                                     "type": "conditional_display",
                                     "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
@@ -2170,7 +2184,7 @@
                           "entry": null
                         },
                         "context_data": {
-                          "skip_text": "4a omitted because you indicated that you have the age range breakdown data available.",
+                          "skip_text": "11a omitted because you indicated that you have the age range breakdown data available.",
                           "conditional_display": {
                             "type": "conditional_display",
                             "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
@@ -2192,8 +2206,9 @@
                       },
                       {
                         "type": "fieldset",
+                        "fieldset_type": "datagrid",
                         "context_data": {
-                          "skip_text": "4b–4e omitted because you indicated that you don't have the age range breakdown data available.",
+                          "skip_text": "11b–11e omitted because you indicated that you don't have the age range breakdown data available.",
                           "conditional_display": {
                             "type": "conditional_display",
                             "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
@@ -2264,7 +2279,7 @@
                                   "entry": null
                                 },
                                 "context_data": {
-                                  "skip_text": "4f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                  "skip_text": "11f 1 omitted because you indicated that you have the age range breakdown data available.",
                                   "conditional_display": {
                                     "type": "conditional_display",
                                     "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
@@ -2286,8 +2301,9 @@
                               },
                               {
                                 "type": "fieldset",
+                                "fieldset_type": "datagrid",
                                 "context_data": {
-                                  "skip_text": "4f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
+                                  "skip_text": "11f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
                                   "conditional_display": {
                                     "type": "conditional_display",
                                     "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",

--- a/docs/section-schemas/backend-json-section-3.json
+++ b/docs/section-schemas/backend-json-section-3.json
@@ -301,11 +301,427 @@
       },
       {
         "id": "2020-03-c",
-        "title": "Tablehouse of Horrors",
+        "title": "Eligibility",
         "type": "subsection",
         "text": "",
-        "parts": []
+        "parts": [
+          {
+            "id": "2020-03-c-01",
+            "type": "part",
+            "title": "Eligibility Renewal and Retention",
+            "questions": [
+              {
+                "id": "2020-03-c-01-01",
+                "label": "Does your state provide presumptive eligibility, allowing children who are presumed to be eligible to access CHIP services?",
+                "type": "radio",
+                "answer": {
+                  "entry": null,
+                  "options": {
+                    "Yes": "yes",
+                    "No": "no",
+                    "N/A": "na"
+                  }
+                },
+                "questions": [
+                  {
+                    "type": "fieldset",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "comment": "Interactive: Hide these two subquestions if the answer to 2020-03-c-01-01 is no or N/A.",
+                        "hide_if": {
+                          "target": "$..*[?(@.id=='2020-03-c-01-01')].answer.entry",
+                          "values": {
+                            "interactive": [
+                                "no",
+                                "na",
+                                null
+                            ],
+                            "noninteractive": [
+                                "no",
+                                "na"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-03-c-01-01-a",
+                        "label": "What percent of children are presumptively enrolled in CHIP pending a full eligibility determination?",
+                        "type": "percentage",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "id": "2020-03-c-01-01-b",
+                        "label": "Of the children who are presumptively enrolled, what percent are determined fully eligible and enrolled in the program?",
+                        "type": "percentage",
+                        "answer": {
+                          "entry": null
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "2020-03-c-01-02",
+                "label": "In an effort to retain more children in CHIP, do you conduct follow-up communication with families through caseworkers and outreach workers?",
+                "type": "radio",
+                "answer": {
+                  "entry": null,
+                  "options": {
+                    "Yes": "yes",
+                    "No": "no"
+                  }
+                }
+              },
+              {
+                "id": "2020-03-c-01-03",
+                "label": "Do you send renewal reminder notices to families?",
+                "type": "radio",
+                "answer": {
+                  "entry": null,
+                  "options": {
+                    "Yes": "yes",
+                    "No": "no"
+                  }
+                },
+                "questions": [
+                  {
+                    "type": "fieldset",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "comment": "Interactive: Hide these two subquestions if the answer to 2020-03-c-01-03 is no or N/A.",
+                        "hide_if": {
+                          "target": "$..*[?(@.id=='2020-03-c-01-03')].answer.entry",
+                          "values": {
+                            "interactive": [
+                                "no",
+                                null
+                            ],
+                            "noninteractive": [
+                                "no"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-03-c-01-03-a",
+                        "label": "How many notices do you send to families before disenrolling a child from the program?",
+                        "type": "text",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "id": "2020-03-c-01-03-b",
+                        "label": "How many days before the end of the eligibility period did you send reminder notices to families?",
+                        "type": "text",
+                        "answer": {
+                          "entry": null
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "2020-03-c-01-04",
+                "label": "What else have you done to simplify the eligibility renewal process for families in order to increase retention?",
+                "type": "text_multiline",
+                "answer": {
+                  "entry": null
+                }
+              },
+              {
+                "id": "2020-03-c-01-05",
+                "label": "Which retention strategies have you found to be most effective?",
+                "type": "text_multiline",
+                "answer": {
+                  "entry": null
+                }
+              },
+              {
+                "id": "2020-03-c-01-06",
+                "label": "How do you measure the effectiveness of your retention strategies? What data sources and methodology do you use to track retention?",
+                "type": "text_multiline",
+                "answer": {
+                  "entry": null
+                }
+              },
+              {
+                "id": "2020-03-c-01-07",
+                "label": "Anything else you’d like to add that wasn’t already covered?",
+                "type": "text_multiline",
+                "answer": {
+                  "entry": null
+                }
+              }
+            ]
+          },
+          {
+            "id": "2020-03-c-02",
+            "type": "part",
+            "title": "Eligibility Denials for First-time Applicants (Not Redetermination)",
+            "questions": [
+              {
+                "id": "2020-03-c-02-01",
+                "label": "How many first-time applicants were denied CHIP coverage in the last federal fiscal year?",
+                "hint": "This only applies to denials for first-time CHIP applicants—don’t include applicants being considered for redetermination.",
+                "type": "integer",
+                "answer": {
+                  "entry": null
+                }
+              },
+              {
+                "id": "2020-03-c-02-02",
+                "label": "How many first-time applicants were denied CHIP coverage for procedural reasons?",
+                "hint": "For example: They were denied because of an incomplete application, missing documentation, or a missing enrollment fee.",
+                "type": "integer",
+                "answer": {
+                  "entry": null
+                }
+              },
+              {
+                "id": "2020-03-c-02-03",
+                "label": "How many first-time applicants were denied CHIP coverage for eligibility reasons?",
+                "hint": "For example: They were denied because their income was too high or too low, they were determined eligible for Medicaid instead, or they had other coverage available.",
+                "type": "integer",
+                "answer": {
+                  "entry": null
+                },
+                "questions": [
+                  {
+
+                    "id": "2020-03-c-02-03-a",
+                    "label": "How many first-time applicants were denied CHIP coverage for eligibility reasons?",
+                    "hint": "For example: They were denied because their income was too high or too low, they were determined eligible for Medicaid instead, or they had other coverage available.",
+                    "type": "integer",
+                    "answer": {
+                      "entry": null
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "2020-03-c-02-04",
+                "label": "How many applicants were denied CHIP coverage for other reasons?",
+                "type": "integer",
+                "answer": {
+                  "entry": null
+                }
+              },
+              {
+                "id": "2020-03-c-02-05",
+                "label": "Did you have any limitations in collecting this data?",
+                "type": "text_multiline",
+                "answer": {
+                  "entry": null
+                }
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "synthesized_table",
+                "label": "Table: Denials for First-Time Applicants",
+                "hint": "This table is auto-populated with the data you entered above.",
+                "fieldset_info": {
+                  "headers": [{"contents": ""}, {"contents": "Number"}, {"contents": "Percent"}],
+                  "rows": [
+                    [
+                      {"contents": "Total denials"},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-02-01')].answer.entry"]},
+                      {"contents": "100%"}
+                    ],
+                    [
+                      {"contents": "Denied for procedural reasons"},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-02-02')].answer.entry"]},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-02-02')].answer.entry", "$..*[?(@.id=='2020-03-c-02-01')].answer.entry"], "actions": ["percentage"]}
+                    ],
+                    [
+                      {"contents": "Denied for eligibility reasons"},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-02-03')].answer.entry"]},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-02-03')].answer.entry", "$..*[?(@.id=='2020-03-c-02-01')].answer.entry"], "actions": ["percentage"]}
+                    ],
+                    [
+                      {"contents": "Denied for eligibility reasons"},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-02-04')].answer.entry"]},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-02-04')].answer.entry", "$..*[?(@.id=='2020-03-c-02-01')].answer.entry"], "actions": ["percentage"]}
+                    ]
+                  ]
+                },
+                "questions": []
+              }
+            ]
+          },
+          {
+            "id": "2020-03-c-03",
+            "type": "part",
+            "title": "Eligibility for Redetermination in CHIP",
+            "text": "Redetermination is the process of redetermining whether a child is eligible to renew in CHIP every 12 months, assuming children haven’t already aged out of the program. Families must resubmit their income each year to determine if they still qualify for the program.",
+            "questions": [
+              {
+                "id": "2020-03-c-03-01",
+                "label": "How many children were eligible for redetermination in CHIP in the last federal fiscal year?",
+                "type": "integer",
+                "answer": {
+                  "entry": null
+                }
+              },
+              {
+                "id": "2020-03-c-03-02",
+                "label": "Of the eligible children, how many were then screened for redetermination?",
+                "type": "integer",
+                "answer": {
+                  "entry": null
+                }
+              },
+              {
+                "id": "2020-03-c-03-03",
+                "label": "How many children were retained in CHIP after the redetermination process?",
+                "type": "integer",
+                "answer": {
+                  "entry": null
+                }
+              },
+              {
+                "id": "2020-03-c-03-04",
+                "label": "How many children were disenrolled in CHIP after the redetermination process?",
+                "comment": "This is very tricky; having 4 apparently be a question the user can enter but also be the total of its subquestions presents issues. Which value takes precedence is one of them. Another is that in addition to being something that apparently can be entered by the user, it is both the output for a synthesized_value operation (sum 4a, 4b, and 4c) and the source for another synthesized_value operation (in the two tables below, where it's one of the inputs to the percentage action). My suggestion is to have 4 be a normal field of its own and have a hint next to it that sums the subquestion answers and tells the user the value they enter for 4 should equal that value. Not ideal, but otherwise we seem to have to either use custom frontend code or support way more nonsense in the data structure spec than we do already.",
+                "type": "integer",
+                "answer": {
+                  "readonly": true,
+                  "entry": null
+                },
+                "questions": [
+                  {
+                      "type": "fieldset",
+                      "hint": "The answer to 4 should be equal to the sum of a, b, and c below: ",
+                      "fieldset_type": "synthesized_value",
+                      "fieldset_info": {
+                        "targets": [
+                          "$..*[?(@.id=='2020-03-c-03-04-a')].answer.entry",
+                          "$..*[?(@.id=='2020-03-c-03-04-b')].answer.entry",
+                          "$..*[?(@.id=='2020-03-c-03-04-c')].answer.entry"
+                        ],
+                        "actions": ["sum"]
+                      },
+                      "questions": []
+                  },
+                  {
+                    "id": "2020-03-c-03-04-a",
+                    "label": "How many children were disenrolled for procedural reasons?",
+                    "hint": "For example: They were denied because of an incomplete application, missing documentation, or a missing enrollment fee.",
+                    "type": "integer",
+                    "answer": {
+                      "entry": null
+                    }
+                  },
+                  {
+                    "id": "2020-03-c-03-04-b",
+                    "label": "How many children were disenrolled for eligibility reasons?",
+                    "hint": "For example: They were denied because their income was too high or too low, they were determined eligible for Medicaid instead, or they had other coverage available.",
+                    "type": "integer",
+                    "answer": {
+                      "entry": null
+                    }
+                  },
+                  {
+                    "id": "2020-03-c-03-04-c",
+                    "label": "How many children were disenrolled for other reasons?",
+                    "type": "integer",
+                    "answer": {
+                      "entry": null
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "2020-03-c-03-05",
+                "label": "Did you have any limitations in collecting this data?",
+                "type": "text_multiline",
+                "answer": {
+                  "entry": null
+                }
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "synthesized_table",
+                "label": "Table: Enrollment Data for CHIP Redetermination",
+                "hint": "These tables are auto-populated with the data you entered above.",
+                "fieldset_info": {
+                  "headers": [{"contents": ""}, {"contents": "Number"}, {"contents": "Percent"}],
+                  "rows": [
+                    [
+                      {"contents": "Children screened for redetermination"},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-03-02')].answer.entry"]},
+                      {"contents": "100%"}
+                    ],
+                    [
+                      {"contents": "Children retained after redetermination"},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-03-03')].answer.entry"]},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-03-03')].answer.entry", "$..*[?(@.id=='2020-03-c-03-02')].answer.entry"], "actions": ["percentage"]}
+                    ],
+                    [
+                      {"contents": "Children disenrolled after redetermination"},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-03-04')].answer.entry"]},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-03-04')].answer.entry", "$..*[?(@.id=='2020-03-c-03-02')].answer.entry"], "actions": ["percentage"]}
+                    ]
+                  ]
+                },
+                "questions": []
+              },
+              {
+                "type": "fieldset",
+                "label": "Table: Disenrollment Data for CHIP Redetermination",
+                "comment": "This is assuming that we make the user manually enter the answer to question 4; otherwise we don't currently have a way to support this functionality; see the comment on question 4 above.",
+                "fieldset_type": "synthesized_table",
+                "fieldset_info": {
+                  "headers": [{"contents": ""}, {"contents": "Number"}, {"contents": "Percent"}],
+                  "rows": [
+                    [
+                      {"contents": "Children disenrolled after redetermination"},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-03-04')].answer.entry"]},
+                      {"contents": "100%"}
+                    ],
+                    [
+                      {"contents": "Children disenrolled for procedural reasons"},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-03-04-a')].answer.entry"]},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-03-04-a')].answer.entry", "$..*[?(@.id=='2020-03-c-03-04')].answer.entry"], "actions": ["percentage"]}
+                    ],
+                    [
+                      {"contents": "Children disenrolled for eligibility reasons"},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-03-04-b')].answer.entry"]},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-03-04-b')].answer.entry", "$..*[?(@.id=='2020-03-c-03-04')].answer.entry"], "actions": ["percentage"]}
+                    ],
+                    [
+                      {"contents": "Children disenrolled for other reasons"},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-03-04-c')].answer.entry"]},
+                      {"targets": ["$..*[?(@.id=='2020-03-c-03-04-c')].answer.entry", "$..*[?(@.id=='2020-03-c-03-04')].answer.entry"], "actions": ["percentage"]}
+                    ]
+                  ]
+                },
+                "questions": []
+              }
+            ]
+          }
+
+        ]
       },
+
+
+
+
+
+
+
+
+
       {
         "id": "2020-03-d",
         "title": "Cost Sharing (Out-of-Pocket Costs)",

--- a/docs/section-schemas/backend-json-section-3.json
+++ b/docs/section-schemas/backend-json-section-3.json
@@ -751,7 +751,6 @@
                       },
                       {
                         "comment": "This is the first real question so far in this part…",
-                        "type": "question",
                         "id": "2020-03-c-04-01-a",
                         "label": "Total for all ages",
                         "type": "integer",

--- a/docs/section-schemas/backend-json-section-3.json
+++ b/docs/section-schemas/backend-json-section-3.json
@@ -549,7 +549,7 @@
                       {"targets": ["$..*[?(@.id=='2020-03-c-02-03')].answer.entry", "$..*[?(@.id=='2020-03-c-02-01')].answer.entry"], "actions": ["percentage"]}
                     ],
                     [
-                      {"contents": "Denied for eligibility reasons"},
+                      {"contents": "Denials for other reasons"},
                       {"targets": ["$..*[?(@.id=='2020-03-c-02-04')].answer.entry"]},
                       {"targets": ["$..*[?(@.id=='2020-03-c-02-04')].answer.entry", "$..*[?(@.id=='2020-03-c-02-01')].answer.entry"], "actions": ["percentage"]}
                     ]

--- a/docs/section-schemas/backend-json-section-3.json
+++ b/docs/section-schemas/backend-json-section-3.json
@@ -709,18 +709,1658 @@
                 "questions": []
               }
             ]
+          },
+
+          {
+            "id": "2020-03-c-04",
+            "type": "part",
+            "title": "Tracking a CHIP cohort over 18 months",
+            "text": "Tracking a cohort of children enrolled in CHIP (Title XXI) will measure how long a specific group stays enrolled over a 18-month period. This information is required by Section 402(a) of CHIPRA.\n\nTo track your cohort, identify a group of children ages 0 to 17 years who are newly enrolled in CHIP (Medicaid Expansion CHIP, Separate CHIP, or both) as of the first three months (Jan-Mar) of the last federal fiscal year.\n\nChildren must be 16.5 years or younger when they enroll to ensure they don’t age out of the program by the end of the 18-month tracking period.\n\nIf your eligibility system doesn’t have the ability to track a cohort, you may need to use a unique identifier or flag to track each child over the 18-month period.",
+            "questions": [
+              {
+                "type": "fieldset",
+                "label": "January – March 2019 (start of the cohort)",
+                "questions": [
+                  {
+                    "comment": "The “sum” question, that they answer if they don't have the breakdowns, can't really be a true top-level question, because then we couldn't hide it in the case where the breakdown data is available. So it has to be a subquestion, meaning that the top-level question isn't real and can't actually be answered. This introduces the need for the special fieldset used here; see the schema docs for more details.",
+                    "type": "fieldset",
+                    "fieldset_type": "marked",
+                    "label": "How many children were newly enrolled in CHIP between January and March of the last federal fiscal year?",
+                    "hint": "Only include children that weren’t enrolled in CHIP the previous month. (For example: Children who enrolled in January 2020 are “newly enrolled” if they weren’t enrolled in the CHIP in December 2019.)",
+                    "fieldset_info": {
+                      "id": "2020-03-c-04-01"
+                    },
+                    "questions": [
+                      {
+                        "comment": "Yes, this is a marked fieldset, i.e. a fieldset mainly pretending to be a question for the purposes of the list markers, immediately followed by an unmarked_descendants fieldset used so that the age range breakdown question gets to pretend to not be a question for the purposes of the list markers.",
+                        "type": "fieldset",
+                        "fieldset_type": "unmarked_descendants",
+                        "questions": [
+                          {
+                            "id": "2020-03-c-04-01-unmarked_descendants",
+                            "label": "I don’t have data for the individual age groups. I’ll report data for the total number for all age groups (0-18 years) instead.",
+                            "type": "checkbox_flag",
+                            "answer": {
+                              "options": {
+                                "type": "boolean"
+                              },
+                              "entry": null
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "comment": "This is the first real question so far in this part…",
+                        "type": "question",
+                        "id": "2020-03-c-04-01-a",
+                        "label": "Total for all ages",
+                        "type": "integer",
+                        "answer": {
+                          "entry": null
+                        },
+                        "context_data": {
+                          "skip_text": "1a omitted because you indicated that you have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  false,
+                                  null
+                                ],
+                                "noninteractive": [
+                                  false,
+                                  null
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "fieldset",
+                        "context_data": {
+                          "skip_text": "1b–1e omitted because you indicated that you don't have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  true
+                                ],
+                                "noninteractive": [
+                                  true
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-01-b",
+                            "label": "0–1 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-01-c",
+                            "label": "1–5 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-01-d",
+                            "label": "6–12 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-01-e",
+                            "label": "13–18 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+
+              {
+                "type": "fieldset",
+                "label": "July – September 2019 (6 months later)",
+                "questions": [
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "marked",
+                    "label": "How many children were still continuously enrolled in CHIP six months later?",
+                    "hint": "Only include children that didn’t have a break in coverage during the six-month period.",
+                    "fieldset_info": {
+                      "id": "2020-03-c-04-02"
+                    },
+                    "questions": [
+                      {
+                        "type": "question",
+                        "id": "2020-03-c-04-02-a",
+                        "label": "Total for all ages",
+                        "type": "integer",
+                        "answer": {
+                          "entry": null
+                        },
+                        "context_data": {
+                          "skip_text": "2a omitted because you indicated that you have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  false,
+                                  null
+                                ],
+                                "noninteractive": [
+                                  false,
+                                  null
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "fieldset",
+                        "context_data": {
+                          "skip_text": "2b–2e omitted because you indicated that don't you have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  true
+                                ],
+                                "noninteractive": [
+                                  true
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-02-b",
+                            "label": "0–1 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-02-c",
+                            "label": "1–5 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-02-d",
+                            "label": "6–12 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-02-e",
+                            "label": "13–18 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "marked",
+                    "label": "How many children had a break in CHIP coverage but were re-enrolled in CHIP six months later?",
+                    "fieldset_info": {
+                      "id": "2020-03-c-04-03"
+                    },
+                    "questions": [
+                      {
+                        "type": "question",
+                        "id": "2020-03-c-04-03-a",
+                        "label": "Total for all ages",
+                        "type": "integer",
+                        "answer": {
+                          "entry": null
+                        },
+                        "context_data": {
+                          "skip_text": "3a omitted because you indicated that you have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  false,
+                                  null
+                                ],
+                                "noninteractive": [
+                                  false,
+                                  null
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "fieldset",
+                        "context_data": {
+                          "skip_text": "3b–3e omitted because you indicated that you don't have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  true
+                                ],
+                                "noninteractive": [
+                                  true
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-03-b",
+                            "label": "0–1 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-03-c",
+                            "label": "1–5 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-03-d",
+                            "label": "6–12 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-03-e",
+                            "label": "13–18 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "fieldset_type": "marked",
+                            "label": "How many children had a break in CHIP coverage but were re-enrolled in Medicaid six months later?",
+                            "fieldset_info": {
+                              "id": "2020-03-c-04-03-f"
+                            },
+                            "questions": [
+                              {
+                                "type": "question",
+                                "id": "2020-03-c-04-03-f-01",
+                                "label": "Total for all ages",
+                                "type": "integer",
+                                "answer": {
+                                  "entry": null
+                                },
+                                "context_data": {
+                                  "skip_text": "3f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                  "conditional_display": {
+                                    "type": "conditional_display",
+                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                    "hide_if": {
+                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                      "values": {
+                                        "interactive": [
+                                          false,
+                                          null
+                                        ],
+                                        "noninteractive": [
+                                          false,
+                                          null
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "type": "fieldset",
+                                "context_data": {
+                                  "skip_text": "3f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
+                                  "conditional_display": {
+                                    "type": "conditional_display",
+                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                    "hide_if": {
+                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                      "values": {
+                                        "interactive": [
+                                          true
+                                        ],
+                                        "noninteractive": [
+                                          true
+                                        ]
+                                      }
+                                    }
+                                  }
+                                },
+                                "questions": [
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-03-f-02",
+                                    "label": "0–1 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-03-f-03",
+                                    "label": "1–5 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-03-f-04",
+                                    "label": "6–12 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-03-f-05",
+                                    "label": "13–18 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "marked",
+                    "label": "How many children were no longer enrolled in CHIP at the end of the six-month period?",
+                    "hint": "Possible reasons for disenrollment:\n•  Transferred to another health insurance program other than CHIP.\n•  Didn’t meet eligibility criteria anymore.\n•  Didn’t complete documentation.\n•  Didn’t pay a premium or enrollment fee.",
+                    "fieldset_info": {
+                      "id": "2020-03-c-04-04"
+                    },
+                    "questions": [
+                      {
+                        "type": "question",
+                        "id": "2020-03-c-04-04-a",
+                        "label": "Total for all ages",
+                        "type": "integer",
+                        "answer": {
+                          "entry": null
+                        },
+                        "context_data": {
+                          "skip_text": "4a omitted because you indicated that you have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  false,
+                                  null
+                                ],
+                                "noninteractive": [
+                                  false,
+                                  null
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "fieldset",
+                        "context_data": {
+                          "skip_text": "4b–4e omitted because you indicated that you don't have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  true
+                                ],
+                                "noninteractive": [
+                                  true
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-04-b",
+                            "label": "0–1 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-04-c",
+                            "label": "1–5 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-04-d",
+                            "label": "6–12 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-04-e",
+                            "label": "13–18 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "fieldset_type": "marked",
+                            "label": "How many children were no longer enrolled in CHIP but enrolled in Medicaid six months later?",
+                            "fieldset_info": {
+                              "id": "2020-03-c-04-04-f"
+                            },
+                            "questions": [
+                              {
+                                "type": "question",
+                                "id": "2020-03-c-04-04-f-01",
+                                "label": "Total for all ages",
+                                "type": "integer",
+                                "answer": {
+                                  "entry": null
+                                },
+                                "context_data": {
+                                  "skip_text": "4f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                  "conditional_display": {
+                                    "type": "conditional_display",
+                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                    "hide_if": {
+                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                      "values": {
+                                        "interactive": [
+                                          false,
+                                          null
+                                        ],
+                                        "noninteractive": [
+                                          false,
+                                          null
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "type": "fieldset",
+                                "context_data": {
+                                  "skip_text": "4f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
+                                  "conditional_display": {
+                                    "type": "conditional_display",
+                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                    "hide_if": {
+                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                      "values": {
+                                        "interactive": [
+                                          true
+                                        ],
+                                        "noninteractive": [
+                                          true
+                                        ]
+                                      }
+                                    }
+                                  }
+                                },
+                                "questions": [
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-04-f-02",
+                                    "label": "0–1 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-04-f-03",
+                                    "label": "1–5 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-04-f-04",
+                                    "label": "6–12 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-04-f-05",
+                                    "label": "13–18 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-03-c-04-05",
+                    "label": "Anything else you’d like to add about your data?",
+                    "type": "text_multiline",
+                    "answer": {
+                        "entry": null
+                    }
+                  }
+                ]
+              },
+
+
+
+              {
+                "type": "fieldset",
+                "label": "January – March 2020 (12 months later)",
+                "hint": "Next year you’ll submit the rest of your data at 12 months and 18 months later of tracking your cohort",
+                "questions": [
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "marked",
+                    "label": "How many children were still continuously enrolled in CHIP 12 months later?",
+                    "hint": "Only include children that didn’t have a break in coverage during the 12-month period.",
+                    "fieldset_info": {
+                      "id": "2020-03-c-04-06"
+                    },
+                    "questions": [
+                      {
+                        "type": "question",
+                        "id": "2020-03-c-04-06-a",
+                        "label": "Total for all ages",
+                        "type": "integer",
+                        "answer": {
+                          "entry": null
+                        },
+                        "context_data": {
+                          "skip_text": "6a omitted because you indicated that you have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  false,
+                                  null
+                                ],
+                                "noninteractive": [
+                                  false,
+                                  null
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "fieldset",
+                        "context_data": {
+                          "skip_text": "6b–6e omitted because you indicated that don't you have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  true
+                                ],
+                                "noninteractive": [
+                                  true
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-06-b",
+                            "label": "0–1 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-06-c",
+                            "label": "1–5 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-06-d",
+                            "label": "6–12 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-06-e",
+                            "label": "13–18 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "marked",
+                    "label": "How many children had a break in CHIP coverage but were re-enrolled in CHIP 12 months later?",
+                    "fieldset_info": {
+                      "id": "2020-03-c-04-07"
+                    },
+                    "questions": [
+                      {
+                        "type": "question",
+                        "id": "2020-03-c-04-07-a",
+                        "label": "Total for all ages",
+                        "type": "integer",
+                        "answer": {
+                          "entry": null
+                        },
+                        "context_data": {
+                          "skip_text": "7a omitted because you indicated that you have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  false,
+                                  null
+                                ],
+                                "noninteractive": [
+                                  false,
+                                  null
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "fieldset",
+                        "context_data": {
+                          "skip_text": "7b–7e omitted because you indicated that you don't have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  true
+                                ],
+                                "noninteractive": [
+                                  true
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-07-b",
+                            "label": "0–1 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-07-c",
+                            "label": "1–5 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-07-d",
+                            "label": "6–12 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-07-e",
+                            "label": "13–18 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "fieldset_type": "marked",
+                            "label": "How many children had a break in CHIP coverage but were re-enrolled in Medicaid 12 months later?",
+                            "fieldset_info": {
+                              "id": "2020-03-c-04-07-f"
+                            },
+                            "questions": [
+                              {
+                                "type": "question",
+                                "id": "2020-03-c-04-07-f-01",
+                                "label": "Total for all ages",
+                                "type": "integer",
+                                "answer": {
+                                  "entry": null
+                                },
+                                "context_data": {
+                                  "skip_text": "7f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                  "conditional_display": {
+                                    "type": "conditional_display",
+                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                    "hide_if": {
+                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                      "values": {
+                                        "interactive": [
+                                          false,
+                                          null
+                                        ],
+                                        "noninteractive": [
+                                          false,
+                                          null
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "type": "fieldset",
+                                "context_data": {
+                                  "skip_text": "7f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
+                                  "conditional_display": {
+                                    "type": "conditional_display",
+                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                    "hide_if": {
+                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                      "values": {
+                                        "interactive": [
+                                          true
+                                        ],
+                                        "noninteractive": [
+                                          true
+                                        ]
+                                      }
+                                    }
+                                  }
+                                },
+                                "questions": [
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-07-f-02",
+                                    "label": "0–1 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-07-f-03",
+                                    "label": "1–5 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-07-f-04",
+                                    "label": "6–12 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-07-f-05",
+                                    "label": "13–18 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "marked",
+                    "label": "How many children were no longer enrolled in CHIP at the end of the 12-month period?",
+                    "hint": "Possible reasons for disenrollment:\n•  Transferred to another health insurance program other than CHIP.\n•  Didn’t meet eligibility criteria anymore.\n•  Didn’t complete documentation.\n•  Didn’t pay a premium or enrollment fee.",
+                    "fieldset_info": {
+                      "id": "2020-03-c-04-08"
+                    },
+                    "questions": [
+                      {
+                        "type": "question",
+                        "id": "2020-03-c-04-08-a",
+                        "label": "Total for all ages",
+                        "type": "integer",
+                        "answer": {
+                          "entry": null
+                        },
+                        "context_data": {
+                          "skip_text": "4a omitted because you indicated that you have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  false,
+                                  null
+                                ],
+                                "noninteractive": [
+                                  false,
+                                  null
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "fieldset",
+                        "context_data": {
+                          "skip_text": "4b–4e omitted because you indicated that you don't have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  true
+                                ],
+                                "noninteractive": [
+                                  true
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-08-b",
+                            "label": "0–1 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-08-c",
+                            "label": "1–5 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-08-d",
+                            "label": "6–12 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-08-e",
+                            "label": "13–18 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "fieldset_type": "marked",
+                            "label": "How many children were no longer enrolled in CHIP at the end of the 12-month period, and enrolled in Medicaid instead?",
+                            "fieldset_info": {
+                              "id": "2020-03-c-04-08-f"
+                            },
+                            "questions": [
+                              {
+                                "type": "question",
+                                "id": "2020-03-c-04-08-f-01",
+                                "label": "Total for all ages",
+                                "type": "integer",
+                                "answer": {
+                                  "entry": null
+                                },
+                                "context_data": {
+                                  "skip_text": "4f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                  "conditional_display": {
+                                    "type": "conditional_display",
+                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                    "hide_if": {
+                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                      "values": {
+                                        "interactive": [
+                                          false,
+                                          null
+                                        ],
+                                        "noninteractive": [
+                                          false,
+                                          null
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "type": "fieldset",
+                                "context_data": {
+                                  "skip_text": "4f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
+                                  "conditional_display": {
+                                    "type": "conditional_display",
+                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                    "hide_if": {
+                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                      "values": {
+                                        "interactive": [
+                                          true
+                                        ],
+                                        "noninteractive": [
+                                          true
+                                        ]
+                                      }
+                                    }
+                                  }
+                                },
+                                "questions": [
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-08-f-02",
+                                    "label": "0–1 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-08-f-03",
+                                    "label": "1–5 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-08-f-04",
+                                    "label": "6–12 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-08-f-05",
+                                    "label": "13–18 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+
+
+              {
+                "type": "fieldset",
+                "label": "July – September 2020 (18 months later)",
+                "questions": [
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "marked",
+                    "label": "How many children were still continuously enrolled in CHIP 18 months later?",
+                    "hint": "Only include children that didn’t have a break in coverage during the 18-month period.",
+                    "fieldset_info": {
+                      "id": "2020-03-c-04-09"
+                    },
+                    "questions": [
+                      {
+                        "type": "question",
+                        "id": "2020-03-c-04-09-a",
+                        "label": "Total for all ages",
+                        "type": "integer",
+                        "answer": {
+                          "entry": null
+                        },
+                        "context_data": {
+                          "skip_text": "6a omitted because you indicated that you have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  false,
+                                  null
+                                ],
+                                "noninteractive": [
+                                  false,
+                                  null
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "fieldset",
+                        "context_data": {
+                          "skip_text": "6b–6e omitted because you indicated that don't you have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  true
+                                ],
+                                "noninteractive": [
+                                  true
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-09-b",
+                            "label": "0–1 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-09-c",
+                            "label": "1–5 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-09-d",
+                            "label": "6–12 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-09-e",
+                            "label": "13–18 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "marked",
+                    "label": "How many children had a break in CHIP coverage but were re-enrolled in CHIP 18 months later?",
+                    "fieldset_info": {
+                      "id": "2020-03-c-04-10"
+                    },
+                    "questions": [
+                      {
+                        "type": "question",
+                        "id": "2020-03-c-04-10-a",
+                        "label": "Total for all ages",
+                        "type": "integer",
+                        "answer": {
+                          "entry": null
+                        },
+                        "context_data": {
+                          "skip_text": "7a omitted because you indicated that you have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  false,
+                                  null
+                                ],
+                                "noninteractive": [
+                                  false,
+                                  null
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "fieldset",
+                        "context_data": {
+                          "skip_text": "7b–7e omitted because you indicated that you don't have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  true
+                                ],
+                                "noninteractive": [
+                                  true
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-10-b",
+                            "label": "0–1 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-10-c",
+                            "label": "1–5 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-10-d",
+                            "label": "6–12 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-10-e",
+                            "label": "13–18 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "fieldset_type": "marked",
+                            "label": "How many children had a break in CHIP coverage but were re-enrolled in Medicaid 18 months later?",
+                            "fieldset_info": {
+                              "id": "2020-03-c-04-10-f"
+                            },
+                            "questions": [
+                              {
+                                "type": "question",
+                                "id": "2020-03-c-04-10-f-01",
+                                "label": "Total for all ages",
+                                "type": "integer",
+                                "answer": {
+                                  "entry": null
+                                },
+                                "context_data": {
+                                  "skip_text": "7f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                  "conditional_display": {
+                                    "type": "conditional_display",
+                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                    "hide_if": {
+                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                      "values": {
+                                        "interactive": [
+                                          false,
+                                          null
+                                        ],
+                                        "noninteractive": [
+                                          false,
+                                          null
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "type": "fieldset",
+                                "context_data": {
+                                  "skip_text": "7f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
+                                  "conditional_display": {
+                                    "type": "conditional_display",
+                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                    "hide_if": {
+                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                      "values": {
+                                        "interactive": [
+                                          true
+                                        ],
+                                        "noninteractive": [
+                                          true
+                                        ]
+                                      }
+                                    }
+                                  }
+                                },
+                                "questions": [
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-10-f-02",
+                                    "label": "0–1 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-10-f-03",
+                                    "label": "1–5 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-10-f-04",
+                                    "label": "6–12 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-10-f-05",
+                                    "label": "13–18 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "marked",
+                    "label": "How many children were no longer enrolled in CHIP at the end of the 18-month period?",
+                    "hint": "Possible reasons for disenrollment:\n•  Transferred to another health insurance program other than CHIP.\n•  Didn’t meet eligibility criteria anymore.\n•  Didn’t complete documentation.\n•  Didn’t pay a premium or enrollment fee.",
+                    "fieldset_info": {
+                      "id": "2020-03-c-04-11"
+                    },
+                    "questions": [
+                      {
+                        "type": "question",
+                        "id": "2020-03-c-04-11-a",
+                        "label": "Total for all ages",
+                        "type": "integer",
+                        "answer": {
+                          "entry": null
+                        },
+                        "context_data": {
+                          "skip_text": "4a omitted because you indicated that you have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  false,
+                                  null
+                                ],
+                                "noninteractive": [
+                                  false,
+                                  null
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "fieldset",
+                        "context_data": {
+                          "skip_text": "4b–4e omitted because you indicated that you don't have the age range breakdown data available.",
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  true
+                                ],
+                                "noninteractive": [
+                                  true
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-11-b",
+                            "label": "0–1 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-11-c",
+                            "label": "1–5 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-11-d",
+                            "label": "6–12 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-11-e",
+                            "label": "13–18 year olds",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "fieldset_type": "marked",
+                            "label": "How many children were no longer enrolled in CHIP at the end of the 12-month period, and enrolled in Medicaid instead?",
+                            "fieldset_info": {
+                              "id": "2020-03-c-04-11-f"
+                            },
+                            "questions": [
+                              {
+                                "type": "question",
+                                "id": "2020-03-c-04-11-f-01",
+                                "label": "Total for all ages",
+                                "type": "integer",
+                                "answer": {
+                                  "entry": null
+                                },
+                                "context_data": {
+                                  "skip_text": "4f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                  "conditional_display": {
+                                    "type": "conditional_display",
+                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                    "hide_if": {
+                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                      "values": {
+                                        "interactive": [
+                                          false,
+                                          null
+                                        ],
+                                        "noninteractive": [
+                                          false,
+                                          null
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "type": "fieldset",
+                                "context_data": {
+                                  "skip_text": "4f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
+                                  "conditional_display": {
+                                    "type": "conditional_display",
+                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                    "hide_if": {
+                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                      "values": {
+                                        "interactive": [
+                                          true
+                                        ],
+                                        "noninteractive": [
+                                          true
+                                        ]
+                                      }
+                                    }
+                                  }
+                                },
+                                "questions": [
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-11-f-02",
+                                    "label": "0–1 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-11-f-03",
+                                    "label": "1–5 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-11-f-04",
+                                    "label": "6–12 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  },
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-11-f-05",
+                                    "label": "13–18 year olds",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+
+
+
+
+            ]
           }
+
 
         ]
       },
-
-
-
-
-
-
-
-
 
       {
         "id": "2020-03-d",

--- a/docs/section-schemas/backend-json-structure-documentation.rst
+++ b/docs/section-schemas/backend-json-structure-documentation.rst
@@ -771,6 +771,16 @@ This would produce something like:
 
     How does this table make you feel?
 
+``unmarked``
+############
+This fieldset contains questions that aren't really being collected and are purely ways of letting users indicate that they do not have the ability to answer certain questions—for example, in the infamous Section 3C, Part 4 has a checkbox that lets the user indicate whether or not they only have totals for the following questions, or whether they have breakdowns\ [#]_. Since the following answers will make clear what data they have available, the state of the checkbox isn't really part of the collected data. It'll still be recorded, but will be marked as distinct.
+
+The main implications of this are that questions in an ``unmarked`` fieldset (or any questions that are descendants of an ``unmarked`` fieldset) do not have list markers, and their ids do not follow the structure of other ids.
+
+The values for the ``id`` properties of the questions that are descendants of an ``unmarked`` fieldset should be the same as the question immediately preceding them, but with ``-unmarked`` appended. For example, in Section 3C Part 4, the aforementioned checkbox comes right after question ``2020-03-c-04-01``. I would therefore give its ``id`` property a value of ``2020-03-c-04-01-unmarked``. If there were multiple ``unmarked`` questions for some reason, I would increment them as if they were real questions—but ``-unmarked`` would still need to be appended to their ``id`` values.
+
+.. [#]  Data broken down into age cohorts, not the other kind of breakdown associated with exposure to that section.
+
 ``text_multiline``
 ++++++++++++++++++
 A long string. As this will probably be represented by the ``TEXT`` type in Postgres, its max length should be longer than anything we will realistically encounter. Its ``entry`` value should be represented as a string. It has optional properties:

--- a/docs/section-schemas/backend-json-structure-documentation.rst
+++ b/docs/section-schemas/backend-json-structure-documentation.rst
@@ -455,6 +455,12 @@ Special ``fieldset`` types
 **************************
 Special ``fieldset`` types that don't necessarily contain questions. They must still have a ``questions`` field because these uses are outliers and it makes more sense to require the field for the vast majority of uses that do contain questions.
 
+``marked``
+##########
+Thanks to Section 3C, we need a ``fieldset`` type that *does* have an ``id`` property, and *does* act as if it were a real question and thus the questions it contains are marked as subquestions. So that's what this is for. Essentially, it's a ``question`` that can't actually accept answers; all the other parts of a question component except the actual input element.
+
+Other ``fieldset`` instances nested below it do not inherit its ``marked`` nature.
+
 ``synthesized_value``
 #####################
 Get values from elsewhere, defined in the ``targets`` property, perform some action(s) upon them, defined in the ``actions`` property, and display the result.

--- a/docs/section-schemas/backend-json-structure-documentation.rst
+++ b/docs/section-schemas/backend-json-structure-documentation.rst
@@ -459,6 +459,8 @@ Special ``fieldset`` types that don't necessarily contain questions. They must s
 ##########
 Thanks to Section 3C, we need a ``fieldset`` type that *does* have an ``id`` property, and *does* act as if it were a real question and thus the questions it contains are marked as subquestions. So that's what this is for. Essentially, it's a ``question`` that can't actually accept answers; all the other parts of a question component except the actual input element.
 
+Because ``fieldset`` can't have an ``id`` property, we have to store the ``id`` for these in the ``fieldset_info`` object, which may be annoying at implementation time. However, this kind of ``fieldset`` will require custom handling anyway, and adding that wrinkle will hopefully not be too difficult.
+
 Other ``fieldset`` instances nested below it do not inherit its ``marked`` nature.
 
 ``synthesized_value``

--- a/docs/section-schemas/backend-json-structure-documentation.rst
+++ b/docs/section-schemas/backend-json-structure-documentation.rst
@@ -847,6 +847,11 @@ A set of choices, multiples of which can be chosen. Its ``entry`` value should b
             "Sleeping": "sleeping"
         }
 
+
+``checkbox_flag``
++++++++++++++++++
+A single checkbox; if checked, its value is ``True``, otherwise it's ``null`` or ``False``. Its ``answer.options`` property object should always have a ``type`` of ``boolean``,
+
 ``money``
 +++++++++
 A short string that can represent an integer or a float. Constrained to two decimal places.

--- a/docs/section-schemas/backend-json-structure-documentation.rst
+++ b/docs/section-schemas/backend-json-structure-documentation.rst
@@ -771,13 +771,14 @@ This would produce something like:
 
     How does this table make you feel?
 
-``unmarked``
-############
+``unmarked_descendants``
+########################
+
 This fieldset contains questions that aren't really being collected and are purely ways of letting users indicate that they do not have the ability to answer certain questions—for example, in the infamous Section 3C, Part 4 has a checkbox that lets the user indicate whether or not they only have totals for the following questions, or whether they have breakdowns\ [#]_. Since the following answers will make clear what data they have available, the state of the checkbox isn't really part of the collected data. It'll still be recorded, but will be marked as distinct.
 
-The main implications of this are that questions in an ``unmarked`` fieldset (or any questions that are descendants of an ``unmarked`` fieldset) do not have list markers, and their ids do not follow the structure of other ids.
+The main implications of this are that questions in an ``unmarked_descendants`` fieldset (or any questions that are descendants of an ``unmarked_descendants`` fieldset) do not have list markers, and their ids do not follow the structure of other ids.
 
-The values for the ``id`` properties of the questions that are descendants of an ``unmarked`` fieldset should be the same as the question immediately preceding them, but with ``-unmarked`` appended. For example, in Section 3C Part 4, the aforementioned checkbox comes right after question ``2020-03-c-04-01``. I would therefore give its ``id`` property a value of ``2020-03-c-04-01-unmarked``. If there were multiple ``unmarked`` questions for some reason, I would increment them as if they were real questions—but ``-unmarked`` would still need to be appended to their ``id`` values.
+The values for the ``id`` properties of the questions that are descendants of an ``unmarked_descendants`` fieldset should be the same as the question immediately preceding them, but with ``-unmarked_descendants`` appended. For example, in Section 3C Part 4, the aforementioned checkbox comes right after question ``2020-03-c-04-01``. I would therefore give its ``id`` property a value of ``2020-03-c-04-01-unmarked_descendants``. If there were multiple ``unmarked_descendants`` questions for some reason, I would increment them as if they were real questions—but ``-unmarked_descendants`` would still need to be appended to their ``id`` values.
 
 .. [#]  Data broken down into age cohorts, not the other kind of breakdown associated with exposure to that section.
 

--- a/docs/section-schemas/backend-json-structure-documentation.rst
+++ b/docs/section-schemas/backend-json-structure-documentation.rst
@@ -455,6 +455,10 @@ Special ``fieldset`` types
 **************************
 Special ``fieldset`` types that don't necessarily contain questions. They must still have a ``questions`` field because these uses are outliers and it makes more sense to require the field for the vast majority of uses that do contain questions.
 
+``datagrid``
+############
+The child questions of a ``datagrid`` ``fieldset`` should be grouped together and presented as a table, possibly without showing their question markers. Currently the only design for this (in, of course, Section 3C) has four questions presented as a single row. As a result, the ``fieldset_info`` details are still undetermined, and will probably change during Section 3C development.
+
 ``marked``
 ##########
 Thanks to Section 3C, we need a ``fieldset`` type that *does* have an ``id`` property, and *does* act as if it were a real question and thus the questions it contains are marked as subquestions. So that's what this is for. Essentially, it's a ``question`` that can't actually accept answers; all the other parts of a question component except the actual input element.

--- a/docs/section-schemas/backend-section.schema.json
+++ b/docs/section-schemas/backend-section.schema.json
@@ -406,6 +406,9 @@
         "type": {
           "const": "fieldset"
         },
+        "comment": {
+          "type": "string"
+        },
         "label": {
           "type": "string"
         },

--- a/docs/section-schemas/backend-section.schema.json
+++ b/docs/section-schemas/backend-section.schema.json
@@ -417,6 +417,7 @@
         },
         "fieldset_type": {
           "enum": [
+            "marked",
             "noninteractive_table",
             "sum",
             "synthesized_table",

--- a/docs/section-schemas/backend-section.schema.json
+++ b/docs/section-schemas/backend-section.schema.json
@@ -418,6 +418,7 @@
         },
         "fieldset_type": {
           "enum": [
+            "datagrid",
             "marked",
             "noninteractive_table",
             "sum",

--- a/docs/section-schemas/backend-section.schema.json
+++ b/docs/section-schemas/backend-section.schema.json
@@ -414,10 +414,10 @@
         },
         "fieldset_type": {
           "enum": [
-            "percentage",
+            "noninteractive_table",
             "sum",
             "synthesized_table",
-            "noninteractive_table"
+            "synthesized_value"
           ]
         },
         "fieldset_info": {

--- a/docs/section-schemas/backend-section.schema.json
+++ b/docs/section-schemas/backend-section.schema.json
@@ -421,7 +421,7 @@
             "sum",
             "synthesized_table",
             "synthesized_value",
-            "unmarked"
+            "unmarked_descendants"
           ]
         },
         "fieldset_info": {

--- a/docs/section-schemas/backend-section.schema.json
+++ b/docs/section-schemas/backend-section.schema.json
@@ -488,6 +488,9 @@
                       },
                       {
                         "type": "string"
+                      },
+                      {
+                        "type": "boolean"
                       }
                     ]
                   }
@@ -504,6 +507,9 @@
                       },
                       {
                         "type": "string"
+                      },
+                      {
+                        "type": "boolean"
                       }
                     ]
                   }

--- a/docs/section-schemas/backend-section.schema.json
+++ b/docs/section-schemas/backend-section.schema.json
@@ -420,7 +420,8 @@
             "noninteractive_table",
             "sum",
             "synthesized_table",
-            "synthesized_value"
+            "synthesized_value",
+            "unmarked"
           ]
         },
         "fieldset_info": {

--- a/docs/section-schemas/backend-section.schema.json
+++ b/docs/section-schemas/backend-section.schema.json
@@ -358,6 +358,7 @@
           "type": {
             "enum": [
               "checkbox",
+              "checkbox_flag",
               "daterange",
               "email",
               "file_upload",


### PR DESCRIPTION
Demote percentage—
It is now a mere action.
These docs are fluid.

Remove `percentage` as a `fieldset_type` option, instead make it an `action` for `synthesized_value` (and by extension `synthesized_table`). Add example showing its use.

This PR now encompasses a lot more, so:

### Section 3C

In Section 3C
Are the worst questions to code—
At least I hope so.

Add JSON for Section 3C, including along the way:

- Add `comment` property to `fieldset`.
- Add `unmarked_descendants` value for `fieldset_type`.
- Add `marked` value for `fieldset_type`.
- Add `checkbox_flag` question type.
- Add boolean type support in `conditional_display`.
- Add documentation for all of the above.