### PR TITLE
A temporary bandaids to try to get the live API back online

### DIFF
--- a/frontend/api_postgres/carts/settings.py
+++ b/frontend/api_postgres/carts/settings.py
@@ -25,7 +25,10 @@ SECRET_KEY = 'uilqxg&r93npq*zt3^h+f4te8#%jh^noc7_r3@&t_ad(8lsr7n'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ["api-postgres-master-2052493048.us-east-1.elb.amazonaws.com"]
+ALLOWED_HOSTS = [
+    'localhost',
+    'api-postgres-master-2052493048.us-east-1.elb.amazonaws.com'
+]
 
 
 # Application definition

--- a/frontend/api_postgres/carts/settings.py
+++ b/frontend/api_postgres/carts/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'uilqxg&r93npq*zt3^h+f4te8#%jh^noc7_r3@&t_ad(8lsr7n'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["api-postgres-master-2052493048.us-east-1.elb.amazonaws.com"]
 
 
 # Application definition

--- a/frontend/api_postgres/carts/settings.py
+++ b/frontend/api_postgres/carts/settings.py
@@ -27,6 +27,8 @@ DEBUG = True
 
 ALLOWED_HOSTS = [
     'localhost',
+    '127.0.0.1',
+    '[::1]',
     'api-postgres-master-2052493048.us-east-1.elb.amazonaws.com'
 ]
 


### PR DESCRIPTION
Temporarily hard-codes the API URL into the list of hosts where the API is allowed to be served from. Ideally this will be written dynamically as part of the deploy step, but to just get it running and make sure it's returning data as expected, slap this bandaid on.

Even with this fix, cartsdemo.cms.gov won't work fully until the API is being served over SSL. It looks to me like it's mostly setup for that, but there's some sort of mismatch where the Django app is listening on port 8000 and maybe the Terraform configuration expects it to be listening on 80. It's also not 100% clear that there's a provisioned certificate. The reason SSL is necessary is because cartsdemo.cms.gov is served over SSL, and web browsers do not allow sites served over SSL to talk to APIs that *aren't* over SSL.