### PR TITLE
Load sections from the API at page load

### DIFF
--- a/frontend/react/package-lock.json
+++ b/frontend/react/package-lock.json
@@ -2581,6 +2581,37 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",

--- a/frontend/react/package.json
+++ b/frontend/react/package.json
@@ -13,6 +13,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
+    "axios": "^0.19.2",
     "font-awesome": "^4.7.0",
     "node-sass": "^4.14.1",
     "react": "^16.13.1",

--- a/frontend/react/src/App.js
+++ b/frontend/react/src/App.js
@@ -4,6 +4,7 @@ import "./App.scss";
 import Routes from "./reactRouter";
 import Header from "./components/layout/Header";
 import Footer from "./components/layout/Footer";
+import InitialDataLoad from "./components/Utils/InitialDataLoad";
 
 function App() {
   let VisibleHeader =
@@ -13,6 +14,7 @@ function App() {
     window.location.pathname.split("/")[1] === "reports" ? null : <Footer />;
   return (
     <div className="App" data-test="component-app">
+      <InitialDataLoad />
       {VisibleHeader}
       <Routes />
       {VisibleFooter}

--- a/frontend/react/src/actions/initial.js
+++ b/frontend/react/src/actions/initial.js
@@ -4,7 +4,7 @@ export const LOAD_SECTIONS = "LOAD SECTIONS";
 
 export const loadSections = () => {
   return async dispatch => {
-    const { data } = await axios.get("//localhost:8000/sections/");
+    const { data } = await axios.get("//localhost:8000/v1/sections/2020/AK");
     dispatch({ type: LOAD_SECTIONS, data });
   };
 };

--- a/frontend/react/src/actions/initial.js
+++ b/frontend/react/src/actions/initial.js
@@ -1,0 +1,10 @@
+import axios from "axios";
+
+export const LOAD_SECTIONS = "LOAD SECTIONS";
+
+export const loadSections = () => {
+  return async dispatch => {
+    const { data } = await axios.get("//localhost:8000/sections/");
+    dispatch({ type: LOAD_SECTIONS, data });
+  };
+};

--- a/frontend/react/src/components/Utils/InitialDataLoad.js
+++ b/frontend/react/src/components/Utils/InitialDataLoad.js
@@ -7,7 +7,9 @@ const InitialDataLoad = () => {
 
   useEffect(() => {
     dispatch(loadSections());
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  // :point-up: We don't need that lint check because the empty dependencies
+  // is what we want: only load the data once, period.
 
   return null;
 };

--- a/frontend/react/src/components/Utils/InitialDataLoad.js
+++ b/frontend/react/src/components/Utils/InitialDataLoad.js
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { loadSections } from "../../actions/initial";
+
+const InitialDataLoad = () => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(loadSections());
+  }, []);
+
+  return null;
+};
+
+export default InitialDataLoad;

--- a/frontend/react/src/components/sections/basicinfoapi/BasicInfo.js
+++ b/frontend/react/src/components/sections/basicinfoapi/BasicInfo.js
@@ -3,52 +3,50 @@ import { connect } from "react-redux";
 import PageInfo from "../../layout/PageInfo";
 import FormNavigation from "../../layout/FormNavigation";
 import FormActions from "../../layout/FormActions";
+import { selectSectionByOrdinal } from "../../../store/formData";
 import {
   Tabs,
   TabPanel
 } from "@cmsgov/design-system-core";
 import QuestionsBasicInfo from "./questions/QuestionsBasicInfo";
-import Data from "./backend-json-section-0.json";
 
-class BasicInfo extends Component {
-  constructor(props) {
-    super(props);
-  }
+const BasicInfo = ({Data}) =>
+  Data ? (
+    <div className="section-basic-info ds-l-col--9 content">
+      <div className="main">
+        <PageInfo />
+        <div className="section-content">
+          <Tabs>
+            <TabPanel id="tab-form" tab={Data.section.title}>
+              <QuestionsBasicInfo previousYear="false"/>
+              <FormNavigation nextUrl="/section1" />
+            </TabPanel>
 
-  render() {
-    return (
-      <div className="section-basic-info ds-l-col--9 content">
-        <div className="main">
-          <PageInfo />
-          <div className="section-content">
-            <Tabs>
-              <TabPanel id="tab-form" tab={Data.section.title}>
-                <QuestionsBasicInfo previousYear="false"/>
-                <FormNavigation nextUrl="/section1" />
-              </TabPanel>
-
-              <TabPanel
-                id="tab-lastyear"
-                tab={`FY${Data.section.year - 1} answers`}
-              >
-                <div disabled>
-                  <QuestionsBasicInfo previousYear="true"/>
-                </div>
-              </TabPanel>
-            </Tabs>
-            <FormActions />
-          </div>
+            <TabPanel
+              id="tab-lastyear"
+              tab={`FY${Data.section.year - 1} answers`}
+            >
+              <div disabled>
+                <QuestionsBasicInfo previousYear="true"/>
+              </div>
+            </TabPanel>
+          </Tabs>
+          <FormActions />
         </div>
       </div>
-    );
-  }
-}
+    </div>
+  ) : null;
+  
 
-const mapStateToProps = (state) => ({
-  abbr: state.stateUser.currentUser.state.id,
-  year: state.global.formYear,
-  programType: state.stateUser.programType,
-  programName: state.stateUser.programName,
-});
+
+const mapStateToProps = (state) => {
+  return {
+    abbr: state.stateUser.currentUser.state.id,
+    Data: selectSectionByOrdinal(state, 0),
+    year: state.global.formYear,
+    programType: state.stateUser.programType,
+    programName: state.stateUser.programName,
+  }
+};
 
 export default connect(mapStateToProps)(BasicInfo);

--- a/frontend/react/src/reactRouter.js
+++ b/frontend/react/src/reactRouter.js
@@ -29,9 +29,7 @@ const Routes = () => (
         {VisibleSidebar}
         <Switch>
           <Route exact path="/" component={Homepage} />
-          <Route exact path="/basic-info" component={BasicInfo} />
-          {/* <Route exact path="/basic-info" component={BasicInfoApi} /> */}
-          <Route exact path="/basic-info-api" component={BasicInfoApi} />
+          <Route exact path="/basic-info" component={BasicInfoApi} />
           <Route exact path="/section1" component={Section1} />
           {/* <Route exact path="/section1" component={Section1Api} /> */}
           <Route exact path="/section1-api" component={Section1Api} />

--- a/frontend/react/src/store/formData.js
+++ b/frontend/react/src/store/formData.js
@@ -1,30 +1,12 @@
-const CURRENT_YEAR_DATA = "CURRENT_YEAR_DATA";
+import { LOAD_SECTIONS } from "../actions/initial";
 
-const initialState = {
-    s2b_o1_g1_q1_question: "1. Briefly describe your goal",
-    s2b_o1_g1_q1_hint:
-      "For example: Enroll 75% of eligible children in the CHIP program.",
-    s2b_o1_g1_q1_answer:
-      "This is the text for section 2b, objective 1, Goal 1, Question1",
-    s2b_o1_g1_q1_prev: "This is last years answer",
+const initialState = [ ];
 
-    s2b_o1_g1_q2_answer: "new",
-    s2b_o1_g1_q3_answer: "Question3",
-  },
-
-const getCurrentData = (answerData) => ({
-    type: CURRENT_YEAR_DATA,
-    s2b_o1_g1_q1_answer: answerData
-})
-  // FORM DATA REDUCER
-export default function (data = initialState, action) {
-    switch (action.type) {
-      case CURRENT_YEAR_DATA:
-        return {
-          ...data,
-          s2b_o1_g1_q1_answer: action.answer,
-        };
-      default:
-        return data;
-    }
+export default (data = initialState, action) => {
+  switch (action.type) {
+    case LOAD_SECTIONS:
+      return action.data;
+    default:
+      return data;
   }
+};

--- a/frontend/react/src/store/formData.js
+++ b/frontend/react/src/store/formData.js
@@ -10,3 +10,11 @@ export default (data = initialState, action) => {
       return data;
   }
 };
+
+export const selectSectionByOrdinal = (state, ordinal) => {
+  const section = state.formData.filter(c => c.contents.section.ordinal === ordinal);
+  if(section.length > 0) {
+    return section[0].contents;
+  }
+  return null;
+}

--- a/frontend/react/src/store/storeIndex.js
+++ b/frontend/react/src/store/storeIndex.js
@@ -1,11 +1,12 @@
 import { createStore, combineReducers, applyMiddleware } from "redux";
 import thunkMiddleware from "redux-thunk";
 import { composeWithDevTools } from "redux-devtools-extension";
+import formData from './formData';
 import stateUser from "./stateUser";
 import global from "./globalVariables";
 
 // Consolidate reducers
-export const reducer = combineReducers({ stateUser, global });
+export const reducer = combineReducers({ formData, stateUser, global });
 
 // Consolidate middleware
 let middlewareArray = [thunkMiddleware];

--- a/frontend/react/src/testUtils.js
+++ b/frontend/react/src/testUtils.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import { shallow } from "enzyme";
-import { createStore } from "redux";
+import { createStore, applyMiddleware } from "redux";
+import thunk from "redux-thunk";
 
 import checkPropTypes from "check-prop-types";
 
@@ -11,7 +12,7 @@ export const findByTestAttribute = (wrapper, val) => {
 };
 
 export const storeFactory = (initialState) => {
-  return createStore(reducer, initialState);
+  return createStore(reducer, initialState, applyMiddleware(thunk));
 };
 
 export const checkProps = (component, conformingProps) => {
@@ -25,6 +26,7 @@ export const checkProps = (component, conformingProps) => {
 };
 
 export const mockInitialState = {
+  formData: [],
   stateUser: {
     name: "New York",
     abbr: "NY",


### PR DESCRIPTION
Inspired by where @hbillings started on #360.

1. Creates a component that exists solely for firing off the request to load data initially
2. Adds a redux action to load data
3. Hooks up the component's initial load so that it dispatches the load action
4. Calls the API's `GET /sections/` method and dispatches the returned data
5. Uses the `formData` reducer to push initial data into the store
6. Switches to `BascInfoApi/BasicInfo` component to dynamically render content from the API

I understand from @tadhg-ohiggins that the `/sections/` endpoint is not the right place to pull data from and the `formData` part of the state may not be the best state name, but it seems reasonable that we can figure out those details once the basic workflow is in place.

But in a nutshell, with this PR, the Basic Info section is dynamically built and populated using the data from the API.

related to #314 
