### PR TITLE
Experimental api v1

### DIFF
--- a/frontend/api_postgres/carts/carts_api/views.py
+++ b/frontend/api_postgres/carts/carts_api/views.py
@@ -80,6 +80,20 @@ class SectionViewSet(viewsets.ModelViewSet):
 
 
 @api_view(["GET"])
+def sections_by_year_and_state(request, year, state):
+    try:
+        data = Section.objects.filter(contents__section__year=year,
+                                      contents__section__state=state.upper())
+    except Section.DoesNotExist:
+        return HttpResponse(status=404)
+
+    if request.method == 'GET':
+        serializer = SectionSerializer(data, many=True,
+                                       context={"request": request})
+        return Response(serializer.data)
+
+
+@api_view(["GET"])
 def section_by_year_and_state(request, year, state, section):
     try:
         data = Section.objects.get(contents__section__year=year,
@@ -90,6 +104,19 @@ def section_by_year_and_state(request, year, state, section):
 
     if request.method == 'GET':
         serializer = SectionSerializer(data)
+        return Response(serializer.data)
+
+
+@api_view(["GET"])
+def sectionbases_by_year(request, year):
+    try:
+        data = SectionBase.objects.filter(contents__section__year=year)
+    except SectionBase.DoesNotExist:
+        return HttpResponse(status=404)
+
+    if request.method == 'GET':
+        serializer = SectionBaseSerializer(data, many=True,
+                                           context={"request": request})
         return Response(serializer.data)
 
 

--- a/frontend/api_postgres/carts/carts_api/views.py
+++ b/frontend/api_postgres/carts/carts_api/views.py
@@ -1,7 +1,15 @@
 import json
+import string
+from typing import (
+    Dict,
+    List,
+    Union,
+)
 from django.contrib.auth.models import User, Group  # type: ignore
 from django.http import HttpResponse  # type: ignore
 from django.template.loader import get_template  # type: ignore
+from jsonpath_ng.ext import parse  # type: ignore
+from jsonpath_ng import DatumInContext  # type: ignore
 from rest_framework import viewsets  # type: ignore
 from rest_framework.decorators import api_view  # type: ignore
 from rest_framework.response import Response  # type: ignore
@@ -99,24 +107,78 @@ def sectionbase_by_year_and_section(request, year, section):
 
 
 @api_view(["GET"])
-def section_subsection_by_state(request, subsection, state):
-    year, section, subsection_letter = subsection.split("-")
-    year, section = int(year), int(section)
+def sectionbase_by_year_section_subsection(request, year, section, subsection):
     try:
+        data = SectionBase.objects.get(contents__section__year=year,
+                                       contents__section__ordinal=section)
+        subsection_id = _id_from_chunks(year, section, subsection)
+        subsections = data.contents["section"]["subsections"]
+        targets = [_ for _ in subsections if _["id"] == subsection_id]
+        if not targets:
+            return HttpResponse(status=404)
+        data.contents = targets[0] if len(targets) == 1 else targets
 
+    except SectionBase.DoesNotExist:
+        return HttpResponse(status=404)
+
+    if request.method == 'GET':
+        serializer = SectionBaseSerializer(data)
+        return Response(serializer.data)
+
+
+@api_view(["GET"])
+def section_subsection_by_year_and_state(request, year, state, section,
+                                         subsection):
+    try:
         data = Section.objects.get(contents__section__year=year,
                                    contents__section__state=state.upper(),
                                    contents__section__ordinal=section)
         subsections = data.contents["section"]["subsections"]
-        targets = [_ for _ in subsections if _["id"] == subsection]
-        if len(targets) == 1:
-            target = targets[0]
-        elif len(targets) > 1:
-            target = targets
-        else:
+        subsection_id = _id_from_chunks(year, section, subsection)
+        targets = [_ for _ in subsections if _["id"] == subsection_id]
+        if not targets:
             return HttpResponse(status=404)
+        data.contents = targets[0] if len(targets) == 1 else targets
 
-        data.contents = target
+    except Section.DoesNotExist:
+        return HttpResponse(status=404)
+
+    if request.method == 'GET':
+        serializer = SectionSerializer(data)
+        return Response(serializer.data)
+
+
+@api_view(["GET"])
+def fragment_by_year_state_id(request, state, id):
+    try:
+        year, section = _year_section_query_from_id(id)
+        data = Section.objects.get(contents__section__year=year,
+                                   contents__section__state=state.upper(),
+                                   contents__section__ordinal=section)
+        targets = _get_fragment_by_id(id, data.contents.get("section"))
+        if not len(targets) == 1:
+            return HttpResponse(status=404)
+        data.contents = targets[0].value
+
+    except Section.DoesNotExist:
+        return HttpResponse(status=404)
+
+    if request.method == 'GET':
+        serializer = SectionSerializer(data)
+        return Response(serializer.data)
+
+
+@api_view(["GET"])
+def generic_fragment_by_id(request, id):
+    try:
+        year, section = _year_section_query_from_id(id)
+        data = SectionBase.objects.get(contents__section__year=year,
+                                       contents__section__ordinal=section)
+        targets = _get_fragment_by_id(id, data.contents.get("section"))
+        if not len(targets) == 1:
+            return HttpResponse(status=404)
+        data.contents = targets[0].value
+
     except Section.DoesNotExist:
         return HttpResponse(status=404)
 
@@ -157,3 +219,25 @@ def report(request, year=None, state=None):
     }
     report_template = get_template("report.html")
     return HttpResponse(report_template.render(context=context))
