### PR TITLE
Change hello_django to carts in AWS template.

### DIFF
--- a/frontend/aws/templates/ecs_task_def_api_postgres.json.tpl
+++ b/frontend/aws/templates/ecs_task_def_api_postgres.json.tpl
@@ -3,7 +3,7 @@
     "name": "api_postgres",
     "image": "${image}",
     "essential": true,
-    "command": ["gunicorn", "hello_django.wsgi:application", "--bind", "0.0.0.0:8000"],
+    "command": ["gunicorn", "carts.wsgi:application", "--bind", "0.0.0.0:8000"],
     "environment": [
       {
         "name": "POSTGRES_HOST",


### PR DESCRIPTION
Another lurker:
`hello_django` should be `carts`
In this spot as well.

Update the AWS template to use the `carts` name, getting one step closer to having the fronted and backend talk in a deployed environment.