### PR TITLE
Section 3c datagrid JSON move

### DIFF
--- a/docs/section-schemas/backend-json-section-3.json
+++ b/docs/section-schemas/backend-json-section-3.json
@@ -751,7 +751,7 @@
                       },
                       {
                         "type": "fieldset",
-                        "fieldset_type": "datagrid",
+                        "fieldset_type": "datagrid_with_total",
                         "context_data": {
                           "skip_text": "1b–1e omitted because you indicated that you don't have the age range breakdown data available.",
                           "conditional_display": {
@@ -859,7 +859,7 @@
                     "questions": [
                       {
                         "type": "fieldset",
-                        "fieldset_type": "datagrid",
+                        "fieldset_type": "datagrid_with_total",
                         "context_data": {
                           "skip_text": "2b–2e omitted because you indicated that don't you have the age range breakdown data available.",
                           "conditional_display": {
@@ -958,7 +958,7 @@
                     "questions": [
                       {
                         "type": "fieldset",
-                        "fieldset_type": "datagrid",
+                        "fieldset_type": "datagrid_with_total",
                         "context_data": {
                           "skip_text": "3b–3e omitted because you indicated that you don't have the age range breakdown data available.",
                           "conditional_display": {
@@ -1053,7 +1053,7 @@
                             "questions": [
                               {
                                 "type": "fieldset",
-                                "fieldset_type": "datagrid",
+                                "fieldset_type": "datagrid_with_total",
                                 "context_data": {
                                   "skip_text": "3f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
                                   "conditional_display": {
@@ -1157,7 +1157,7 @@
                     "questions": [
                       {
                         "type": "fieldset",
-                        "fieldset_type": "datagrid",
+                        "fieldset_type": "datagrid_with_total",
                         "context_data": {
                           "skip_text": "4b–4e omitted because you indicated that you don't have the age range breakdown data available.",
                           "conditional_display": {
@@ -1252,7 +1252,7 @@
                             "questions": [
                               {
                                 "type": "fieldset",
-                                "fieldset_type": "datagrid",
+                                "fieldset_type": "datagrid_with_total",
                                 "context_data": {
                                   "skip_text": "4f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
                                   "conditional_display": {
@@ -1371,7 +1371,7 @@
                     "questions": [
                       {
                         "type": "fieldset",
-                        "fieldset_type": "datagrid",
+                        "fieldset_type": "datagrid_with_total",
                         "context_data": {
                           "skip_text": "6b–6e omitted because you indicated that don't you have the age range breakdown data available.",
                           "conditional_display": {
@@ -1470,7 +1470,7 @@
                     "questions": [
                       {
                         "type": "fieldset",
-                        "fieldset_type": "datagrid",
+                        "fieldset_type": "datagrid_with_total",
                         "context_data": {
                           "skip_text": "7b–7e omitted because you indicated that you don't have the age range breakdown data available.",
                           "conditional_display": {
@@ -1565,7 +1565,7 @@
                             "questions": [
                               {
                                 "type": "fieldset",
-                                "fieldset_type": "datagrid",
+                                "fieldset_type": "datagrid_with_total",
                                 "context_data": {
                                   "skip_text": "7f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
                                   "conditional_display": {
@@ -1669,7 +1669,7 @@
                     "questions": [
                       {
                         "type": "fieldset",
-                        "fieldset_type": "datagrid",
+                        "fieldset_type": "datagrid_with_total",
                         "context_data": {
                           "skip_text": "8b–8e omitted because you indicated that you don't have the age range breakdown data available.",
                           "conditional_display": {
@@ -1764,7 +1764,7 @@
                             "questions": [
                               {
                                 "type": "fieldset",
-                                "fieldset_type": "datagrid",
+                                "fieldset_type": "datagrid_with_total",
                                 "context_data": {
                                   "skip_text": "8f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
                                   "conditional_display": {
@@ -1876,7 +1876,7 @@
                     "questions": [
                       {
                         "type": "fieldset",
-                        "fieldset_type": "datagrid",
+                        "fieldset_type": "datagrid_with_total",
                         "context_data": {
                           "skip_text": "9b–9e omitted because you indicated that don't you have the age range breakdown data available.",
                           "conditional_display": {
@@ -1975,7 +1975,7 @@
                     "questions": [
                       {
                         "type": "fieldset",
-                        "fieldset_type": "datagrid",
+                        "fieldset_type": "datagrid_with_total",
                         "context_data": {
                           "skip_text": "10b–10e omitted because you indicated that you don't have the age range breakdown data available.",
                           "conditional_display": {
@@ -2070,7 +2070,7 @@
                             "questions": [
                               {
                                 "type": "fieldset",
-                                "fieldset_type": "datagrid",
+                                "fieldset_type": "datagrid_with_total",
                                 "context_data": {
                                   "skip_text": "10f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
                                   "conditional_display": {
@@ -2174,7 +2174,7 @@
                     "questions": [
                       {
                         "type": "fieldset",
-                        "fieldset_type": "datagrid",
+                        "fieldset_type": "datagrid_with_total",
                         "context_data": {
                           "skip_text": "11b–11e omitted because you indicated that you don't have the age range breakdown data available.",
                           "conditional_display": {
@@ -2269,7 +2269,7 @@
                             "questions": [
                               {
                                 "type": "fieldset",
-                                "fieldset_type": "datagrid",
+                                "fieldset_type": "datagrid_with_total",
                                 "context_data": {
                                   "skip_text": "11f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
                                   "conditional_display": {

--- a/docs/section-schemas/backend-json-section-3.json
+++ b/docs/section-schemas/backend-json-section-3.json
@@ -750,36 +750,6 @@
                         ]
                       },
                       {
-                        "comment": "This is the first real question so far in this part…",
-                        "type": "question",
-                        "id": "2020-03-c-04-01-a",
-                        "label": "Total for all ages",
-                        "type": "integer",
-                        "answer": {
-                          "entry": null
-                        },
-                        "context_data": {
-                          "skip_text": "1a omitted because you indicated that you have the age range breakdown data available.",
-                          "conditional_display": {
-                            "type": "conditional_display",
-                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                            "hide_if": {
-                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                              "values": {
-                                "interactive": [
-                                  false,
-                                  null
-                                ],
-                                "noninteractive": [
-                                  false,
-                                  null
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      },
-                      {
                         "type": "fieldset",
                         "fieldset_type": "datagrid",
                         "context_data": {
@@ -801,6 +771,36 @@
                           }
                         },
                         "questions": [
+                          {
+                            "comment": "This is the first real question so far in this part…",
+                            "type": "question",
+                            "id": "2020-03-c-04-01-a",
+                            "label": "Total for all ages",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            },
+                            "context_data": {
+                              "skip_text": "1a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [
+                                      false,
+                                      null
+                                    ],
+                                    "noninteractive": [
+                                      false,
+                                      null
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
                           {
                             "type": "question",
                             "id": "2020-03-c-04-01-b",
@@ -858,35 +858,6 @@
                     },
                     "questions": [
                       {
-                        "type": "question",
-                        "id": "2020-03-c-04-02-a",
-                        "label": "Total for all ages",
-                        "type": "integer",
-                        "answer": {
-                          "entry": null
-                        },
-                        "context_data": {
-                          "skip_text": "2a omitted because you indicated that you have the age range breakdown data available.",
-                          "conditional_display": {
-                            "type": "conditional_display",
-                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                            "hide_if": {
-                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                              "values": {
-                                "interactive": [
-                                  false,
-                                  null
-                                ],
-                                "noninteractive": [
-                                  false,
-                                  null
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      },
-                      {
                         "type": "fieldset",
                         "fieldset_type": "datagrid",
                         "context_data": {
@@ -908,6 +879,35 @@
                           }
                         },
                         "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-02-a",
+                            "label": "Total for all ages",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            },
+                            "context_data": {
+                              "skip_text": "2a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [
+                                      false,
+                                      null
+                                    ],
+                                    "noninteractive": [
+                                      false,
+                                      null
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
                           {
                             "type": "question",
                             "id": "2020-03-c-04-02-b",
@@ -957,35 +957,6 @@
                     },
                     "questions": [
                       {
-                        "type": "question",
-                        "id": "2020-03-c-04-03-a",
-                        "label": "Total for all ages",
-                        "type": "integer",
-                        "answer": {
-                          "entry": null
-                        },
-                        "context_data": {
-                          "skip_text": "3a omitted because you indicated that you have the age range breakdown data available.",
-                          "conditional_display": {
-                            "type": "conditional_display",
-                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                            "hide_if": {
-                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                              "values": {
-                                "interactive": [
-                                  false,
-                                  null
-                                ],
-                                "noninteractive": [
-                                  false,
-                                  null
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      },
-                      {
                         "type": "fieldset",
                         "fieldset_type": "datagrid",
                         "context_data": {
@@ -1007,6 +978,35 @@
                           }
                         },
                         "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-03-a",
+                            "label": "Total for all ages",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            },
+                            "context_data": {
+                              "skip_text": "3a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [
+                                      false,
+                                      null
+                                    ],
+                                    "noninteractive": [
+                                      false,
+                                      null
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
                           {
                             "type": "question",
                             "id": "2020-03-c-04-03-b",
@@ -1052,35 +1052,6 @@
                             },
                             "questions": [
                               {
-                                "type": "question",
-                                "id": "2020-03-c-04-03-f-01",
-                                "label": "Total for all ages",
-                                "type": "integer",
-                                "answer": {
-                                  "entry": null
-                                },
-                                "context_data": {
-                                  "skip_text": "3f 1 omitted because you indicated that you have the age range breakdown data available.",
-                                  "conditional_display": {
-                                    "type": "conditional_display",
-                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                                    "hide_if": {
-                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                                      "values": {
-                                        "interactive": [
-                                          false,
-                                          null
-                                        ],
-                                        "noninteractive": [
-                                          false,
-                                          null
-                                        ]
-                                      }
-                                    }
-                                  }
-                                }
-                              },
-                              {
                                 "type": "fieldset",
                                 "fieldset_type": "datagrid",
                                 "context_data": {
@@ -1102,6 +1073,35 @@
                                   }
                                 },
                                 "questions": [
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-03-f-01",
+                                    "label": "Total for all ages",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    },
+                                    "context_data": {
+                                      "skip_text": "3f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [
+                                              false,
+                                              null
+                                            ],
+                                            "noninteractive": [
+                                              false,
+                                              null
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
                                   {
                                     "type": "question",
                                     "id": "2020-03-c-04-03-f-02",
@@ -1156,35 +1156,6 @@
                     },
                     "questions": [
                       {
-                        "type": "question",
-                        "id": "2020-03-c-04-04-a",
-                        "label": "Total for all ages",
-                        "type": "integer",
-                        "answer": {
-                          "entry": null
-                        },
-                        "context_data": {
-                          "skip_text": "4a omitted because you indicated that you have the age range breakdown data available.",
-                          "conditional_display": {
-                            "type": "conditional_display",
-                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                            "hide_if": {
-                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                              "values": {
-                                "interactive": [
-                                  false,
-                                  null
-                                ],
-                                "noninteractive": [
-                                  false,
-                                  null
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      },
-                      {
                         "type": "fieldset",
                         "fieldset_type": "datagrid",
                         "context_data": {
@@ -1206,6 +1177,35 @@
                           }
                         },
                         "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-04-a",
+                            "label": "Total for all ages",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            },
+                            "context_data": {
+                              "skip_text": "4a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [
+                                      false,
+                                      null
+                                    ],
+                                    "noninteractive": [
+                                      false,
+                                      null
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
                           {
                             "type": "question",
                             "id": "2020-03-c-04-04-b",
@@ -1251,35 +1251,6 @@
                             },
                             "questions": [
                               {
-                                "type": "question",
-                                "id": "2020-03-c-04-04-f-01",
-                                "label": "Total for all ages",
-                                "type": "integer",
-                                "answer": {
-                                  "entry": null
-                                },
-                                "context_data": {
-                                  "skip_text": "4f 1 omitted because you indicated that you have the age range breakdown data available.",
-                                  "conditional_display": {
-                                    "type": "conditional_display",
-                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                                    "hide_if": {
-                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                                      "values": {
-                                        "interactive": [
-                                          false,
-                                          null
-                                        ],
-                                        "noninteractive": [
-                                          false,
-                                          null
-                                        ]
-                                      }
-                                    }
-                                  }
-                                }
-                              },
-                              {
                                 "type": "fieldset",
                                 "fieldset_type": "datagrid",
                                 "context_data": {
@@ -1301,6 +1272,35 @@
                                   }
                                 },
                                 "questions": [
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-04-f-01",
+                                    "label": "Total for all ages",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    },
+                                    "context_data": {
+                                      "skip_text": "4f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [
+                                              false,
+                                              null
+                                            ],
+                                            "noninteractive": [
+                                              false,
+                                              null
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
                                   {
                                     "type": "question",
                                     "id": "2020-03-c-04-04-f-02",
@@ -1355,9 +1355,6 @@
                   }
                 ]
               },
-
-
-
               {
                 "type": "fieldset",
                 "label": "January – March 2020 (12 months later)",
@@ -1372,35 +1369,6 @@
                       "id": "2020-03-c-04-06"
                     },
                     "questions": [
-                      {
-                        "type": "question",
-                        "id": "2020-03-c-04-06-a",
-                        "label": "Total for all ages",
-                        "type": "integer",
-                        "answer": {
-                          "entry": null
-                        },
-                        "context_data": {
-                          "skip_text": "6a omitted because you indicated that you have the age range breakdown data available.",
-                          "conditional_display": {
-                            "type": "conditional_display",
-                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                            "hide_if": {
-                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                              "values": {
-                                "interactive": [
-                                  false,
-                                  null
-                                ],
-                                "noninteractive": [
-                                  false,
-                                  null
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      },
                       {
                         "type": "fieldset",
                         "fieldset_type": "datagrid",
@@ -1423,6 +1391,35 @@
                           }
                         },
                         "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-06-a",
+                            "label": "Total for all ages",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            },
+                            "context_data": {
+                              "skip_text": "6a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [
+                                      false,
+                                      null
+                                    ],
+                                    "noninteractive": [
+                                      false,
+                                      null
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
                           {
                             "type": "question",
                             "id": "2020-03-c-04-06-b",
@@ -1472,35 +1469,6 @@
                     },
                     "questions": [
                       {
-                        "type": "question",
-                        "id": "2020-03-c-04-07-a",
-                        "label": "Total for all ages",
-                        "type": "integer",
-                        "answer": {
-                          "entry": null
-                        },
-                        "context_data": {
-                          "skip_text": "7a omitted because you indicated that you have the age range breakdown data available.",
-                          "conditional_display": {
-                            "type": "conditional_display",
-                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                            "hide_if": {
-                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                              "values": {
-                                "interactive": [
-                                  false,
-                                  null
-                                ],
-                                "noninteractive": [
-                                  false,
-                                  null
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      },
-                      {
                         "type": "fieldset",
                         "fieldset_type": "datagrid",
                         "context_data": {
@@ -1522,6 +1490,35 @@
                           }
                         },
                         "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-07-a",
+                            "label": "Total for all ages",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            },
+                            "context_data": {
+                              "skip_text": "7a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [
+                                      false,
+                                      null
+                                    ],
+                                    "noninteractive": [
+                                      false,
+                                      null
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
                           {
                             "type": "question",
                             "id": "2020-03-c-04-07-b",
@@ -1567,35 +1564,6 @@
                             },
                             "questions": [
                               {
-                                "type": "question",
-                                "id": "2020-03-c-04-07-f-01",
-                                "label": "Total for all ages",
-                                "type": "integer",
-                                "answer": {
-                                  "entry": null
-                                },
-                                "context_data": {
-                                  "skip_text": "7f 1 omitted because you indicated that you have the age range breakdown data available.",
-                                  "conditional_display": {
-                                    "type": "conditional_display",
-                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                                    "hide_if": {
-                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                                      "values": {
-                                        "interactive": [
-                                          false,
-                                          null
-                                        ],
-                                        "noninteractive": [
-                                          false,
-                                          null
-                                        ]
-                                      }
-                                    }
-                                  }
-                                }
-                              },
-                              {
                                 "type": "fieldset",
                                 "fieldset_type": "datagrid",
                                 "context_data": {
@@ -1617,6 +1585,35 @@
                                   }
                                 },
                                 "questions": [
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-07-f-01",
+                                    "label": "Total for all ages",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    },
+                                    "context_data": {
+                                      "skip_text": "7f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [
+                                              false,
+                                              null
+                                            ],
+                                            "noninteractive": [
+                                              false,
+                                              null
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
                                   {
                                     "type": "question",
                                     "id": "2020-03-c-04-07-f-02",
@@ -1671,35 +1668,6 @@
                     },
                     "questions": [
                       {
-                        "type": "question",
-                        "id": "2020-03-c-04-08-a",
-                        "label": "Total for all ages",
-                        "type": "integer",
-                        "answer": {
-                          "entry": null
-                        },
-                        "context_data": {
-                          "skip_text": "8a omitted because you indicated that you have the age range breakdown data available.",
-                          "conditional_display": {
-                            "type": "conditional_display",
-                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                            "hide_if": {
-                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                              "values": {
-                                "interactive": [
-                                  false,
-                                  null
-                                ],
-                                "noninteractive": [
-                                  false,
-                                  null
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      },
-                      {
                         "type": "fieldset",
                         "fieldset_type": "datagrid",
                         "context_data": {
@@ -1721,6 +1689,35 @@
                           }
                         },
                         "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-08-a",
+                            "label": "Total for all ages",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            },
+                            "context_data": {
+                              "skip_text": "8a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [
+                                      false,
+                                      null
+                                    ],
+                                    "noninteractive": [
+                                      false,
+                                      null
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
                           {
                             "type": "question",
                             "id": "2020-03-c-04-08-b",
@@ -1766,35 +1763,6 @@
                             },
                             "questions": [
                               {
-                                "type": "question",
-                                "id": "2020-03-c-04-08-f-01",
-                                "label": "Total for all ages",
-                                "type": "integer",
-                                "answer": {
-                                  "entry": null
-                                },
-                                "context_data": {
-                                  "skip_text": "8f 1 omitted because you indicated that you have the age range breakdown data available.",
-                                  "conditional_display": {
-                                    "type": "conditional_display",
-                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                                    "hide_if": {
-                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                                      "values": {
-                                        "interactive": [
-                                          false,
-                                          null
-                                        ],
-                                        "noninteractive": [
-                                          false,
-                                          null
-                                        ]
-                                      }
-                                    }
-                                  }
-                                }
-                              },
-                              {
                                 "type": "fieldset",
                                 "fieldset_type": "datagrid",
                                 "context_data": {
@@ -1816,6 +1784,35 @@
                                   }
                                 },
                                 "questions": [
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-08-f-01",
+                                    "label": "Total for all ages",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    },
+                                    "context_data": {
+                                      "skip_text": "8f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [
+                                              false,
+                                              null
+                                            ],
+                                            "noninteractive": [
+                                              false,
+                                              null
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
                                   {
                                     "type": "question",
                                     "id": "2020-03-c-04-08-f-02",
@@ -1878,35 +1875,6 @@
                     },
                     "questions": [
                       {
-                        "type": "question",
-                        "id": "2020-03-c-04-09-a",
-                        "label": "Total for all ages",
-                        "type": "integer",
-                        "answer": {
-                          "entry": null
-                        },
-                        "context_data": {
-                          "skip_text": "9a omitted because you indicated that you have the age range breakdown data available.",
-                          "conditional_display": {
-                            "type": "conditional_display",
-                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                            "hide_if": {
-                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                              "values": {
-                                "interactive": [
-                                  false,
-                                  null
-                                ],
-                                "noninteractive": [
-                                  false,
-                                  null
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      },
-                      {
                         "type": "fieldset",
                         "fieldset_type": "datagrid",
                         "context_data": {
@@ -1928,6 +1896,35 @@
                           }
                         },
                         "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-09-a",
+                            "label": "Total for all ages",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            },
+                            "context_data": {
+                              "skip_text": "9a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [
+                                      false,
+                                      null
+                                    ],
+                                    "noninteractive": [
+                                      false,
+                                      null
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
                           {
                             "type": "question",
                             "id": "2020-03-c-04-09-b",
@@ -1977,35 +1974,6 @@
                     },
                     "questions": [
                       {
-                        "type": "question",
-                        "id": "2020-03-c-04-10-a",
-                        "label": "Total for all ages",
-                        "type": "integer",
-                        "answer": {
-                          "entry": null
-                        },
-                        "context_data": {
-                          "skip_text": "10a omitted because you indicated that you have the age range breakdown data available.",
-                          "conditional_display": {
-                            "type": "conditional_display",
-                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                            "hide_if": {
-                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                              "values": {
-                                "interactive": [
-                                  false,
-                                  null
-                                ],
-                                "noninteractive": [
-                                  false,
-                                  null
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      },
-                      {
                         "type": "fieldset",
                         "fieldset_type": "datagrid",
                         "context_data": {
@@ -2027,6 +1995,35 @@
                           }
                         },
                         "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-10-a",
+                            "label": "Total for all ages",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            },
+                            "context_data": {
+                              "skip_text": "10a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [
+                                      false,
+                                      null
+                                    ],
+                                    "noninteractive": [
+                                      false,
+                                      null
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
                           {
                             "type": "question",
                             "id": "2020-03-c-04-10-b",
@@ -2072,35 +2069,6 @@
                             },
                             "questions": [
                               {
-                                "type": "question",
-                                "id": "2020-03-c-04-10-f-01",
-                                "label": "Total for all ages",
-                                "type": "integer",
-                                "answer": {
-                                  "entry": null
-                                },
-                                "context_data": {
-                                  "skip_text": "10f 1 omitted because you indicated that you have the age range breakdown data available.",
-                                  "conditional_display": {
-                                    "type": "conditional_display",
-                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                                    "hide_if": {
-                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                                      "values": {
-                                        "interactive": [
-                                          false,
-                                          null
-                                        ],
-                                        "noninteractive": [
-                                          false,
-                                          null
-                                        ]
-                                      }
-                                    }
-                                  }
-                                }
-                              },
-                              {
                                 "type": "fieldset",
                                 "fieldset_type": "datagrid",
                                 "context_data": {
@@ -2122,6 +2090,35 @@
                                   }
                                 },
                                 "questions": [
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-10-f-01",
+                                    "label": "Total for all ages",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    },
+                                    "context_data": {
+                                      "skip_text": "10f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [
+                                              false,
+                                              null
+                                            ],
+                                            "noninteractive": [
+                                              false,
+                                              null
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
                                   {
                                     "type": "question",
                                     "id": "2020-03-c-04-10-f-02",
@@ -2176,35 +2173,6 @@
                     },
                     "questions": [
                       {
-                        "type": "question",
-                        "id": "2020-03-c-04-11-a",
-                        "label": "Total for all ages",
-                        "type": "integer",
-                        "answer": {
-                          "entry": null
-                        },
-                        "context_data": {
-                          "skip_text": "11a omitted because you indicated that you have the age range breakdown data available.",
-                          "conditional_display": {
-                            "type": "conditional_display",
-                            "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                            "hide_if": {
-                              "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                              "values": {
-                                "interactive": [
-                                  false,
-                                  null
-                                ],
-                                "noninteractive": [
-                                  false,
-                                  null
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      },
-                      {
                         "type": "fieldset",
                         "fieldset_type": "datagrid",
                         "context_data": {
@@ -2226,6 +2194,35 @@
                           }
                         },
                         "questions": [
+                          {
+                            "type": "question",
+                            "id": "2020-03-c-04-11-a",
+                            "label": "Total for all ages",
+                            "type": "integer",
+                            "answer": {
+                              "entry": null
+                            },
+                            "context_data": {
+                              "skip_text": "11a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [
+                                      false,
+                                      null
+                                    ],
+                                    "noninteractive": [
+                                      false,
+                                      null
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
                           {
                             "type": "question",
                             "id": "2020-03-c-04-11-b",
@@ -2271,35 +2268,6 @@
                             },
                             "questions": [
                               {
-                                "type": "question",
-                                "id": "2020-03-c-04-11-f-01",
-                                "label": "Total for all ages",
-                                "type": "integer",
-                                "answer": {
-                                  "entry": null
-                                },
-                                "context_data": {
-                                  "skip_text": "11f 1 omitted because you indicated that you have the age range breakdown data available.",
-                                  "conditional_display": {
-                                    "type": "conditional_display",
-                                    "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
-                                    "hide_if": {
-                                      "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
-                                      "values": {
-                                        "interactive": [
-                                          false,
-                                          null
-                                        ],
-                                        "noninteractive": [
-                                          false,
-                                          null
-                                        ]
-                                      }
-                                    }
-                                  }
-                                }
-                              },
-                              {
                                 "type": "fieldset",
                                 "fieldset_type": "datagrid",
                                 "context_data": {
@@ -2321,6 +2289,35 @@
                                   }
                                 },
                                 "questions": [
+                                  {
+                                    "type": "question",
+                                    "id": "2020-03-c-04-11-f-01",
+                                    "label": "Total for all ages",
+                                    "type": "integer",
+                                    "answer": {
+                                      "entry": null
+                                    },
+                                    "context_data": {
+                                      "skip_text": "11f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [
+                                              false,
+                                              null
+                                            ],
+                                            "noninteractive": [
+                                              false,
+                                              null
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
                                   {
                                     "type": "question",
                                     "id": "2020-03-c-04-11-f-02",

--- a/docs/section-schemas/backend-section.schema.json
+++ b/docs/section-schemas/backend-section.schema.json
@@ -419,6 +419,7 @@
         "fieldset_type": {
           "enum": [
             "datagrid",
+            "datagrid_with_total",
             "marked",
             "noninteractive_table",
             "sum",


### PR DESCRIPTION
Datagrid with total.
Data's hard to represent,
And so here we are.

Due to some requirements changing and to the implementation of datagrids being too awkward when the fact that the datagrid's presence isn't announced until the second question of the set, we decided to move the first question into the same fieldset as the rest.

This means that datagrids will now ignore some of the `conditional_display` elements of questions within them, until we figure out which of those can be omitted entirely or changed into structures that make more sense.

Also, rename these from `datagrid` to `datagrid_with_total` to indicate that they have this special behavior, since it seems possible that datagrids without it might turn up. Change the schema to reflect the new fieldset type.

None of this is in the documentation, and won't be until we've figured out a few things.

Supports #417.