### PR TITLE
Add Django setup steps to entrypoint.sh

### DIFF
--- a/frontend/api_postgres/entrypoint.sh
+++ b/frontend/api_postgres/entrypoint.sh
@@ -11,4 +11,6 @@ then
     echo "PostgreSQL started"
 fi
 
+docker-compose run api_postgres sh -c "python manage.py makemigrations && python manage.py migrate && python manage.py idempotent_fixtures"
+
 exec "$@"

--- a/frontend/api_postgres/entrypoint.sh
+++ b/frontend/api_postgres/entrypoint.sh
@@ -11,6 +11,6 @@ then
     echo "PostgreSQL started"
 fi
 
-docker-compose run api_postgres sh -c "python manage.py makemigrations && python manage.py migrate && python manage.py idempotent_fixtures"
+python manage.py makemigrations && python manage.py migrate && python manage.py idempotent_fixtures
 
 exec "$@"


### PR DESCRIPTION
Django needs info.
Not what it knows already.
Only the new stuff.

Add a bunch of Django commands that make migrations, migrate, and load fixtures. These won't do anything if they've already been covered by prior deploys.

@dwhitecl This is the change we talked about earlier.