### PR TITLE
Make setAnswerEntry handle things that don't have .target.value

### DIFF
--- a/frontend/react/src/actions/initial.js
+++ b/frontend/react/src/actions/initial.js
@@ -13,10 +13,11 @@ export const loadSections = () => {
 };
 
 // Move this to where actions should go when we know where that is.
-export const setAnswerEntry = (fragmentId, eventChange) => {
+export const setAnswerEntry = (fragmentId, something) => {
+  const value = (something.target && something.target.value) ? something.target.value : something;
   return {
     type: QUESTION_ANSWERED,
     fragmentId: fragmentId,
-    data: eventChange.target.value,
+    data: value,
   };
 };


### PR DESCRIPTION
Stricter is better
But too many things will break
So, be tolerant.

Eventually we should accept only the unwrapped value; my putting it in an event-like object was a mistake. However, right now that would break a bunch of things, so this will put off the breakage while also allowing unwrapped values to work.