### PR TITLE
Introduce Security Automated Framework pattern.  starting with RDS scanning

### DIFF
--- a/.jenkins/Jenkinsfile.dev
+++ b/.jenkins/Jenkinsfile.dev
@@ -24,6 +24,7 @@ pipeline {
           def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
 
           jenkinsUtils.installAwsCli()
+          jenkinsUtils.installEcsCli()
           jenkinsUtils.installTerraform("0.12.24")
 
           if( env.BUILD_NUMBER == "1" ) {
@@ -162,6 +163,41 @@ pipeline {
               docker build . -t loaded_testcafe:${BRANCH_NAME} --build-arg application_endpoint=$APPLICATION_ENDPOINT
               docker run --rm --name ${BRANCH_NAME} -e APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT loaded_testcafe:${BRANCH_NAME} chromium /tests/**/*.js
             '''
+          }
+        }
+      }
+    }
+    stage("Run Inspec Scans") {
+      when {
+        expression { env.DEPLOY == "true"}
+      }
+      steps {
+        script {
+          def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
+          lock('docker_socket') {
+            jenkinsUtils.buildAndPushImageToEcr("saf/postgres_rds", "inspec_postgres_rds", [env.BUILD_TAG, env.JOB_BASE_NAME])
+          }
+          dir('saf/aws') {
+            jenkinsUtils.terraformApply(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "apply",
+              [
+                "application_version": env.BUILD_TAG,
+                "vpc_name": env.VPC_NAME
+              ]
+            )
+            jenkinsUtils.runInspecScan(
+              "postgres_rds",
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "inspec_postgres_rds_task_definition_arn"),
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "inspec_postgres_rds_cluster"),
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "inspec_postgres_rds_subnets"),
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "inspec_postgres_rds_security_group")
+            )
+          }
+        }
+      }
+      post {
+        always {
+          script {
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'saf/aws/inspec_scan_result_*'
           }
         }
       }

--- a/.jenkins/Jenkinsfile.master
+++ b/.jenkins/Jenkinsfile.master
@@ -17,6 +17,7 @@ pipeline {
           def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
 
           jenkinsUtils.installAwsCli()
+          jenkinsUtils.installEcsCli()
           jenkinsUtils.installTerraform("0.12.24")
 
           env.DEPLOY_DATA = jenkinsUtils.pathHasChanges("data") || jenkinsUtils.pathHasChanges(".jenkins")
@@ -29,15 +30,18 @@ pipeline {
         script {
           def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
           lock('docker_socket') {
-            jenkinsUtils.buildAndPushImageToEcr("data/postgres_deployer", "postgres_deployer", [env.BUILD_TAG, env.JOB_NAME])
-            jenkinsUtils.buildAndPushImageToEcr("frontend/api_postgres", "postgres_django", [env.BUILD_TAG, env.JOB_NAME])
-            jenkinsUtils.buildAndPushImageToEcr("frontend/api_sqlserver", "sqlserver_django", [env.BUILD_TAG, env.JOB_NAME])
-            jenkinsUtils.buildAndPushImageToEcr("frontend/react", "react", [env.BUILD_TAG, env.JOB_NAME])
+            jenkinsUtils.buildAndPushImageToEcr("data/postgres_deployer", "postgres_deployer", [env.BUILD_TAG, env.JOB_BASE_NAME])
+            jenkinsUtils.buildAndPushImageToEcr("frontend/api_postgres", "postgres_django", [env.BUILD_TAG, env.JOB_BASE_NAME])
+            jenkinsUtils.buildAndPushImageToEcr("frontend/api_sqlserver", "sqlserver_django", [env.BUILD_TAG, env.JOB_BASE_NAME])
+            jenkinsUtils.buildAndPushImageToEcr("frontend/react", "react", [env.BUILD_TAG, env.JOB_BASE_NAME])
           }
         }
       }
     }
     stage("Scan Images") {
+      when {
+        expression { env.SKIP_SCANS != "true" }
+      }
       steps {
         script {
           def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
@@ -63,7 +67,7 @@ pipeline {
         script {
           def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
           dir('data/aws') {
-            jenkinsUtils.terraformApply(env.APPLICATION_BUCKET, env.JOB_NAME, "apply",
+            jenkinsUtils.terraformApply(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "apply",
               [
                 "application_version": env.BUILD_TAG,
                 "vpc_name": env.VPC_NAME
@@ -88,7 +92,7 @@ pipeline {
         script {
           def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
           dir('frontend/aws') {
-            jenkinsUtils.terraformApply(env.APPLICATION_BUCKET, env.JOB_NAME, "apply",
+            jenkinsUtils.terraformApply(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "apply",
               [
                 "application_version": env.BUILD_TAG,
                 "vpc_name": env.VPC_NAME
@@ -110,14 +114,49 @@ pipeline {
         script {
           def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
           dir('frontend/aws') {
-            env.APPLICATION_ENDPOINT = jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_NAME, "application_endpoint")
+            env.APPLICATION_ENDPOINT = jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "application_endpoint")
           }
           dir('tests/testcafe') {
             sh '''
               set -e
-              docker build . -t loaded_testcafe:${JOB_NAME} --build-arg application_endpoint=$APPLICATION_ENDPOINT
-              docker run --rm --name ${JOB_NAME} -e APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT loaded_testcafe:${JOB_NAME} chromium /tests/**/*.js
+              docker build . -t loaded_testcafe:${JOB_BASE_NAME} --build-arg application_endpoint=$APPLICATION_ENDPOINT
+              docker run --rm --name ${JOB_BASE_NAME} -e APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT loaded_testcafe:${JOB_BASE_NAME} chromium /tests/**/*.js
             '''
+          }
+        }
+      }
+    }
+    stage("Run Inspec Scans") {
+      when {
+        expression { env.SKIP_SCANS != "true" }
+      }
+      steps {
+        script {
+          def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
+          lock('docker_socket') {
+            jenkinsUtils.buildAndPushImageToEcr("saf/postgres_rds", "inspec_postgres_rds", [env.BUILD_TAG, env.JOB_BASE_NAME])
+          }
+          dir('saf/aws') {
+            jenkinsUtils.terraformApply(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "apply",
+              [
+                "application_version": env.BUILD_TAG,
+                "vpc_name": env.VPC_NAME
+              ]
+            )
+            jenkinsUtils.runInspecScan(
+              "postgres_rds",
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "inspec_postgres_rds_task_definition_arn"),
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "inspec_postgres_rds_cluster"),
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "inspec_postgres_rds_subnets"),
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "inspec_postgres_rds_security_group")
+            )
+          }
+        }
+      }
+      post {
+        always {
+          script {
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'saf/aws/inspec_scan_result_*'
           }
         }
       }
@@ -133,8 +172,10 @@ pipeline {
             remote_url=`git config remote.origin.url | sed -e 's|^https://||'`
             git config user.name 'Jenkins'
             git config user.email 'jenkins@mycompany.com'
-            git tag $BUILD_TAG
+            git tag $BUILD_TAG -f
+            git tag master-tag -f
             git push -f https://$GIT_CREDENTIAL@$remote_url refs/tags/$BUILD_TAG
+            git push -f https://$GIT_CREDENTIAL@$remote_url refs/tags/master-tag
           '''
           if (env.DOWNSTREAM_JOB != "") {
             try {
@@ -153,14 +194,14 @@ pipeline {
     failure {
       script {
         if (env.SLACK_CREDENTIAL_NAME != null && env.SLACK_CHANNEL_NAME != null && env.SLACK_TEAM_DOMAIN_NAME != null ){
-          slackSend channel: env.SLACK_CHANNEL_NAME, teamDomain: env.SLACK_TEAM_DOMAIN_NAME, tokenCredentialId: env.SLACK_CREDENTIAL_NAME, color: 'danger', message: ":X: Failure.     <${env.BUILD_URL} |${JOB_NAME} #${env.BUILD_NUMBER}> has failed.  The build is broken."
+          slackSend channel: env.SLACK_CHANNEL_NAME, teamDomain: env.SLACK_TEAM_DOMAIN_NAME, tokenCredentialId: env.SLACK_CREDENTIAL_NAME, color: 'danger', message: ":X: Failure.     <${env.BUILD_URL} |${JOB_BASE_NAME} #${env.BUILD_NUMBER}> has failed.  The build is broken."
         }
       }
     }
     fixed {
       script {
         if (env.SLACK_CREDENTIAL_NAME != null && env.SLACK_CHANNEL_NAME != null && env.SLACK_TEAM_DOMAIN_NAME != null ){
-          slackSend channel: env.SLACK_CHANNEL_NAME, teamDomain: env.SLACK_TEAM_DOMAIN_NAME, tokenCredentialId: env.SLACK_CREDENTIAL_NAME, color: 'good', message: ":white_check_mark: Fixed.       <${env.BUILD_URL} |${JOB_NAME} #${env.BUILD_NUMBER}> succeeded.  The build is fixed."
+          slackSend channel: env.SLACK_CHANNEL_NAME, teamDomain: env.SLACK_TEAM_DOMAIN_NAME, tokenCredentialId: env.SLACK_CREDENTIAL_NAME, color: 'good', message: ":white_check_mark: Fixed.       <${env.BUILD_URL} |${JOB_BASE_NAME} #${env.BUILD_NUMBER}> succeeded.  The build is fixed."
         }
       }
     }

--- a/.jenkins/Jenkinsfile.prod
+++ b/.jenkins/Jenkinsfile.prod
@@ -22,10 +22,36 @@ pipeline {
           def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
 
           jenkinsUtils.installAwsCli()
+          jenkinsUtils.installEcsCli()
           jenkinsUtils.installTerraform("0.12.24")
 
           env.DEPLOY_DATA = jenkinsUtils.pathHasChanges("data") || jenkinsUtils.pathHasChanges(".jenkins")
           env.DEPLOY_FRONTEND = jenkinsUtils.pathHasChanges("frontend") || env.DEPLOY_DATA
+        }
+      }
+    }
+    stage("Scan Images") {
+      when {
+        expression { env.SKIP_SCANS != "true" }
+      }
+      steps {
+        script {
+          def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
+          jenkinsUtils.triggerEcrScan("postgres_deployer", env.VERSION)
+          jenkinsUtils.triggerEcrScan("api_postgres", env.VERSION)
+          jenkinsUtils.triggerEcrScan("api_sqlserver", env.VERSION)
+          jenkinsUtils.triggerEcrScan("react", env.VERSION)
+          jenkinsUtils.fetchEcrScanResult("postgres_deployer", env.VERSION)
+          jenkinsUtils.fetchEcrScanResult("api_postgres", env.VERSION)
+          jenkinsUtils.fetchEcrScanResult("api_sqlserver", env.VERSION)
+          jenkinsUtils.fetchEcrScanResult("react", env.VERSION)
+        }
+      }
+      post {
+        always {
+          script {
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'ecr_scan_*.json'
+          }
         }
       }
     }
@@ -37,7 +63,7 @@ pipeline {
         script {
           def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
           dir('data/aws') {
-            jenkinsUtils.terraformApply(env.APPLICATION_BUCKET, env.JOB_NAME, "apply",
+            jenkinsUtils.terraformApply(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "apply",
               [
                 "application_version": env.VERSION,
                 "vpc_name": env.VPC_NAME
@@ -62,7 +88,7 @@ pipeline {
         script {
           def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
           dir('frontend/aws') {
-            jenkinsUtils.terraformApply(env.APPLICATION_BUCKET, env.JOB_NAME, "apply",
+            jenkinsUtils.terraformApply(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "apply",
               [
                 "application_version": env.VERSION,
                 "vpc_name": env.VPC_NAME
@@ -87,14 +113,49 @@ pipeline {
         script {
           def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
           dir('frontend/aws') {
-            env.APPLICATION_ENDPOINT = jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_NAME, "application_endpoint")
+            env.APPLICATION_ENDPOINT = jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "application_endpoint")
           }
           dir('tests/testcafe') {
             sh '''
               set -e
-              docker build . -t loaded_testcafe:${JOB_NAME} --build-arg application_endpoint=$APPLICATION_ENDPOINT
-              docker run --rm --name ${JOB_NAME} -e APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT loaded_testcafe:${JOB_NAME} chromium /tests/**/*.js
+              docker build . -t loaded_testcafe:${JOB_BASE_NAME} --build-arg application_endpoint=$APPLICATION_ENDPOINT
+              docker run --rm --name ${JOB_BASE_NAME} -e APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT loaded_testcafe:${JOB_BASE_NAME} chromium /tests/**/*.js
             '''
+          }
+        }
+      }
+    }
+    stage("Run Inspec Scans") {
+      when {
+        expression { env.SKIP_SCANS != "true" }
+      }
+      steps {
+        script {
+          def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
+          lock('docker_socket') {
+            jenkinsUtils.buildAndPushImageToEcr("saf/postgres_rds", "inspec_postgres_rds", [env.BUILD_TAG, env.JOB_BASE_NAME])
+          }
+          dir('saf/aws') {
+            jenkinsUtils.terraformApply(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "apply",
+              [
+                "application_version": env.BUILD_TAG,
+                "vpc_name": env.VPC_NAME
+              ]
+            )
+            jenkinsUtils.runInspecScan(
+              "postgres_rds",
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "inspec_postgres_rds_task_definition_arn"),
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "inspec_postgres_rds_cluster"),
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "inspec_postgres_rds_subnets"),
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.JOB_BASE_NAME, "inspec_postgres_rds_security_group")
+            )
+          }
+        }
+      }
+      post {
+        always {
+          script {
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'saf/aws/inspec_scan_result_*'
           }
         }
       }
@@ -109,8 +170,8 @@ pipeline {
             remote_url=`git config remote.origin.url | sed -e 's|^https://||'`
             git config user.name 'Jenkins'
             git config user.email 'jenkins@mycompany.com'
-            git tag $JOB_NAME -f
-            git push https://$GIT_CREDENTIAL@$remote_url refs/tags/$JOB_NAME -f
+            git tag $JOB_BASE_NAME -f
+            git push https://$GIT_CREDENTIAL@$remote_url refs/tags/$JOB_BASE_NAME -f
           '''
           if (env.DOWNSTREAM_JOB) {
             try {
@@ -129,14 +190,14 @@ pipeline {
     failure {
       script {
         if (env.SLACK_CREDENTIAL_NAME != null && env.SLACK_CHANNEL_NAME != null && env.SLACK_TEAM_DOMAIN_NAME != null ){
-          slackSend channel: env.SLACK_CHANNEL_NAME, teamDomain: env.SLACK_TEAM_DOMAIN_NAME, tokenCredentialId: env.SLACK_CREDENTIAL_NAME, color: 'danger', message: ":X: Failure.     <${env.BUILD_URL} |${JOB_NAME} #${env.BUILD_NUMBER}> has failed.  The build is broken."
+          slackSend channel: env.SLACK_CHANNEL_NAME, teamDomain: env.SLACK_TEAM_DOMAIN_NAME, tokenCredentialId: env.SLACK_CREDENTIAL_NAME, color: 'danger', message: ":X: Failure.     <${env.BUILD_URL} |${JOB_BASE_NAME} #${env.BUILD_NUMBER}> has failed.  The build is broken."
         }
       }
     }
     fixed {
       script {
         if (env.SLACK_CREDENTIAL_NAME != null && env.SLACK_CHANNEL_NAME != null && env.SLACK_TEAM_DOMAIN_NAME != null ){
-          slackSend channel: env.SLACK_CHANNEL_NAME, teamDomain: env.SLACK_TEAM_DOMAIN_NAME, tokenCredentialId: env.SLACK_CREDENTIAL_NAME, color: 'good', message: ":white_check_mark: Fixed.       <${env.BUILD_URL} |${JOB_NAME} #${env.BUILD_NUMBER}> succeeded.  The build is fixed."
+          slackSend channel: env.SLACK_CHANNEL_NAME, teamDomain: env.SLACK_TEAM_DOMAIN_NAME, tokenCredentialId: env.SLACK_CREDENTIAL_NAME, color: 'good', message: ":white_check_mark: Fixed.       <${env.BUILD_URL} |${JOB_BASE_NAME} #${env.BUILD_NUMBER}> succeeded.  The build is fixed."
         }
       }
     }

--- a/.jenkins/Jenkinsfile.saf
+++ b/.jenkins/Jenkinsfile.saf
@@ -1,0 +1,87 @@
+pipeline {
+  agent { label "ec2-jnlp-slave" }
+  options {
+    disableConcurrentBuilds()
+    quietPeriod(0)
+    ansiColor('xterm')
+  }
+  environment {
+    BUILD_TAG = resolveBuildTag()
+  }
+  stages {
+    stage("Prep Agent") {
+      steps {
+        script {
+          currentBuild.displayName = env.ENVIRONMENT
+
+          def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
+
+          jenkinsUtils.installAwsCli()
+          jenkinsUtils.installEcsCli()
+          jenkinsUtils.installTerraform("0.12.24")
+        }
+      }
+    }
+    stage("Scan Images") {
+      steps {
+        script {
+          def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
+          jenkinsUtils.triggerEcrScan("postgres_deployer", env.BUILD_TAG)
+          jenkinsUtils.triggerEcrScan("api_postgres", env.BUILD_TAG)
+          jenkinsUtils.triggerEcrScan("api_sqlserver", env.BUILD_TAG)
+          jenkinsUtils.triggerEcrScan("react", env.BUILD_TAG)
+          jenkinsUtils.fetchEcrScanResult("postgres_deployer", env.BUILD_TAG)
+          jenkinsUtils.fetchEcrScanResult("api_postgres", env.BUILD_TAG)
+          jenkinsUtils.fetchEcrScanResult("api_sqlserver", env.BUILD_TAG)
+          jenkinsUtils.fetchEcrScanResult("react", env.BUILD_TAG)
+        }
+      }
+      post {
+        always {
+          script {
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'ecr_scan_*.json'
+          }
+        }
+      }
+    }
+    stage("Run Inspec Scans") {
+      steps {
+        script {
+          def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
+          lock('docker_socket') {
+            jenkinsUtils.buildAndPushImageToEcr("saf/postgres_rds", "inspec_postgres_rds", [env.BUILD_TAG, env.JOB_BASE_NAME])
+          }
+          dir('saf/aws') {
+            jenkinsUtils.terraformApply(env.APPLICATION_BUCKET, env.ENVIRONMENT, "apply",
+              [
+                "application_version": env.BUILD_TAG,
+                "vpc_name": env.VPC_NAME
+              ]
+            )
+            jenkinsUtils.runInspecScan(
+              "postgres_rds",
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.ENVIRONMENT, "inspec_postgres_rds_task_definition_arn"),
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.ENVIRONMENT, "inspec_postgres_rds_cluster"),
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.ENVIRONMENT, "inspec_postgres_rds_subnets"),
+              jenkinsUtils.terraformOutput(env.APPLICATION_BUCKET, env.ENVIRONMENT, "inspec_postgres_rds_security_group")
+            )
+          }
+        }
+      }
+      post {
+        always {
+          script {
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'saf/aws/inspec_scan_result_*'
+          }
+        }
+      }
+    }
+  }
+}
+
+def resolveBuildTag() {
+  tag_prefix = sh(script: 'cat versionPrefix', returnStdout: true).trim()
+  commit_count = sh(script: 'git rev-list --count $GIT_COMMIT', returnStdout: true).trim()
+  build_tag = "${tag_prefix}.${commit_count}"
+  return build_tag
+}

--- a/app/react/env-config.js
+++ b/app/react/env-config.js
@@ -1,4 +1,0 @@
-window._env_ = {
-  API_POSTGRES_URL: "https//default.dev.api_postgres.com",
-  API_SQLSERVER_URL: "https//default.dev.api_sqlserver.com",
-}

--- a/app/react/public/env-config.js
+++ b/app/react/public/env-config.js
@@ -1,4 +1,0 @@
-window._env_ = {
-  API_POSTGRES_URL: "https//default.dev.api_postgres.com",
-  API_SQLSERVER_URL: "https//default.dev.api_sqlserver.com",
-}

--- a/data/aws/vpc.tf
+++ b/data/aws/vpc.tf
@@ -9,6 +9,10 @@ data "aws_subnet_ids" "private" {
   tags = {
     Type = "private"
   }
+  filter {
+    name   = "tag:vpc-conf-layer"
+    values = ["data"]
+  }
 }
 
 data "aws_subnet_ids" "public" {

--- a/frontend/aws/vpc.tf
+++ b/frontend/aws/vpc.tf
@@ -9,6 +9,10 @@ data "aws_subnet_ids" "private" {
   tags = {
     Type = "private"
   }
+  filter {
+    name   = "tag:vpc-conf-layer"
+    values = ["app"]
+  }
 }
 
 data "aws_subnet_ids" "public" {

--- a/saf/aws/ecs_inspec_postgres_rds.tf
+++ b/saf/aws/ecs_inspec_postgres_rds.tf
@@ -1,0 +1,71 @@
+
+data "aws_ssm_parameter" "postgres_user" {
+  name = "/${terraform.workspace}/postgres_user"
+}
+
+data "aws_ssm_parameter" "postgres_password" {
+  name = "/${terraform.workspace}/postgres_password"
+}
+
+data "aws_ssm_parameter" "postgres_host" {
+  name = "/${terraform.workspace}/postgres_host"
+}
+
+data "aws_ssm_parameter" "postgres_db" {
+  name = "/${terraform.workspace}/postgres_db"
+}
+
+data "aws_ssm_parameter" "postgres_security_group" {
+  name = "/${terraform.workspace}/postgres_security_group"
+}
+
+
+####################################################################################################
+# Create an inspec_postgres_rds ECS Task Def to scan RDS
+####################################################################################################
+data "aws_ecr_repository" "inspec_postgres_rds" {
+  name = "inspec_postgres_rds"
+}
+
+resource "aws_ecs_task_definition" "inspec_postgres_rds" {
+  family                   = "inspec_postgres_rds-${terraform.workspace}"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 1024
+  memory                   = 4096
+  task_role_arn            = aws_iam_role.ecs_task.arn
+  execution_role_arn       = aws_iam_role.ecs_execution_role.arn
+  container_definitions = templatefile("templates/ecs_task_def_inspec_postgres_rds.json.tpl", {
+    image                    = "${data.aws_ecr_repository.inspec_postgres_rds.repository_url}:${var.application_version}",
+    postgres_host            = data.aws_ssm_parameter.postgres_host.value,
+    postgres_user            = data.aws_ssm_parameter.postgres_user.value,
+    postgres_password        = data.aws_ssm_parameter.postgres_password.value,
+    postgres_db              = data.aws_ssm_parameter.postgres_db.value,
+    cloudwatch_log_group     = aws_cloudwatch_log_group.saf.name,
+    cloudwatch_stream_prefix = "inspec_postgres_rds"
+  })
+}
+
+resource "aws_security_group" "inspec_postgres_rds" {
+  vpc_id = data.aws_vpc.app.id
+}
+
+resource "aws_security_group_rule" "inspec_postgres_rds_egress" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.inspec_postgres_rds.id
+}
+
+resource "aws_security_group_rule" "db_ingress" {
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.inspec_postgres_rds.id
+  security_group_id        = data.aws_ssm_parameter.postgres_security_group.value
+}
+
+####################################################################################################

--- a/saf/aws/ecs_shared.tf
+++ b/saf/aws/ecs_shared.tf
@@ -1,0 +1,40 @@
+
+####################################################################################################
+# Create some base IAM objects for ECS tasks and services, often shared
+####################################################################################################
+resource "aws_iam_role" "ecs_task" {
+  # The name parameter for this resource has a length limit and is not required.  We won't specify a name.
+  assume_role_policy = file("files/assume-role-policy-ecs-tasks.json")
+}
+
+resource "aws_iam_role" "ecs_execution_role" {
+  # The name parameter for this resource has a length limit and is not required.  We won't specify a name.
+  assume_role_policy = file("files/assume-role-policy-ecs-tasks.json")
+}
+
+resource "aws_iam_policy" "execution_policy" {
+  name   = "ecs_execution_policy_saf_${terraform.workspace}"
+  policy = file("files/ecs_execution_policy.json")
+}
+
+resource "aws_iam_role_policy_attachment" "execution" {
+  role       = aws_iam_role.ecs_execution_role.id
+  policy_arn = aws_iam_policy.execution_policy.arn
+}
+####################################################################################################
+
+####################################################################################################
+# Create an ECS Cluster for the saf layer, pretty much just containing the deployer container for now
+####################################################################################################
+resource "aws_ecs_cluster" "saf" {
+  name               = "saf-${terraform.workspace}"
+  capacity_providers = ["FARGATE"]
+}
+
+resource "aws_cloudwatch_log_group" "saf" {
+  name = "saf-${terraform.workspace}"
+  tags = {
+    Workspace = terraform.workspace
+  }
+}
+####################################################################################################

--- a/saf/aws/files/assume-role-policy-ecs-tasks.json
+++ b/saf/aws/files/assume-role-policy-ecs-tasks.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": [
+          "ecs-tasks.amazonaws.com"
+        ]
+      },
+      "Effect": "Allow"
+    }
+  ]
+}

--- a/saf/aws/files/ecs_execution_policy.json
+++ b/saf/aws/files/ecs_execution_policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/saf/aws/main.tf
+++ b/saf/aws/main.tf
@@ -1,0 +1,20 @@
+provider "aws" {
+  version = "2.58.0"
+  region  = "us-east-1"
+}
+
+terraform {
+  backend "s3" {
+    key     = "tf_state/application/saf"
+    region  = "us-east-1"
+    encrypt = true
+  }
+}
+
+provider "random" {
+  version = "2.2.0"
+}
+
+provider "null" {
+  version = "2.1.0"
+}

--- a/saf/aws/outputs.tf
+++ b/saf/aws/outputs.tf
@@ -1,0 +1,16 @@
+
+output "inspec_postgres_rds_cluster" {
+  value = aws_ecs_cluster.saf.name
+}
+
+output "inspec_postgres_rds_task_definition_arn" {
+  value = aws_ecs_task_definition.inspec_postgres_rds.arn
+}
+
+output "inspec_postgres_rds_subnets" {
+  value = join(", ", tolist(data.aws_subnet_ids.private.ids))
+}
+
+output "inspec_postgres_rds_security_group" {
+  value = aws_security_group.inspec_postgres_rds.id
+}

--- a/saf/aws/templates/ecs_task_def_inspec_postgres_rds.json.tpl
+++ b/saf/aws/templates/ecs_task_def_inspec_postgres_rds.json.tpl
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "inspec_postgres_rds",
+    "image": "${image}",
+    "essential": true,
+    "environment": [
+      {
+        "name": "POSTGRES_HOST",
+        "value": "${postgres_host}"
+      },
+      {
+        "name": "POSTGRES_USER",
+        "value": "${postgres_user}"
+      },
+      {
+        "name": "POSTGRES_PASSWORD",
+        "value": "${postgres_password}"
+      },
+      {
+        "name": "POSTGRES_DB",
+        "value": "${postgres_db}"
+      },
+      {
+        "name": "CHEF_LICENSE",
+        "value": "accept-no-persist"
+      }
+    ],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${cloudwatch_log_group}",
+            "awslogs-region": "us-east-1",
+            "awslogs-stream-prefix": "${cloudwatch_stream_prefix}"
+        }
+    }
+  }
+]

--- a/saf/aws/variables.tf
+++ b/saf/aws/variables.tf
@@ -1,0 +1,12 @@
+
+variable "application_version" {}
+
+variable "vpc_name" {}
+
+variable "postgres_user" {
+  default = "pguser"
+}
+
+variable "postgres_db" {
+  default = "postgres"
+}

--- a/saf/aws/vpc.tf
+++ b/saf/aws/vpc.tf
@@ -1,0 +1,19 @@
+data "aws_vpc" "app" {
+  tags = {
+    Name = var.vpc_name
+  }
+}
+
+data "aws_subnet_ids" "private" {
+  vpc_id = data.aws_vpc.app.id
+  tags = {
+    Type = "private"
+  }
+}
+
+data "aws_subnet_ids" "public" {
+  vpc_id = data.aws_vpc.app.id
+  tags = {
+    Type = "public"
+  }
+}

--- a/saf/postgres_rds/Dockerfile
+++ b/saf/postgres_rds/Dockerfile
@@ -1,0 +1,11 @@
+# ==============================================================================
+# => chef inspec image
+FROM chef/inspec as inspector
+
+RUN apk add --no-cache make gcc libc-dev postgresql-client gettext
+
+
+COPY entrypoint.sh overlay_attributes.yml ./
+
+
+ENTRYPOINT ["sh", "entrypoint.sh"]

--- a/saf/postgres_rds/entrypoint.sh
+++ b/saf/postgres_rds/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set +e
+
+envsubst < overlay_attributes.yml > overlay_attributes_subd.yml
+mkdir profiles
+cd profiles
+git clone https://github.com/mitre/aws-rds-crunchy-data-postgresql-9-stig-baseline.git
+git clone https://github.com/CMSgov/cms-ars-3.1-moderate-aws-rds-crunchy-data-postgresql-9-stig-overlay.git
+cd cms-ars-3.1-moderate-aws-rds-crunchy-data-postgresql-9-stig-overlay
+bundle install
+cd ..
+inspec exec cms-ars-3.1-moderate-aws-rds-crunchy-data-postgresql-9-stig-overlay --attrs=../overlay_attributes_subd.yml --reporter=cli json:output.json
+echo "BEGIN_JSON_RESULTS"
+cat output.json
+echo "END_JSON_RESULTS"

--- a/saf/postgres_rds/overlay_attributes.yml
+++ b/saf/postgres_rds/overlay_attributes.yml
@@ -1,0 +1,95 @@
+# description: 'Postgres OS user (e.g., 'postgres').'
+pg_owner: 'postgres'
+
+# description: 'Postgres OS group (e.g., 'postgres').'
+pg_group: 'postgres'
+
+# description: 'Postgres OS user password'
+pg_owner_password: ''
+
+# description: 'Postgres database admin user (e.g., 'root').'
+pg_dba: '$POSTGRES_USER'
+
+# description: 'Postgres database admin password ('password').'
+pg_dba_password: '$POSTGRES_PASSWORD'
+
+# description: 'Postgres normal user'
+pg_user: '$POSTGRES_USER'
+
+# description: 'Postgres normal user password'
+pg_user_password: '$POSTGRES_PASSWORD'
+
+# description: 'Postgres database hostname'
+pg_host: '$POSTGRES_HOST'
+
+# description: 'Postgres database port'
+pg_port: '5432'
+
+# description: 'Postgres database name ('test')'
+pg_db: '$POSTGRES_DB'
+
+# description: 'Postgres database table name'
+pg_table: ''
+
+# description: 'User on remote database server'
+login_user: ''
+
+# description: 'Database host ip'
+login_host: ''
+
+# description: 'Database version'
+pg_version: '9.5'
+
+# description: 'Data directory for database (e.g., '/var/lib/pgsql/9.5/data')'.
+pg_data_dir: ''
+
+# description: 'Configuration file for the database ('/var/lib/pgsql/9.5/data/postgresql.conf').'
+pg_conf_file: ''
+
+# description: 'User defined configuration file for the database (e.g., '/var/lib/pgsql/9.5/data/stig-postgresql.conf')'.
+pg_user_defined_conf: ''
+
+# description: 'Configuration file to enable client authentication (e.g., '/var/lib/pgsql/9.5/data/pg_hba.conf')'.
+pg_hba_conf_file: ''
+
+# description: 'Configuration file that maps operating system usernames and database usernames (e.g., '/var/lib/pgsql/9.5/data/pg_ident.conf').'
+pg_ident_conf_file: ''
+
+# description: 'List of shared directories (e.g., pg_shared_dirs: ['/usr/pgsql-9.5', '/usr/pgsql-9.5/bin', '/usr/pgsql-9.5/lib', '/usr/pgsql-9.5/share']).'
+pg_shared_dirs: []
+
+# description: 'Database configuration mode (e.g., 0600)'
+pg_conf_mode: '0600'
+
+# description: 'Postgres ssl setting (e.g., 'on').'
+pg_ssl: 'off'
+
+# description: 'Postgres log destination (e.g., 'syslog').'
+pg_log_dest: ''
+
+# description: 'Postgres syslog facility (e.g., ['local0']).'
+pg_syslog_facility: []
+
+# description: 'Postgres syslog owner (e.g., 'postgres').'
+pg_syslog_owner: ''
+
+# description: 'Postgres audit log items (e.g., ['ddl','role','read','write']).'
+pgaudit_log_items: ['ddl','role','read','write']
+
+# description: 'Postgres audit log line items (e.g. ['%m','%u','%c']).'
+pgaudit_log_line_items: ['%m','%u','%c']
+
+# description: 'Postgres super users (e.g., ['postgres']).'
+pg_superusers: ['$POSTGRES_USER']
+
+# description: 'Postgres users'
+pg_users: ['$POSTGRES_USER']
+
+# description: 'Postgres replicas (e.g. ['192.168.1.3/32']).'
+pg_replicas: []
+
+# description: 'Postgres max number of connections allowed (e.g., 100).'
+pg_max_connections: 10
+
+# description: 'Postgres timezone (e.g., 'UTC').'
+pg_timezone: ''


### PR DESCRIPTION
Introducing some SAF workflows into our app.
We're starting with running a profile based on a STIG against our RDS.

A scanner image is launched as an ECS task within the private subnets (next to rds).

Scan results are brought back via cloudwatch logs and archived to Jenkins.  

The json can be sent anywhere you like.

All pipeline jobs now scan the images and RDS by default on deploy.  That functionality can be shut off by setting SAF_SCAN=false in the CasC config (or omitting the variable altogether)

Three jobs are made dedicated to SAF, inside a SAF folder.  There's saf-master, saf-staging, and saf-prod.
The ECR image scans and the Inspec scans change over time, that is, existing infrastructure and images can become insecure as new vulnerabilities are found and published.
Therefore, the saf-* builds which are dedicated to scanning all images and RDS run once a day sometime between 2am and 3am.  These can be disabled at will.

Have fun