### PR TITLE
Make the deployment script run the right Django application.

### DIFF
--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     build:
       context: ./api_postgres
       dockerfile: Dockerfile
-    command: gunicorn hello_django.wsgi:application --bind 0.0.0.0:8000
+    command: gunicorn carts.wsgi:application --bind 0.0.0.0:8000
     ports:
       - 8000:8000
     networks:
@@ -30,7 +30,7 @@ services:
     build:
       context: ./api_sqlserver
       dockerfile: Dockerfile
-    command: gunicorn hello_django.wsgi:application --bind 0.0.0.0:8000
+    command: gunicorn carts.wsgi:application --bind 0.0.0.0:8000
     ports:
       - 8001:8000
     networks:


### PR DESCRIPTION
Not hello_django
But rather run the carts app.
It is for the best.

Switch the deployment docker-compose.yml to invoke the carts Django app.