### PR TITLE
Make the API URL dynamically settable, so it can work in all environments

### DIFF
--- a/frontend/aws/templates/ecs_task_def_ui.json.tpl
+++ b/frontend/aws/templates/ecs_task_def_ui.json.tpl
@@ -5,7 +5,7 @@
     "essential": true,
     "environment": [
       {
-        "name": "API_URL",
+        "name": "REACT_APP_API_URL",
         "value": "${api_url}"
       }
     ],

--- a/frontend/docker-compose.dev.yml
+++ b/frontend/docker-compose.dev.yml
@@ -20,8 +20,9 @@ services:
     networks:
       - data_net
     environment:
-      - API_URL=http://localhost:8000 # This is how a browser would call the api
       - CHOKIDAR_USEPOLLING=true
+      - CHOKIDAR_INTERVAL=3000
+      - REACT_APP_API_URL=http://localhost:8000
     stdin_open: true
     volumes:
       - ./react:/app

--- a/frontend/react/src/actions/initial.js
+++ b/frontend/react/src/actions/initial.js
@@ -6,7 +6,7 @@ export const QUESTION_ANSWERED = "QUESTION ANSWERED";
 export const loadSections = () => {
   return async (dispatch) => {
     const { data } = await axios.get(
-      "//localhost:8000/api/v1/sections/2020/AK"
+      `${process.env.REACT_APP_API_URL}/api/v1/sections/2020/AK`
     );
     dispatch({ type: LOAD_SECTIONS, data });
   };

--- a/frontend/react/src/store/saveMiddleware.js
+++ b/frontend/react/src/store/saveMiddleware.js
@@ -36,7 +36,7 @@ const saveMiddleware = () => {
       isSaving = true;
 
       try {
-        await axios.post(`//localhost:8000/api/v1/sections/2020/AK`, pending);
+        await axios.post(`${process.env.REACT_APP_API_URL}/api/v1/sections/2020/AK`, pending);
 
         // If the save is successful, we can clear out the list of pending
         // saves, because they have been persisted on the server.


### PR DESCRIPTION
- update the Axios calls to use `process.env.REACT_APP_API_URL` for the API URL base
- update the dev Docker configuration to set `REACT_APP_API_URL`
- update a Terraform template to set `REACT_APP_API_URL` in the ui container

**Note:** I used the name `REACT_APP_API_URL` because all environment variables that start with `REACT_APP_` are automatically injected by `create-react-app`, so by using that prefix, we get the environment support for free.

