### PR TITLE
SAF - Correct image names causing ECR Scan failures

### DIFF
--- a/.jenkins/Jenkinsfile.prod
+++ b/.jenkins/Jenkinsfile.prod
@@ -38,12 +38,12 @@ pipeline {
         script {
           def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
           jenkinsUtils.triggerEcrScan("postgres_deployer", env.VERSION)
-          jenkinsUtils.triggerEcrScan("api_postgres", env.VERSION)
-          jenkinsUtils.triggerEcrScan("api_sqlserver", env.VERSION)
+          jenkinsUtils.triggerEcrScan("postgres_django", env.VERSION)
+          jenkinsUtils.triggerEcrScan("sqlserver_django", env.VERSION)
           jenkinsUtils.triggerEcrScan("react", env.VERSION)
           jenkinsUtils.fetchEcrScanResult("postgres_deployer", env.VERSION)
-          jenkinsUtils.fetchEcrScanResult("api_postgres", env.VERSION)
-          jenkinsUtils.fetchEcrScanResult("api_sqlserver", env.VERSION)
+          jenkinsUtils.fetchEcrScanResult("postgres_django", env.VERSION)
+          jenkinsUtils.fetchEcrScanResult("sqlserver_django", env.VERSION)
           jenkinsUtils.fetchEcrScanResult("react", env.VERSION)
         }
       }

--- a/.jenkins/Jenkinsfile.saf
+++ b/.jenkins/Jenkinsfile.saf
@@ -27,12 +27,12 @@ pipeline {
         script {
           def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
           jenkinsUtils.triggerEcrScan("postgres_deployer", env.BUILD_TAG)
-          jenkinsUtils.triggerEcrScan("api_postgres", env.BUILD_TAG)
-          jenkinsUtils.triggerEcrScan("api_sqlserver", env.BUILD_TAG)
+          jenkinsUtils.triggerEcrScan("postgres_django", env.BUILD_TAG)
+          jenkinsUtils.triggerEcrScan("sqlserver_django", env.BUILD_TAG)
           jenkinsUtils.triggerEcrScan("react", env.BUILD_TAG)
           jenkinsUtils.fetchEcrScanResult("postgres_deployer", env.BUILD_TAG)
-          jenkinsUtils.fetchEcrScanResult("api_postgres", env.BUILD_TAG)
-          jenkinsUtils.fetchEcrScanResult("api_sqlserver", env.BUILD_TAG)
+          jenkinsUtils.fetchEcrScanResult("postgres_django", env.BUILD_TAG)
+          jenkinsUtils.fetchEcrScanResult("sqlserver_django", env.BUILD_TAG)
           jenkinsUtils.fetchEcrScanResult("react", env.BUILD_TAG)
         }
       }


### PR DESCRIPTION

This typo was causing downstream builds (staging) to fail, as it was looking for an ECR repo that doesn't exist.

These names are a bit confusing.  