+
+
+def _id_from_chunks(year, *args):
+    def fill(chunk):
+        chunk = str(chunk).lower()
+        if chunk in string.ascii_lowercase:
+            return chunk
+        return chunk.zfill(2)
+    chunks = [year] + [*args]
+
+    return "-".join(fill(c) for c in chunks)
+
+
+def _year_section_query_from_id(ident: str) -> List[int]:
+    return [int(_) for _ in ident.split("-")[:2]]
+
+
+def _get_fragment_by_id(ident: str,
+                        contents: Union[Dict, List]) -> DatumInContext:
+    pathstring = f"$..*[?(@.id=='{ident}')]"
+    find_by_id = parse(pathstring)
+    return find_by_id.find(contents)

--- a/frontend/api_postgres/carts/urls.py
+++ b/frontend/api_postgres/carts/urls.py
@@ -25,6 +25,21 @@ router.register(r'sections', views.SectionViewSet)
 router.register(r'sectionbases', views.SectionBaseViewSet)
 router.register(r'sectionschemas', views.SectionSchemaViewSet)
 
+api_patterns = [
+    path("sections/<int:year>/<str:state>/<int:section>",
+         views.section_by_year_and_state),
+    path("sections/<int:year>/<str:state>/<int:section>/<str:subsection>",
+         views.section_subsection_by_year_and_state),
+    path("questions/<str:state>/<slug:id>",
+         views.fragment_by_year_state_id),
+    path("generic-sections/<int:year>/<int:section>",
+         views.sectionbase_by_year_and_section),
+    path("generic-sections/<int:year>/<int:section>/<str:subsection>",
+         views.sectionbase_by_year_section_subsection),
+    path("generic-questions/<slug:id>",
+         views.generic_fragment_by_id),
+]
+
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include(router.urls)),
@@ -33,8 +48,8 @@ urlpatterns = [
          views.section_by_year_and_state),
     path("structure/<int:year>/<int:section>",
          views.sectionbase_by_year_and_section),
-    path("subsection_data/<str:subsection>/<str:state>",
-         views.section_subsection_by_state),
     # path('api-auth/', include('rest_framework.urls',
     #  namespace='rest_framework'))
+    path("api/v1/", include(api_patterns)),
 ]
+

--- a/frontend/api_postgres/carts/urls.py
+++ b/frontend/api_postgres/carts/urls.py
@@ -26,12 +26,16 @@ router.register(r'sectionbases', views.SectionBaseViewSet)
 router.register(r'sectionschemas', views.SectionSchemaViewSet)
 
 api_patterns = [
+    path("sections/<int:year>/<str:state>",
+         views.sections_by_year_and_state),
     path("sections/<int:year>/<str:state>/<int:section>",
          views.section_by_year_and_state),
     path("sections/<int:year>/<str:state>/<int:section>/<str:subsection>",
          views.section_subsection_by_year_and_state),
     path("questions/<str:state>/<slug:id>",
          views.fragment_by_year_state_id),
+    path("generic-sections/<int:year>",
+         views.sectionbases_by_year),
     path("generic-sections/<int:year>/<int:section>",
          views.sectionbase_by_year_and_section),
     path("generic-sections/<int:year>/<int:section>/<str:subsection>",


### PR DESCRIPTION
Use better naming
And version the API.
Read-only for now.

Adds some new routes, all under `/api/v1`.

- `/api/v1/sections/<int:year>/<str:state>`: all the sections for a year and state, e.g. `/api/v1/sections/2020/ak`.
- `/api/v1/sections/<int:year>/<str:state>/<int:section>`: the section for that year and state, e.g. `/api/v1/sections/2020/ak/1`.
- `/api/v1/sections/<int:year>/<str:state>/<int:section>/<str:subsection>`: the subsection for that year and state, e.g. `/api/v1/sections/2020/az/3/c`.
- `/api/v1/questions/<str:state>/<slug:id>`: e.g. `/api/v1/questions/ma/2020-03-c-01-01`.
- `/api/v1/generic-sections/<int:year>`: all the default sections for a year e.g. `/api/v1/generic-sections/2020`.
- `/api/v1/generic-sections/<int:year>/<int:section>`: the default section for that year e.g. `/api/v1/generic-sections/2020/1`.
- `/api/v1/generic-sections/<int:year>/<int:section>/<str:subsection>`: the default subsection for that year e.g. `/api/v1/generic-sections/2020/1/a`.
- `/api/v1/generic-questions/<slug:id>`: the default corresponding question, e.g. `/api/v1/generic-questions/2020-01-a-01`.

Related to #353.