### PR TITLE
Read local file instead of pulling from the API

### DIFF
--- a/frontend/react/src/actions/initial.js
+++ b/frontend/react/src/actions/initial.js
@@ -3,12 +3,15 @@ import axios from "axios";
 export const LOAD_SECTIONS = "LOAD SECTIONS";
 export const QUESTION_ANSWERED = "QUESTION ANSWERED";
 
+const temp__data = require("./initial.json");
+
 export const loadSections = () => {
   return async (dispatch) => {
-    const { data } = await axios.get(
-      `${window._env_.API_POSTGRES_URL}/api/v1/sections/2020/AK`
-    );
-    dispatch({ type: LOAD_SECTIONS, data });
+    // const { data } = await axios.get(
+    //   `${window._env_.API_POSTGRES_URL}/api/v1/sections/2020/AK`
+    // );
+    // dispatch({ type: LOAD_SECTIONS, data });
+    dispatch({ type: LOAD_SECTIONS, data: temp__data });
   };
 };
 

--- a/frontend/react/src/actions/initial.json
+++ b/frontend/react/src/actions/initial.json
@@ -1,0 +1,4406 @@
+[
+  {
+    "contents": {
+      "section": {
+        "id": "2020-01",
+        "type": "section",
+        "year": 2020,
+        "state": "AK",
+        "title": "Program Fees and Policy Changes",
+        "valid": null,
+        "ordinal": 1,
+        "subsections": [
+          {
+            "id": "2020-01-a",
+            "type": "subsection",
+            "parts": [
+              {
+                "id": "2020-01-a-01",
+                "type": "part",
+                "title": "Medicaid Expansion CHIP Enrollment and Premium Fees",
+                "questions": [
+                  {
+                    "id": "2020-01-a-01-01",
+                    "type": "radio",
+                    "label": "Does your program charge an enrollment fee?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-01-a-01-01-a",
+                        "type": "money",
+                        "label": "How much is your enrollment fee?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-01-a-01-01 is no or unanswered; noninteractive: hide if that's no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-01-a-01-01')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-01-a-01-02",
+                    "type": "radio",
+                    "label": "Does your program charge a premium fee?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-01-a-01-02-a",
+                        "type": "radio",
+                        "label": "Are your premium fees tiered by Federal Poverty Level (FPL)?",
+                        "answer": {
+                          "entry": null,
+                          "options": { "No": "no", "Yes": "yes" }
+                        },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-01-a-01-02 is no or unanswered; noninteractive: hide if that's no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-01-a-01-02')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            },
+                            "skip_text": "This question doesn’t apply to your state since you answered NO to Question 2."
+                          }
+                        }
+                      },
+                      {
+                        "id": "2020-01-a-01-02-b",
+                        "type": "ranges",
+                        "label": "Indicate the premium fee ranges and corresponding FPL ranges.",
+                        "answer": {
+                          "entry": null,
+                          "header": "Premium fees",
+                          "entry_max": 0,
+                          "entry_min": 1,
+                          "range_type": ["percentage", "money"],
+                          "range_categories": [
+                            ["FPL starts at", "FPL ends at"],
+                            ["Premium fee starts at", "Premium fee ends at"]
+                          ]
+                        },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-01-a-01-02 is no or unanswered; noninteractive: hide if that's no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-01-a-01-02')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            },
+                            "skip_text": "This question doesn’t apply to your state since you answered NO to Question 2."
+                          }
+                        }
+                      },
+                      {
+                        "id": "2020-01-a-01-02-c",
+                        "type": "money",
+                        "label": "How much is your premium fee?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-01-a-01-02-a is yes or unanswered; noninteractive: hide if that's yes.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-01-a-01-02-a')].answer.entry",
+                              "values": {
+                                "interactive": [null, "yes"],
+                                "noninteractive": ["yes"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-01-a-01-03",
+                    "type": "radio",
+                    "label": "Is the maximum premium fee a family would be charged each year tiered by FPL?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-01-a-01-03-a",
+                        "type": "ranges",
+                        "label": "Indicate the premium fee ranges and corresponding FPL ranges.",
+                        "answer": {
+                          "entry": null,
+                          "header": "Premium fees",
+                          "entry_max": 0,
+                          "entry_min": 1,
+                          "range_type": ["percentage", "money"],
+                          "range_categories": [
+                            ["FPL starts at", "FPL ends at"],
+                            ["Premium fee starts at", "Premium fee ends at"]
+                          ]
+                        },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-01-a-01-03 is no or unanswered; noninteractive: hide if that's no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-01-a-01-03')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            },
+                            "skip_text": "This question doesn’t apply to your state since you answered NO to Question 3."
+                          }
+                        }
+                      },
+                      {
+                        "id": "2020-01-a-01-03-b",
+                        "type": "money",
+                        "label": "What's the maximum premium fee a family would be charged each year?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-01-a-01-03 is yes or unanswered; noninteractive: hide if that's yes.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-01-a-01-03')].answer.entry",
+                              "values": {
+                                "interactive": [null, "yes"],
+                                "noninteractive": ["yes"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-01-a-01-04",
+                    "type": "text_multiline",
+                    "label": "Do your premium fees differ for different CHIP populations beyond FPL (for example, by age)? If so, briefly explain the fee structure breakdown.",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-01-a-01-05",
+                    "hint": "Select all that apply.",
+                    "type": "checkbox",
+                    "label": "Which delivery system(s) do you use?",
+                    "answer": {
+                      "entry": "ffs",
+                      "options": {
+                        "Fee for Service (FFS)": "ffs",
+                        "Managed Care Organization (MCO)": "mco",
+                        "Primary Care Case Management (PCCM)": "pccm"
+                      }
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-01-06",
+                    "type": "text_multiline",
+                    "label": "Which delivery system(s) are available to which CHIP populations? Indicate whether eligibility status, income level, age range, or other criteria determine which delivery system a population receives.",
+                    "answer": { "entry": null }
+                  }
+                ],
+                "context_data": {
+                  "skip_text": "Part 1 only applies to states with a Medicaid expansion CHIP program. Skip to Part 2.",
+                  "show_if_state_program_type_in": [
+                    "medicaid_exp_chip",
+                    "combo"
+                  ]
+                }
+              },
+              {
+                "id": "2020-01-a-02",
+                "type": "part",
+                "title": "Separate CHIP Enrollment and Premium Fees",
+                "questions": [
+                  {
+                    "id": "2020-01-a-02-01",
+                    "type": "radio",
+                    "label": "Does your program charge an enrollment fee?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-01-a-02-01-a",
+                        "type": "money",
+                        "label": "How much is your enrollment fee?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-01-a-02-01 is no or unanswered; noninteractive: hide if that's no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-01-a-02-01')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-01-a-02-02",
+                    "type": "radio",
+                    "label": "Does your program charge a premium fee?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-01-a-02-02-a",
+                        "type": "radio",
+                        "label": "Are your premium fees tiered by Federal Poverty Level (FPL)?",
+                        "answer": {
+                          "entry": null,
+                          "options": { "No": "no", "Yes": "yes" }
+                        },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-01-a-02-02 is no or unanswered; noninteractive: hide if that's no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-01-a-02-02')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            },
+                            "skip_text": "This question doesn’t apply to your state since you answered NO to Question 2."
+                          }
+                        }
+                      },
+                      {
+                        "id": "2020-01-a-02-02-b",
+                        "type": "ranges",
+                        "label": "Indicate the premium fee ranges and corresponding FPL ranges.",
+                        "answer": {
+                          "entry": null,
+                          "header": "Premium fees",
+                          "entry_max": 0,
+                          "entry_min": 1,
+                          "range_type": ["percentage", "money"],
+                          "range_categories": [
+                            ["FPL starts at", "FPL ends at"],
+                            ["Premium fee starts at", "Premium fee ends at"]
+                          ]
+                        },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-01-a-02-02 is no or unanswered; noninteractive: hide if that's no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-01-a-02-02')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            },
+                            "skip_text": "This question doesn’t apply to your state since you answered NO to Question 2."
+                          }
+                        }
+                      },
+                      {
+                        "id": "2020-01-a-02-02-c",
+                        "type": "money",
+                        "label": "How much is your premium fee?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-01-a-02-02-a is yes or unanswered; noninteractive: hide if that's yes.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-01-a-02-02-a')].answer.entry",
+                              "values": {
+                                "interactive": [null, "yes"],
+                                "noninteractive": ["yes"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-01-a-02-03",
+                    "type": "radio",
+                    "label": "Is the maximum premium fee a family would be charged each year tiered by FPL?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-01-a-02-03-a",
+                        "type": "ranges",
+                        "label": "Indicate the premium fee ranges and corresponding FPL ranges.",
+                        "answer": {
+                          "entry": null,
+                          "header": "Premium fees",
+                          "entry_max": 0,
+                          "entry_min": 1,
+                          "range_type": ["percentage", "money"],
+                          "range_categories": [
+                            ["FPL starts at", "FPL ends at"],
+                            ["Premium fee starts at", "Premium fee ends at"]
+                          ]
+                        },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-01-a-02-03 is no or unanswered; noninteractive: hide if that's no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-01-a-02-03')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            },
+                            "skip_text": "This question doesn’t apply to your state since you answered NO to Question 3."
+                          }
+                        }
+                      },
+                      {
+                        "id": "2020-01-a-02-03-b",
+                        "type": "money",
+                        "label": "What's the maximum premium fee a family would be charged each year?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-01-a-02-03 is yes or unanswered; noninteractive: hide if that's yes.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-01-a-02-03')].answer.entry",
+                              "values": {
+                                "interactive": [null, "yes"],
+                                "noninteractive": ["yes"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-01-a-02-04",
+                    "type": "text_multiline",
+                    "label": "Do your premium fees differ for different CHIP populations beyond FPL (for example, by age)? If so, briefly explain the fee structure breakdown.",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-01-a-02-05",
+                    "hint": "Select all that apply.",
+                    "type": "checkbox",
+                    "label": "Which delivery system(s) do you use?",
+                    "answer": {
+                      "entry": null,
+                      "options": {
+                        "Fee for Service (FFS)": "ffs",
+                        "Managed Care Organization (MCO)": "mco",
+                        "Primary Care Case Management (PCCM)": "pccm"
+                      }
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-02-06",
+                    "type": "text_multiline",
+                    "label": "Which delivery system(s) are available to which CHIP populations? Indicate whether eligibility status, income level, age range, or other criteria determine which delivery system a population receives.",
+                    "answer": { "entry": null }
+                  }
+                ],
+                "context_data": {
+                  "skip_text": "Part 2 only applies to states with a separate CHIP program. Skip to Part 3.",
+                  "show_if_state_program_type_in": ["separate_chip", "combo"]
+                }
+              },
+              {
+                "id": "2020-01-a-03",
+                "text": "Indicate any changes you’ve made to your Medicaid expansion CHIP programs/policies in the past federal fiscal year. All changes require a State Plan Amendment (SPA).",
+                "type": "part",
+                "title": "Changes in Medicaid Expansion CHIP Programs and Policies",
+                "questions": [
+                  {
+                    "id": "2020-01-a-03-01",
+                    "type": "radio",
+                    "label": "Have you made any changes to the eligibility determination process?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Eligibility determination process"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-03-02",
+                    "type": "radio",
+                    "label": "Have you made any changes to the eligibility redetermination process?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Eligibility redetermination process"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-03-03",
+                    "hint": "For example: increasing the FPL or income levels, or other eligibility criteria.",
+                    "type": "radio",
+                    "label": "Have you made any changes to the eligibility levels or target populations?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Eligibility levels or target population"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-03-04",
+                    "hint": "For example: adding or removing different types of coverage.",
+                    "type": "radio",
+                    "label": "Have you made any changes to the benefits available to enrolees?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Benefits available to enrollees"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-03-05",
+                    "type": "radio",
+                    "label": "Have you made any changes to the single streamlined application?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Single streamlined application"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-03-06",
+                    "type": "radio",
+                    "label": "Have you made any changes to your outreach efforts?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": { "bullet_text": "Outreach efforts" }
+                  },
+                  {
+                    "id": "2020-01-a-03-07",
+                    "hint": "For example: transitioning from Fee for Service to Managed Care for different CHIP populations.",
+                    "type": "radio",
+                    "label": "Have you made any changes to the delivery system(s)?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": { "bullet_text": "Delivery system(s)" }
+                  },
+                  {
+                    "id": "2020-01-a-03-08",
+                    "hint": "For example: changing amounts, populations, or the collection process.",
+                    "type": "radio",
+                    "label": "Have you made any changes to your cost sharing requirements?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": { "bullet_text": "Cost sharing" }
+                  },
+                  {
+                    "id": "2020-01-a-03-09",
+                    "hint": "For example: changing substitutions or the waiting periods.",
+                    "type": "radio",
+                    "label": "Have you made any changes to the crowd-out policies?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": { "bullet_text": "Crowd-out policies" }
+                  },
+                  {
+                    "id": "2020-01-a-03-10",
+                    "type": "radio",
+                    "label": "Have you made any changes to an enrollment freeze and/or enrollment cap?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Enrollment freeze and/or enrollment cap"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-03-11",
+                    "type": "radio",
+                    "label": "Have you made any changes to the enrollment process for health plan selection?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Enrollment process for health plan selection"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-03-12",
+                    "hint": "For example: changing from the Medicaid Fair Hearing Process to state law.",
+                    "type": "radio",
+                    "label": "Have you made any changes to the protections for applicants and enrollees?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Protections for applicants and enrollees"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-03-13",
+                    "hint": "For example: adding premium assistance or changing the population that receives premium assistance.",
+                    "type": "radio",
+                    "label": "Have you made any changes to premium assistance?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": { "bullet_text": "Premium assistance" }
+                  },
+                  {
+                    "id": "2020-01-a-03-14",
+                    "type": "radio",
+                    "label": "Have you made any changes to the methods and procedures for preventing, investigating, or referring fraud or abuse cases?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Methods and procedures for prevention, investigation, and referral of cases of fraud and abuse"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-03-15",
+                    "hint": "For example: expanding eligibility to pregnant enrollees.",
+                    "type": "radio",
+                    "label": "Have you made any changes to your prenatal care eligibility?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Prenatal care eligibility"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-03-16",
+                    "hint": "For example: extending coverage to pregnant enrollees.",
+                    "type": "radio",
+                    "label": "Have you made any changes to your Pregnant Woman State Plan expansion?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Pregnant Woman State Plan expansion"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-03-17",
+                    "type": "radio",
+                    "label": "Have you made any changes to eligibility for “lawfully residing pregnant women”?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Eligibility for “lawfully residing pregnant women”"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-03-18",
+                    "type": "radio",
+                    "label": "Have you made any changes to eligibility for “lawfully residing children”?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Eligibility for “lawfully residing children”"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-03-19",
+                    "type": "radio",
+                    "label": "Have you made any changes to any other program areas?",
+                    "answer": {
+                      "entry": "no",
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": { "bullet_text": "Other program areas" }
+                  },
+                  {
+                    "id": "2020-01-a-03-20",
+                    "type": "text_multiline",
+                    "label": "Anything else you'd like to add that wasn't already covered?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-01-a-03-21",
+                    "type": "text_multiline",
+                    "label": "Do you plan to submit a SPA to reflect changes to your programs or policies if you haven’t done so already?",
+                    "answer": { "entry": null },
+                    "comment": "Display bulleted list of all 2020-01-a-03 questions 1–19 with yes answers",
+                    "context_data": {
+                      "interactive_conditional": "Show if any 2020-01-a-03 questions 1–19 has a yes answer, hide otherwise.",
+                      "noninteractive_conditional": "Show if any 2020-01-a-03 questions 1–19 has a yes answer, hide otherwise."
+                    }
+                  }
+                ],
+                "context_data": {
+                  "skip_text": "Part 3 only applies to states with a Medicaid expansion CHIP program. Skip to Part 4.",
+                  "show_if_state_program_type_in": [
+                    "medicaid_exp_chip",
+                    "combo"
+                  ]
+                }
+              },
+              {
+                "id": "2020-01-a-04",
+                "text": "Indicate any changes you’ve made to your separate CHIP programs/policies in the past federal fiscal year. All changes require a State Plan Amendment (SPA).",
+                "type": "part",
+                "title": "Changes in Separate CHIP Programs and Policies",
+                "questions": [
+                  {
+                    "id": "2020-01-a-04-01",
+                    "type": "radio",
+                    "label": "Have you made any changes to the eligibility determination process?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Eligibility determination process"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-04-02",
+                    "type": "radio",
+                    "label": "Have you made any changes to the eligibility redetermination process?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Eligibility redetermination process"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-04-03",
+                    "hint": "For example: increasing the FPL or income levels, or other eligibility criteria.",
+                    "type": "radio",
+                    "label": "Have you made any changes to the eligibility levels or target populations?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Eligibility levels or target population"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-04-04",
+                    "hint": "For example: adding or removing different types of coverage.",
+                    "type": "radio",
+                    "label": "Have you made any changes to the benefits available to enrolees?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Benefits available to enrollees"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-04-05",
+                    "type": "radio",
+                    "label": "Have you made any changes to the single streamlined application?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Single streamlined application"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-04-06",
+                    "type": "radio",
+                    "label": "Have you made any changes to your outreach efforts?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": { "bullet_text": "Outreach efforts" }
+                  },
+                  {
+                    "id": "2020-01-a-04-07",
+                    "hint": "For example: transitioning from Fee for Service to Managed Care for different CHIP populations.",
+                    "type": "radio",
+                    "label": "Have you made any changes to the delivery system(s)?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": { "bullet_text": "Delivery system(s)" }
+                  },
+                  {
+                    "id": "2020-01-a-04-08",
+                    "hint": "For example: changing amounts, populations, or the collection process.",
+                    "type": "radio",
+                    "label": "Have you made any changes to your cost sharing requirements?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": { "bullet_text": "Cost sharing" }
+                  },
+                  {
+                    "id": "2020-01-a-04-09",
+                    "hint": "For example: changing substitutions or the waiting periods.",
+                    "type": "radio",
+                    "label": "Have you made any changes to the crowd-out policies?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": { "bullet_text": "Crowd-out policies" }
+                  },
+                  {
+                    "id": "2020-01-a-04-10",
+                    "type": "radio",
+                    "label": "Have you made any changes to an enrollment freeze and/or enrollment cap?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Enrollment freeze and/or enrollment cap"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-04-11",
+                    "type": "radio",
+                    "label": "Have you made any changes to the enrollment process for health plan selection?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Enrollment process for health plan selection"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-04-12",
+                    "hint": "For example: changing from the Medicaid Fair Hearing Process to state law.",
+                    "type": "radio",
+                    "label": "Have you made any changes to the protections for applicants and enrollees?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Protections for applicants and enrollees"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-04-13",
+                    "hint": "For example: adding premium assistance or changing the population that receives premium assistance.",
+                    "type": "radio",
+                    "label": "Have you made any changes to premium assistance?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": { "bullet_text": "Premium assistance" }
+                  },
+                  {
+                    "id": "2020-01-a-04-14",
+                    "type": "radio",
+                    "label": "Have you made any changes to the methods and procedures for preventing, investigating, or referring fraud or abuse cases?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Methods and procedures for prevention, investigation, and referral of cases of fraud and abuse"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-04-15",
+                    "hint": "For example: expanding eligibility to pregnant enrollees.",
+                    "type": "radio",
+                    "label": "Have you made any changes to your prenatal care eligibility?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Prenatal care eligibility"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-04-16",
+                    "hint": "For example: extending coverage to pregnant enrollees.",
+                    "type": "radio",
+                    "label": "Have you made any changes to your Pregnant Woman State Plan expansion?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Pregnant Woman State Plan expansion"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-04-17",
+                    "type": "radio",
+                    "label": "Have you made any changes to eligibility for “lawfully residing pregnant women”?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Eligibility for “lawfully residing pregnant women”"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-04-18",
+                    "type": "radio",
+                    "label": "Have you made any changes to eligibility for “lawfully residing children”?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": {
+                      "bullet_text": "Eligibility for “lawfully residing children”"
+                    }
+                  },
+                  {
+                    "id": "2020-01-a-04-19",
+                    "type": "radio",
+                    "label": "Have you made any changes to any other program areas?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "context_data": { "bullet_text": "Other program areas" }
+                  },
+                  {
+                    "id": "2020-01-a-04-20",
+                    "type": "text_multiline",
+                    "label": "Anything else you'd like to add that wasn't already covered?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-01-a-04-21",
+                    "type": "text_multiline",
+                    "label": "Do you plan to submit a SPA to reflect changes to your programs or policies if you haven’t done so already?",
+                    "answer": { "entry": null },
+                    "comment": "Display bulleted list of all 2020-01-a-04 questions 1–19 with yes answers",
+                    "context_data": {
+                      "interactive_conditional": "Show if any 2020-01-a-04 questions 1–19 has a yes answer, hide otherwise.",
+                      "noninteractive_conditional": "Show if any 2020-01-a-04 questions 1–19 has a yes answer, hide otherwise."
+                    }
+                  }
+                ],
+                "context_data": {
+                  "skip_text": "Part 4 only applies to states with a separate CHIP program.",
+                  "show_if_state_program_type_in": ["separate_chip", "combo"]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "contents": {
+      "section": {
+        "id": "2020-03",
+        "type": "section",
+        "year": 2020,
+        "state": "AK",
+        "title": "Program Operations",
+        "valid": null,
+        "ordinal": 3,
+        "subsections": [
+          {
+            "id": "2020-03-a",
+            "type": "subsection",
+            "parts": [
+              {
+                "id": "2020-03-a-01",
+                "type": "part",
+                "questions": [
+                  {
+                    "id": "2020-03-a-01-01",
+                    "type": "radio",
+                    "label": "Have you changed your outreach methods in the last federal fiscal year?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-03-a-01-01-a",
+                        "type": "text_multiline",
+                        "label": "What are you doing differently?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-a-01-01 is no or unanswered; noninteractive: hide if that's no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-a-01-01')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-03-a-01-02",
+                    "hint": "For example: minorities, immigrants, or children living in rural areas.",
+                    "type": "radio",
+                    "label": "Are you targeting specific populations in your outreach efforts?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-03-a-01-02-a",
+                        "type": "text_multiline",
+                        "label": "Have these efforts been successful? How have you measured the effectiveness of your outreach efforts?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-a-01-02 is no or unanswered; noninteractive: hide if that's no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-a-01-02')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-03-a-01-03",
+                    "hint": "For example: TV, school outreach, or word of mouth.",
+                    "type": "text_multiline",
+                    "label": "What methods have been most effective in reaching low-income, uninsured children?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-a-01-04",
+                    "type": "text_multiline",
+                    "label": "Anything else you’d like to add about your outreach efforts?",
+                    "answer": { "entry": null }
+                  }
+                ]
+              }
+            ],
+            "title": "Program Outreach"
+          },
+          {
+            "id": "2020-03-b",
+            "text": "Substitution of coverage (also known as crowd-out) occurs when someone with private insurance drops their private coverage and substitutes it with publicly funded insurance such as CHIP.",
+            "type": "subsection",
+            "parts": [
+              {
+                "id": "2020-03-b-01",
+                "type": "part",
+                "questions": [
+                  {
+                    "id": "2020-03-b-01-01",
+                    "type": "radio",
+                    "label": "Do you track the number of children who have access to private insurance?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "N/A": "na", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-03-b-01-01-a",
+                        "type": "text_multiline",
+                        "label": "What percent of children who enrolled in CHIP had access to private health insurance at the time of application?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-b-01-01 is no, N/A, or unanswered; noninteractive: hide if that's no or N/A.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-b-01-01')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no", "na"],
+                                "noninteractive": ["no", "na"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-03-b-01-02",
+                    "type": "radio",
+                    "label": "Do you use a database to match children to their private insurance status? ",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "N/A": "na", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-03-b-01-02-a",
+                        "type": "text_multiline",
+                        "label": "Which database do you use?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-b-01-02 is no, N/A, or unanswered; noninteractive: hide if that's no or N/A.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-b-01-02')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no", "na"],
+                                "noninteractive": ["no", "na"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "fieldset",
+                    "questions": [
+                      {
+                        "id": "2020-03-b-01-03",
+                        "type": "radio",
+                        "label": "Does your S-CHIP program require a child to be uninsured for a minimum amount of time before enrollment (“the waiting period”)?",
+                        "answer": {
+                          "entry": null,
+                          "options": { "No": "no", "N/A": "na", "Yes": "yes" }
+                        },
+                        "questions": [
+                          {
+                            "type": "fieldset",
+                            "questions": [
+                              {
+                                "id": "2020-03-b-01-03-a",
+                                "type": "text_multiline",
+                                "label": "How long is the waiting period?",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-b-01-03-b",
+                                "type": "text_multiline",
+                                "label": "Which populations does the waiting period apply to?  (Include FPLs for each group.)",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-b-01-03-c",
+                                "type": "text_multiline",
+                                "label": "What exemptions apply to the waiting period?",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-b-01-03-c",
+                                "type": "text_multiline",
+                                "label": "What percent of children subject to the waiting period meet an exemption?",
+                                "answer": { "entry": null }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "id": "2020-03-b-01-04",
+                        "type": "text_multiline",
+                        "label": "What percent of children screened for S-CHIP eligibility cannot be enrolled because they have group health plan coverage?",
+                        "answer": { "entry": null }
+                      }
+                    ],
+                    "context_data": {
+                      "skip_text": "Some questions omitted because they do not apply to your program.",
+                      "show_if_state_program_type_in": [
+                        "separate_chip",
+                        "combo"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "2020-03-b-01-05",
+                    "type": "text_multiline",
+                    "label": "Anything else you’d like to add about crowd-out that wasn’t already covered? Did you run into any limitations when collecting data?",
+                    "answer": { "entry": null }
+                  }
+                ]
+              }
+            ],
+            "title": "Substitution of Coverage (Crowd-out)"
+          },
+          {
+            "id": "2020-03-c",
+            "text": "",
+            "type": "subsection",
+            "parts": [
+              {
+                "id": "2020-03-c-01",
+                "type": "part",
+                "title": "Eligibility Renewal and Retention",
+                "questions": [
+                  {
+                    "id": "2020-03-c-01-01",
+                    "type": "radio",
+                    "label": "Does your state provide presumptive eligibility, allowing children who are presumed to be eligible to access CHIP services?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "N/A": "na", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "questions": [
+                          {
+                            "id": "2020-03-c-01-01-a",
+                            "type": "percentage",
+                            "label": "What percent of children are presumptively enrolled in CHIP pending a full eligibility determination?",
+                            "answer": { "entry": null }
+                          },
+                          {
+                            "id": "2020-03-c-01-01-b",
+                            "type": "percentage",
+                            "label": "Of the children who are presumptively enrolled, what percent are determined fully eligible and enrolled in the program?",
+                            "answer": { "entry": null }
+                          }
+                        ],
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide these two subquestions if the answer to 2020-03-c-01-01 is no or N/A.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-01-01')].answer.entry",
+                              "values": {
+                                "interactive": ["no", "na", null],
+                                "noninteractive": ["no", "na"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-03-c-01-02",
+                    "type": "radio",
+                    "label": "In an effort to retain more children in CHIP, do you conduct follow-up communication with families through caseworkers and outreach workers?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    }
+                  },
+                  {
+                    "id": "2020-03-c-01-03",
+                    "type": "radio",
+                    "label": "Do you send renewal reminder notices to families?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "questions": [
+                          {
+                            "id": "2020-03-c-01-03-a",
+                            "type": "text",
+                            "label": "How many notices do you send to families before disenrolling a child from the program?",
+                            "answer": { "entry": null }
+                          },
+                          {
+                            "id": "2020-03-c-01-03-b",
+                            "type": "text",
+                            "label": "How many days before the end of the eligibility period did you send reminder notices to families?",
+                            "answer": { "entry": null }
+                          }
+                        ],
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide these two subquestions if the answer to 2020-03-c-01-03 is no or N/A.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-c-01-03')].answer.entry",
+                              "values": {
+                                "interactive": ["no", null],
+                                "noninteractive": ["no"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-03-c-01-04",
+                    "type": "text_multiline",
+                    "label": "What else have you done to simplify the eligibility renewal process for families in order to increase retention?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-c-01-05",
+                    "type": "text_multiline",
+                    "label": "Which retention strategies have you found to be most effective?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-c-01-06",
+                    "type": "text_multiline",
+                    "label": "How do you measure the effectiveness of your retention strategies? What data sources and methodology do you use to track retention?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-c-01-07",
+                    "type": "text_multiline",
+                    "label": "Anything else you’d like to add that wasn’t already covered?",
+                    "answer": { "entry": null }
+                  }
+                ]
+              },
+              {
+                "id": "2020-03-c-02",
+                "type": "part",
+                "title": "Eligibility Denials for First-time Applicants (Not Redetermination)",
+                "questions": [
+                  {
+                    "id": "2020-03-c-02-01",
+                    "hint": "This only applies to denials for first-time CHIP applicants—don’t include applicants being considered for redetermination.",
+                    "type": "integer",
+                    "label": "How many first-time applicants were denied CHIP coverage in the last federal fiscal year?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-c-02-02",
+                    "hint": "For example: They were denied because of an incomplete application, missing documentation, or a missing enrollment fee.",
+                    "type": "integer",
+                    "label": "How many first-time applicants were denied CHIP coverage for procedural reasons?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-c-02-03",
+                    "hint": "For example: They were denied because their income was too high or too low, they were determined eligible for Medicaid instead, or they had other coverage available.",
+                    "type": "integer",
+                    "label": "How many first-time applicants were denied CHIP coverage for eligibility reasons?",
+                    "answer": { "entry": null },
+                    "questions": [
+                      {
+                        "id": "2020-03-c-02-03-a",
+                        "hint": "For example: They were denied because their income was too high or too low, they were determined eligible for Medicaid instead, or they had other coverage available.",
+                        "type": "integer",
+                        "label": "How many first-time applicants were denied CHIP coverage for eligibility reasons?",
+                        "answer": { "entry": null }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-03-c-02-04",
+                    "type": "integer",
+                    "label": "How many applicants were denied CHIP coverage for other reasons?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-c-02-05",
+                    "type": "text_multiline",
+                    "label": "Did you have any limitations in collecting this data?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "hint": "This table is auto-populated with the data you entered above.",
+                    "type": "fieldset",
+                    "label": "Table: Denials for First-Time Applicants",
+                    "questions": [],
+                    "fieldset_info": {
+                      "rows": [
+                        [
+                          { "contents": "Total denials" },
+                          {
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-02-01')].answer.entry"
+                            ]
+                          },
+                          { "contents": "100%" }
+                        ],
+                        [
+                          { "contents": "Denied for procedural reasons" },
+                          {
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-02-02')].answer.entry"
+                            ]
+                          },
+                          {
+                            "actions": ["percentage"],
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-02-02')].answer.entry",
+                              "$..*[?(@.id=='2020-03-c-02-01')].answer.entry"
+                            ]
+                          }
+                        ],
+                        [
+                          { "contents": "Denied for eligibility reasons" },
+                          {
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-02-03')].answer.entry"
+                            ]
+                          },
+                          {
+                            "actions": ["percentage"],
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-02-03')].answer.entry",
+                              "$..*[?(@.id=='2020-03-c-02-01')].answer.entry"
+                            ]
+                          }
+                        ],
+                        [
+                          { "contents": "Denials for other reasons" },
+                          {
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-02-04')].answer.entry"
+                            ]
+                          },
+                          {
+                            "actions": ["percentage"],
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-02-04')].answer.entry",
+                              "$..*[?(@.id=='2020-03-c-02-01')].answer.entry"
+                            ]
+                          }
+                        ]
+                      ],
+                      "headers": [
+                        { "contents": "" },
+                        { "contents": "Number" },
+                        { "contents": "Percent" }
+                      ]
+                    },
+                    "fieldset_type": "synthesized_table"
+                  }
+                ]
+              },
+              {
+                "id": "2020-03-c-03",
+                "text": "Redetermination is the process of redetermining whether a child is eligible to renew in CHIP every 12 months, assuming children haven’t already aged out of the program. Families must resubmit their income each year to determine if they still qualify for the program.",
+                "type": "part",
+                "title": "Eligibility for Redetermination in CHIP",
+                "questions": [
+                  {
+                    "id": "2020-03-c-03-01",
+                    "type": "integer",
+                    "label": "How many children were eligible for redetermination in CHIP in the last federal fiscal year?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-c-03-02",
+                    "type": "integer",
+                    "label": "Of the eligible children, how many were then screened for redetermination?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-c-03-03",
+                    "type": "integer",
+                    "label": "How many children were retained in CHIP after the redetermination process?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-c-03-04",
+                    "type": "integer",
+                    "label": "How many children were disenrolled in CHIP after the redetermination process?",
+                    "answer": { "entry": null, "readonly": true },
+                    "comment": "This is very tricky; having 4 apparently be a question the user can enter but also be the total of its subquestions presents issues. Which value takes precedence is one of them. Another is that in addition to being something that apparently can be entered by the user, it is both the output for a synthesized_value operation (sum 4a, 4b, and 4c) and the source for another synthesized_value operation (in the two tables below, where it's one of the inputs to the percentage action). My suggestion is to have 4 be a normal field of its own and have a hint next to it that sums the subquestion answers and tells the user the value they enter for 4 should equal that value. Not ideal, but otherwise we seem to have to either use custom frontend code or support way more nonsense in the data structure spec than we do already.",
+                    "questions": [
+                      {
+                        "hint": "The answer to 4 should be equal to the sum of a, b, and c below: ",
+                        "type": "fieldset",
+                        "questions": [],
+                        "fieldset_info": {
+                          "actions": ["sum"],
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-03-04-a')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-03-04-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-03-04-c')].answer.entry"
+                          ]
+                        },
+                        "fieldset_type": "synthesized_value"
+                      },
+                      {
+                        "id": "2020-03-c-03-04-a",
+                        "hint": "For example: They were denied because of an incomplete application, missing documentation, or a missing enrollment fee.",
+                        "type": "integer",
+                        "label": "How many children were disenrolled for procedural reasons?",
+                        "answer": { "entry": null }
+                      },
+                      {
+                        "id": "2020-03-c-03-04-b",
+                        "hint": "For example: They were denied because their income was too high or too low, they were determined eligible for Medicaid instead, or they had other coverage available.",
+                        "type": "integer",
+                        "label": "How many children were disenrolled for eligibility reasons?",
+                        "answer": { "entry": null }
+                      },
+                      {
+                        "id": "2020-03-c-03-04-c",
+                        "type": "integer",
+                        "label": "How many children were disenrolled for other reasons?",
+                        "answer": { "entry": null }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-03-c-03-05",
+                    "type": "text_multiline",
+                    "label": "Did you have any limitations in collecting this data?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "hint": "These tables are auto-populated with the data you entered above.",
+                    "type": "fieldset",
+                    "label": "Table: Enrollment Data for CHIP Redetermination",
+                    "questions": [],
+                    "fieldset_info": {
+                      "rows": [
+                        [
+                          {
+                            "contents": "Children screened for redetermination"
+                          },
+                          {
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-03-02')].answer.entry"
+                            ]
+                          },
+                          { "contents": "100%" }
+                        ],
+                        [
+                          {
+                            "contents": "Children retained after redetermination"
+                          },
+                          {
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-03-03')].answer.entry"
+                            ]
+                          },
+                          {
+                            "actions": ["percentage"],
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-03-03')].answer.entry",
+                              "$..*[?(@.id=='2020-03-c-03-02')].answer.entry"
+                            ]
+                          }
+                        ],
+                        [
+                          {
+                            "contents": "Children disenrolled after redetermination"
+                          },
+                          {
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-03-04')].answer.entry"
+                            ]
+                          },
+                          {
+                            "actions": ["percentage"],
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-03-04')].answer.entry",
+                              "$..*[?(@.id=='2020-03-c-03-02')].answer.entry"
+                            ]
+                          }
+                        ]
+                      ],
+                      "headers": [
+                        { "contents": "" },
+                        { "contents": "Number" },
+                        { "contents": "Percent" }
+                      ]
+                    },
+                    "fieldset_type": "synthesized_table"
+                  },
+                  {
+                    "type": "fieldset",
+                    "label": "Table: Disenrollment Data for CHIP Redetermination",
+                    "comment": "This is assuming that we make the user manually enter the answer to question 4; otherwise we don't currently have a way to support this functionality; see the comment on question 4 above.",
+                    "questions": [],
+                    "fieldset_info": {
+                      "rows": [
+                        [
+                          {
+                            "contents": "Children disenrolled after redetermination"
+                          },
+                          {
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-03-04')].answer.entry"
+                            ]
+                          },
+                          { "contents": "100%" }
+                        ],
+                        [
+                          {
+                            "contents": "Children disenrolled for procedural reasons"
+                          },
+                          {
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-03-04-a')].answer.entry"
+                            ]
+                          },
+                          {
+                            "actions": ["percentage"],
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-03-04-a')].answer.entry",
+                              "$..*[?(@.id=='2020-03-c-03-04')].answer.entry"
+                            ]
+                          }
+                        ],
+                        [
+                          {
+                            "contents": "Children disenrolled for eligibility reasons"
+                          },
+                          {
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-03-04-b')].answer.entry"
+                            ]
+                          },
+                          {
+                            "actions": ["percentage"],
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-03-04-b')].answer.entry",
+                              "$..*[?(@.id=='2020-03-c-03-04')].answer.entry"
+                            ]
+                          }
+                        ],
+                        [
+                          {
+                            "contents": "Children disenrolled for other reasons"
+                          },
+                          {
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-03-04-c')].answer.entry"
+                            ]
+                          },
+                          {
+                            "actions": ["percentage"],
+                            "targets": [
+                              "$..*[?(@.id=='2020-03-c-03-04-c')].answer.entry",
+                              "$..*[?(@.id=='2020-03-c-03-04')].answer.entry"
+                            ]
+                          }
+                        ]
+                      ],
+                      "headers": [
+                        { "contents": "" },
+                        { "contents": "Number" },
+                        { "contents": "Percent" }
+                      ]
+                    },
+                    "fieldset_type": "synthesized_table"
+                  }
+                ]
+              },
+              {
+                "id": "2020-03-c-04",
+                "text": "Tracking a cohort of children enrolled in CHIP (Title XXI) will measure how long a specific group stays enrolled over a 18-month period. This information is required by Section 402(a) of CHIPRA.\n\nTo track your cohort, identify a group of children ages 0 to 17 years who are newly enrolled in CHIP (Medicaid Expansion CHIP, Separate CHIP, or both) as of the first three months (Jan-Mar) of the last federal fiscal year.\n\nChildren must be 16.5 years or younger when they enroll to ensure they don’t age out of the program by the end of the 18-month tracking period.\n\nIf your eligibility system doesn’t have the ability to track a cohort, you may need to use a unique identifier or flag to track each child over the 18-month period.",
+                "type": "part",
+                "title": "Tracking a CHIP cohort over 18 months",
+                "questions": [
+                  {
+                    "type": "fieldset",
+                    "label": "January – March 2019 (start of the cohort)",
+                    "questions": [
+                      {
+                        "hint": "Only include children that weren’t enrolled in CHIP the previous month. (For example: Children who enrolled in January 2020 are “newly enrolled” if they weren’t enrolled in the CHIP in December 2019.)",
+                        "type": "fieldset",
+                        "label": "How many children were newly enrolled in CHIP between January and March of the last federal fiscal year?",
+                        "comment": "The “sum” question, that they answer if they don't have the breakdowns, can't really be a true top-level question, because then we couldn't hide it in the case where the breakdown data is available. So it has to be a subquestion, meaning that the top-level question isn't real and can't actually be answered. This introduces the need for the special fieldset used here; see the schema docs for more details.",
+                        "questions": [
+                          {
+                            "type": "fieldset",
+                            "comment": "Yes, this is a marked fieldset, i.e. a fieldset mainly pretending to be a question for the purposes of the list markers, immediately followed by an unmarked_descendants fieldset used so that the age range breakdown question gets to pretend to not be a question for the purposes of the list markers.",
+                            "questions": [
+                              {
+                                "id": "2020-03-c-04-01-unmarked_descendants",
+                                "type": "checkbox_flag",
+                                "label": "I don’t have data for the individual age groups. I’ll report data for the total number for all age groups (0-18 years) instead.",
+                                "answer": {
+                                  "entry": null,
+                                  "options": { "type": "boolean" }
+                                }
+                              }
+                            ],
+                            "fieldset_type": "unmarked_descendants"
+                          },
+                          {
+                            "id": "2020-03-c-04-01-a",
+                            "type": "integer",
+                            "label": "Total for all ages",
+                            "answer": { "entry": null },
+                            "comment": "This is the first real question so far in this part…",
+                            "context_data": {
+                              "skip_text": "1a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [false, null],
+                                    "noninteractive": [false, null]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "questions": [
+                              {
+                                "id": "2020-03-c-04-01-b",
+                                "type": "integer",
+                                "label": "0–1 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-01-c",
+                                "type": "integer",
+                                "label": "1–5 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-01-d",
+                                "type": "integer",
+                                "label": "6–12 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-01-e",
+                                "type": "integer",
+                                "label": "13–18 year olds",
+                                "answer": { "entry": null }
+                              }
+                            ],
+                            "context_data": {
+                              "skip_text": "1b–1e omitted because you indicated that you don't have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [true],
+                                    "noninteractive": [true]
+                                  }
+                                }
+                              }
+                            },
+                            "fieldset_type": "datagrid"
+                          }
+                        ],
+                        "fieldset_info": { "id": "2020-03-c-04-01" },
+                        "fieldset_type": "marked"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "fieldset",
+                    "label": "July – September 2019 (6 months later)",
+                    "questions": [
+                      {
+                        "hint": "Only include children that didn’t have a break in coverage during the six-month period.",
+                        "type": "fieldset",
+                        "label": "How many children were still continuously enrolled in CHIP six months later?",
+                        "questions": [
+                          {
+                            "id": "2020-03-c-04-02-a",
+                            "type": "integer",
+                            "label": "Total for all ages",
+                            "answer": { "entry": null },
+                            "context_data": {
+                              "skip_text": "2a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [false, null],
+                                    "noninteractive": [false, null]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "questions": [
+                              {
+                                "id": "2020-03-c-04-02-b",
+                                "type": "integer",
+                                "label": "0–1 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-02-c",
+                                "type": "integer",
+                                "label": "1–5 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-02-d",
+                                "type": "integer",
+                                "label": "6–12 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-02-e",
+                                "type": "integer",
+                                "label": "13–18 year olds",
+                                "answer": { "entry": null }
+                              }
+                            ],
+                            "context_data": {
+                              "skip_text": "2b–2e omitted because you indicated that don't you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [true],
+                                    "noninteractive": [true]
+                                  }
+                                }
+                              }
+                            },
+                            "fieldset_type": "datagrid"
+                          }
+                        ],
+                        "fieldset_info": { "id": "2020-03-c-04-02" },
+                        "fieldset_type": "marked"
+                      },
+                      {
+                        "type": "fieldset",
+                        "label": "How many children had a break in CHIP coverage but were re-enrolled in CHIP six months later?",
+                        "questions": [
+                          {
+                            "id": "2020-03-c-04-03-a",
+                            "type": "integer",
+                            "label": "Total for all ages",
+                            "answer": { "entry": null },
+                            "context_data": {
+                              "skip_text": "3a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [false, null],
+                                    "noninteractive": [false, null]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "questions": [
+                              {
+                                "id": "2020-03-c-04-03-b",
+                                "type": "integer",
+                                "label": "0–1 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-03-c",
+                                "type": "integer",
+                                "label": "1–5 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-03-d",
+                                "type": "integer",
+                                "label": "6–12 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-03-e",
+                                "type": "integer",
+                                "label": "13–18 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "type": "fieldset",
+                                "label": "How many children had a break in CHIP coverage but were re-enrolled in Medicaid six months later?",
+                                "questions": [
+                                  {
+                                    "id": "2020-03-c-04-03-f-01",
+                                    "type": "integer",
+                                    "label": "Total for all ages",
+                                    "answer": { "entry": null },
+                                    "context_data": {
+                                      "skip_text": "3f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [false, null],
+                                            "noninteractive": [false, null]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "fieldset",
+                                    "questions": [
+                                      {
+                                        "id": "2020-03-c-04-03-f-02",
+                                        "type": "integer",
+                                        "label": "0–1 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-03-f-03",
+                                        "type": "integer",
+                                        "label": "1–5 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-03-f-04",
+                                        "type": "integer",
+                                        "label": "6–12 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-03-f-05",
+                                        "type": "integer",
+                                        "label": "13–18 year olds",
+                                        "answer": { "entry": null }
+                                      }
+                                    ],
+                                    "context_data": {
+                                      "skip_text": "3f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [true],
+                                            "noninteractive": [true]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "fieldset_type": "datagrid"
+                                  }
+                                ],
+                                "fieldset_info": { "id": "2020-03-c-04-03-f" },
+                                "fieldset_type": "marked"
+                              }
+                            ],
+                            "context_data": {
+                              "skip_text": "3b–3e omitted because you indicated that you don't have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [true],
+                                    "noninteractive": [true]
+                                  }
+                                }
+                              }
+                            },
+                            "fieldset_type": "datagrid"
+                          }
+                        ],
+                        "fieldset_info": { "id": "2020-03-c-04-03" },
+                        "fieldset_type": "marked"
+                      },
+                      {
+                        "hint": "Possible reasons for disenrollment:\n•  Transferred to another health insurance program other than CHIP.\n•  Didn’t meet eligibility criteria anymore.\n•  Didn’t complete documentation.\n•  Didn’t pay a premium or enrollment fee.",
+                        "type": "fieldset",
+                        "label": "How many children were no longer enrolled in CHIP at the end of the six-month period?",
+                        "questions": [
+                          {
+                            "id": "2020-03-c-04-04-a",
+                            "type": "integer",
+                            "label": "Total for all ages",
+                            "answer": { "entry": null },
+                            "context_data": {
+                              "skip_text": "4a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [false, null],
+                                    "noninteractive": [false, null]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "questions": [
+                              {
+                                "id": "2020-03-c-04-04-b",
+                                "type": "integer",
+                                "label": "0–1 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-04-c",
+                                "type": "integer",
+                                "label": "1–5 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-04-d",
+                                "type": "integer",
+                                "label": "6–12 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-04-e",
+                                "type": "integer",
+                                "label": "13–18 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "type": "fieldset",
+                                "label": "How many children were no longer enrolled in CHIP but enrolled in Medicaid six months later?",
+                                "questions": [
+                                  {
+                                    "id": "2020-03-c-04-04-f-01",
+                                    "type": "integer",
+                                    "label": "Total for all ages",
+                                    "answer": { "entry": null },
+                                    "context_data": {
+                                      "skip_text": "4f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [false, null],
+                                            "noninteractive": [false, null]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "fieldset",
+                                    "questions": [
+                                      {
+                                        "id": "2020-03-c-04-04-f-02",
+                                        "type": "integer",
+                                        "label": "0–1 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-04-f-03",
+                                        "type": "integer",
+                                        "label": "1–5 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-04-f-04",
+                                        "type": "integer",
+                                        "label": "6–12 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-04-f-05",
+                                        "type": "integer",
+                                        "label": "13–18 year olds",
+                                        "answer": { "entry": null }
+                                      }
+                                    ],
+                                    "context_data": {
+                                      "skip_text": "4f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [true],
+                                            "noninteractive": [true]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "fieldset_type": "datagrid"
+                                  }
+                                ],
+                                "fieldset_info": { "id": "2020-03-c-04-04-f" },
+                                "fieldset_type": "marked"
+                              }
+                            ],
+                            "context_data": {
+                              "skip_text": "4b–4e omitted because you indicated that you don't have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [true],
+                                    "noninteractive": [true]
+                                  }
+                                }
+                              }
+                            },
+                            "fieldset_type": "datagrid"
+                          }
+                        ],
+                        "fieldset_info": { "id": "2020-03-c-04-04" },
+                        "fieldset_type": "marked"
+                      },
+                      {
+                        "id": "2020-03-c-04-05",
+                        "type": "text_multiline",
+                        "label": "Anything else you’d like to add about your data?",
+                        "answer": { "entry": null }
+                      }
+                    ]
+                  },
+                  {
+                    "hint": "Next year you’ll submit the rest of your data at 12 months and 18 months later of tracking your cohort",
+                    "type": "fieldset",
+                    "label": "January – March 2020 (12 months later)",
+                    "questions": [
+                      {
+                        "hint": "Only include children that didn’t have a break in coverage during the 12-month period.",
+                        "type": "fieldset",
+                        "label": "How many children were still continuously enrolled in CHIP 12 months later?",
+                        "questions": [
+                          {
+                            "id": "2020-03-c-04-06-a",
+                            "type": "integer",
+                            "label": "Total for all ages",
+                            "answer": { "entry": null },
+                            "context_data": {
+                              "skip_text": "6a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [false, null],
+                                    "noninteractive": [false, null]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "questions": [
+                              {
+                                "id": "2020-03-c-04-06-b",
+                                "type": "integer",
+                                "label": "0–1 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-06-c",
+                                "type": "integer",
+                                "label": "1–5 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-06-d",
+                                "type": "integer",
+                                "label": "6–12 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-06-e",
+                                "type": "integer",
+                                "label": "13–18 year olds",
+                                "answer": { "entry": null }
+                              }
+                            ],
+                            "context_data": {
+                              "skip_text": "6b–6e omitted because you indicated that don't you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [true],
+                                    "noninteractive": [true]
+                                  }
+                                }
+                              }
+                            },
+                            "fieldset_type": "datagrid"
+                          }
+                        ],
+                        "fieldset_info": { "id": "2020-03-c-04-06" },
+                        "fieldset_type": "marked"
+                      },
+                      {
+                        "type": "fieldset",
+                        "label": "How many children had a break in CHIP coverage but were re-enrolled in CHIP 12 months later?",
+                        "questions": [
+                          {
+                            "id": "2020-03-c-04-07-a",
+                            "type": "integer",
+                            "label": "Total for all ages",
+                            "answer": { "entry": null },
+                            "context_data": {
+                              "skip_text": "7a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [false, null],
+                                    "noninteractive": [false, null]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "questions": [
+                              {
+                                "id": "2020-03-c-04-07-b",
+                                "type": "integer",
+                                "label": "0–1 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-07-c",
+                                "type": "integer",
+                                "label": "1–5 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-07-d",
+                                "type": "integer",
+                                "label": "6–12 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-07-e",
+                                "type": "integer",
+                                "label": "13–18 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "type": "fieldset",
+                                "label": "How many children had a break in CHIP coverage but were re-enrolled in Medicaid 12 months later?",
+                                "questions": [
+                                  {
+                                    "id": "2020-03-c-04-07-f-01",
+                                    "type": "integer",
+                                    "label": "Total for all ages",
+                                    "answer": { "entry": null },
+                                    "context_data": {
+                                      "skip_text": "7f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [false, null],
+                                            "noninteractive": [false, null]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "fieldset",
+                                    "questions": [
+                                      {
+                                        "id": "2020-03-c-04-07-f-02",
+                                        "type": "integer",
+                                        "label": "0–1 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-07-f-03",
+                                        "type": "integer",
+                                        "label": "1–5 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-07-f-04",
+                                        "type": "integer",
+                                        "label": "6–12 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-07-f-05",
+                                        "type": "integer",
+                                        "label": "13–18 year olds",
+                                        "answer": { "entry": null }
+                                      }
+                                    ],
+                                    "context_data": {
+                                      "skip_text": "7f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [true],
+                                            "noninteractive": [true]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "fieldset_type": "datagrid"
+                                  }
+                                ],
+                                "fieldset_info": { "id": "2020-03-c-04-07-f" },
+                                "fieldset_type": "marked"
+                              }
+                            ],
+                            "context_data": {
+                              "skip_text": "7b–7e omitted because you indicated that you don't have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [true],
+                                    "noninteractive": [true]
+                                  }
+                                }
+                              }
+                            },
+                            "fieldset_type": "datagrid"
+                          }
+                        ],
+                        "fieldset_info": { "id": "2020-03-c-04-07" },
+                        "fieldset_type": "marked"
+                      },
+                      {
+                        "hint": "Possible reasons for disenrollment:\n•  Transferred to another health insurance program other than CHIP.\n•  Didn’t meet eligibility criteria anymore.\n•  Didn’t complete documentation.\n•  Didn’t pay a premium or enrollment fee.",
+                        "type": "fieldset",
+                        "label": "How many children were no longer enrolled in CHIP at the end of the 12-month period?",
+                        "questions": [
+                          {
+                            "id": "2020-03-c-04-08-a",
+                            "type": "integer",
+                            "label": "Total for all ages",
+                            "answer": { "entry": null },
+                            "context_data": {
+                              "skip_text": "8a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [false, null],
+                                    "noninteractive": [false, null]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "questions": [
+                              {
+                                "id": "2020-03-c-04-08-b",
+                                "type": "integer",
+                                "label": "0–1 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-08-c",
+                                "type": "integer",
+                                "label": "1–5 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-08-d",
+                                "type": "integer",
+                                "label": "6–12 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-08-e",
+                                "type": "integer",
+                                "label": "13–18 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "type": "fieldset",
+                                "label": "How many children were no longer enrolled in CHIP at the end of the 12-month period, and enrolled in Medicaid instead?",
+                                "questions": [
+                                  {
+                                    "id": "2020-03-c-04-08-f-01",
+                                    "type": "integer",
+                                    "label": "Total for all ages",
+                                    "answer": { "entry": null },
+                                    "context_data": {
+                                      "skip_text": "8f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [false, null],
+                                            "noninteractive": [false, null]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "fieldset",
+                                    "questions": [
+                                      {
+                                        "id": "2020-03-c-04-08-f-02",
+                                        "type": "integer",
+                                        "label": "0–1 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-08-f-03",
+                                        "type": "integer",
+                                        "label": "1–5 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-08-f-04",
+                                        "type": "integer",
+                                        "label": "6–12 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-08-f-05",
+                                        "type": "integer",
+                                        "label": "13–18 year olds",
+                                        "answer": { "entry": null }
+                                      }
+                                    ],
+                                    "context_data": {
+                                      "skip_text": "8f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [true],
+                                            "noninteractive": [true]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "fieldset_type": "datagrid"
+                                  }
+                                ],
+                                "fieldset_info": { "id": "2020-03-c-04-08-f" },
+                                "fieldset_type": "marked"
+                              }
+                            ],
+                            "context_data": {
+                              "skip_text": "8b–8e omitted because you indicated that you don't have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [true],
+                                    "noninteractive": [true]
+                                  }
+                                }
+                              }
+                            },
+                            "fieldset_type": "datagrid"
+                          }
+                        ],
+                        "fieldset_info": { "id": "2020-03-c-04-08" },
+                        "fieldset_type": "marked"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "fieldset",
+                    "label": "July – September 2020 (18 months later)",
+                    "questions": [
+                      {
+                        "hint": "Only include children that didn’t have a break in coverage during the 18-month period.",
+                        "type": "fieldset",
+                        "label": "How many children were still continuously enrolled in CHIP 18 months later?",
+                        "questions": [
+                          {
+                            "id": "2020-03-c-04-09-a",
+                            "type": "integer",
+                            "label": "Total for all ages",
+                            "answer": { "entry": null },
+                            "context_data": {
+                              "skip_text": "9a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [false, null],
+                                    "noninteractive": [false, null]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "questions": [
+                              {
+                                "id": "2020-03-c-04-09-b",
+                                "type": "integer",
+                                "label": "0–1 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-09-c",
+                                "type": "integer",
+                                "label": "1–5 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-09-d",
+                                "type": "integer",
+                                "label": "6–12 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-09-e",
+                                "type": "integer",
+                                "label": "13–18 year olds",
+                                "answer": { "entry": null }
+                              }
+                            ],
+                            "context_data": {
+                              "skip_text": "9b–9e omitted because you indicated that don't you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [true],
+                                    "noninteractive": [true]
+                                  }
+                                }
+                              }
+                            },
+                            "fieldset_type": "datagrid"
+                          }
+                        ],
+                        "fieldset_info": { "id": "2020-03-c-04-09" },
+                        "fieldset_type": "marked"
+                      },
+                      {
+                        "type": "fieldset",
+                        "label": "How many children had a break in CHIP coverage but were re-enrolled in CHIP 18 months later?",
+                        "questions": [
+                          {
+                            "id": "2020-03-c-04-10-a",
+                            "type": "integer",
+                            "label": "Total for all ages",
+                            "answer": { "entry": null },
+                            "context_data": {
+                              "skip_text": "10a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [false, null],
+                                    "noninteractive": [false, null]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "questions": [
+                              {
+                                "id": "2020-03-c-04-10-b",
+                                "type": "integer",
+                                "label": "0–1 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-10-c",
+                                "type": "integer",
+                                "label": "1–5 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-10-d",
+                                "type": "integer",
+                                "label": "6–12 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-10-e",
+                                "type": "integer",
+                                "label": "13–18 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "type": "fieldset",
+                                "label": "How many children had a break in CHIP coverage but were re-enrolled in Medicaid 18 months later?",
+                                "questions": [
+                                  {
+                                    "id": "2020-03-c-04-10-f-01",
+                                    "type": "integer",
+                                    "label": "Total for all ages",
+                                    "answer": { "entry": null },
+                                    "context_data": {
+                                      "skip_text": "10f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [false, null],
+                                            "noninteractive": [false, null]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "fieldset",
+                                    "questions": [
+                                      {
+                                        "id": "2020-03-c-04-10-f-02",
+                                        "type": "integer",
+                                        "label": "0–1 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-10-f-03",
+                                        "type": "integer",
+                                        "label": "1–5 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-10-f-04",
+                                        "type": "integer",
+                                        "label": "6–12 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-10-f-05",
+                                        "type": "integer",
+                                        "label": "13–18 year olds",
+                                        "answer": { "entry": null }
+                                      }
+                                    ],
+                                    "context_data": {
+                                      "skip_text": "10f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [true],
+                                            "noninteractive": [true]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "fieldset_type": "datagrid"
+                                  }
+                                ],
+                                "fieldset_info": { "id": "2020-03-c-04-10-f" },
+                                "fieldset_type": "marked"
+                              }
+                            ],
+                            "context_data": {
+                              "skip_text": "10b–10e omitted because you indicated that you don't have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [true],
+                                    "noninteractive": [true]
+                                  }
+                                }
+                              }
+                            },
+                            "fieldset_type": "datagrid"
+                          }
+                        ],
+                        "fieldset_info": { "id": "2020-03-c-04-10" },
+                        "fieldset_type": "marked"
+                      },
+                      {
+                        "hint": "Possible reasons for disenrollment:\n•  Transferred to another health insurance program other than CHIP.\n•  Didn’t meet eligibility criteria anymore.\n•  Didn’t complete documentation.\n•  Didn’t pay a premium or enrollment fee.",
+                        "type": "fieldset",
+                        "label": "How many children were no longer enrolled in CHIP at the end of the 18-month period?",
+                        "questions": [
+                          {
+                            "id": "2020-03-c-04-11-a",
+                            "type": "integer",
+                            "label": "Total for all ages",
+                            "answer": { "entry": null },
+                            "context_data": {
+                              "skip_text": "11a omitted because you indicated that you have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [false, null],
+                                    "noninteractive": [false, null]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "fieldset",
+                            "questions": [
+                              {
+                                "id": "2020-03-c-04-11-b",
+                                "type": "integer",
+                                "label": "0–1 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-11-c",
+                                "type": "integer",
+                                "label": "1–5 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-11-d",
+                                "type": "integer",
+                                "label": "6–12 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "id": "2020-03-c-04-11-e",
+                                "type": "integer",
+                                "label": "13–18 year olds",
+                                "answer": { "entry": null }
+                              },
+                              {
+                                "type": "fieldset",
+                                "label": "How many children were no longer enrolled in CHIP at the end of the 12-month period, and enrolled in Medicaid instead?",
+                                "questions": [
+                                  {
+                                    "id": "2020-03-c-04-11-f-01",
+                                    "type": "integer",
+                                    "label": "Total for all ages",
+                                    "answer": { "entry": null },
+                                    "context_data": {
+                                      "skip_text": "11f 1 omitted because you indicated that you have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is false or null; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [false, null],
+                                            "noninteractive": [false, null]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "fieldset",
+                                    "questions": [
+                                      {
+                                        "id": "2020-03-c-04-11-f-02",
+                                        "type": "integer",
+                                        "label": "0–1 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-11-f-03",
+                                        "type": "integer",
+                                        "label": "1–5 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-11-f-04",
+                                        "type": "integer",
+                                        "label": "6–12 year olds",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-03-c-04-11-f-05",
+                                        "type": "integer",
+                                        "label": "13–18 year olds",
+                                        "answer": { "entry": null }
+                                      }
+                                    ],
+                                    "context_data": {
+                                      "skip_text": "11f 2–5 omitted because you indicated that you don't have the age range breakdown data available.",
+                                      "conditional_display": {
+                                        "type": "conditional_display",
+                                        "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                        "hide_if": {
+                                          "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                          "values": {
+                                            "interactive": [true],
+                                            "noninteractive": [true]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "fieldset_type": "datagrid"
+                                  }
+                                ],
+                                "fieldset_info": { "id": "2020-03-c-04-11-f" },
+                                "fieldset_type": "marked"
+                              }
+                            ],
+                            "context_data": {
+                              "skip_text": "11b–11e omitted because you indicated that you don't have the age range breakdown data available.",
+                              "conditional_display": {
+                                "type": "conditional_display",
+                                "comment": "Interactive: Hide if 2020-03-c-04-01-a is true; noninteractive: same.",
+                                "hide_if": {
+                                  "target": "$..*[?(@.id=='2020-03-c-04-01-a')].answer.entry",
+                                  "values": {
+                                    "interactive": [true],
+                                    "noninteractive": [true]
+                                  }
+                                }
+                              }
+                            },
+                            "fieldset_type": "datagrid"
+                          }
+                        ],
+                        "fieldset_info": { "id": "2020-03-c-04-11" },
+                        "fieldset_type": "marked"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "title": "Eligibility"
+          },
+          {
+            "id": "2020-03-d",
+            "text": "Cost sharing is the share of costs that CHIP enrollees pay out of pocket. Cost sharing can include enrollment fees, premium fees, deductibles, coinsurance, copayments, and any other out-of-pocket costs. States can choose to require cost sharing or not.",
+            "type": "subsection",
+            "parts": [
+              {
+                "id": "2020-03-d-01",
+                "type": "part",
+                "questions": [
+                  {
+                    "id": "2020-03-d-01-01",
+                    "type": "radio",
+                    "label": "Does your state require cost sharing?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    }
+                  },
+                  {
+                    "id": "2020-03-d-01-02",
+                    "type": "radio",
+                    "label": "Who tracks cost sharing to ensure families don’t pay more than the 5% aggregate household income in a year?",
+                    "answer": {
+                      "entry": null,
+                      "options": {
+                        "Other ": "other",
+                        "States": "states",
+                        "Health plans": "health_plans",
+                        "Third party administrator": "third_party_administrator",
+                        "Families (“the shoebox method”)": "families"
+                      }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-03-d-01-02-a",
+                        "type": "text_multiline",
+                        "label": "What information or tools do you provide families with so they can track cost sharing?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-d-01-02 is anything except families; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-d-01-02')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  "health_plans",
+                                  "states",
+                                  "third_party_administrator",
+                                  "other"
+                                ],
+                                "noninteractive": [
+                                  "health_plans",
+                                  "states",
+                                  "third_party_administrator",
+                                  "other"
+                                ]
+                              }
+                            },
+                            "skip_text": "2a not shown due to your answer to 2."
+                          }
+                        }
+                      },
+                      {
+                        "id": "2020-03-d-01-02-b",
+                        "type": "text_multiline",
+                        "label": "Who tracks cost sharing?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-d-01-02 is anything except other; noninteractive: same.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-d-01-02')].answer.entry",
+                              "values": {
+                                "interactive": [
+                                  "health_plans",
+                                  "states",
+                                  "third_party_administrator",
+                                  "families"
+                                ],
+                                "noninteractive": [
+                                  "health_plans",
+                                  "states",
+                                  "third_party_administrator",
+                                  "families"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "comment": "Interactive: Hide if 2020-03-d-01-01 is no; noninteractive: hide if that's no.",
+                        "hide_if": {
+                          "target": "$..*[?(@.id=='2020-03-d-01-01')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no"]
+                          }
+                        },
+                        "skip_text": "This section doesn’t apply to your state. Skip to the next section."
+                      }
+                    }
+                  },
+                  {
+                    "id": "2020-03-d-01-03",
+                    "type": "text_multiline",
+                    "label": "How are healthcare providers notified that they shouldn’t charge families once families have reached the 5% cap?",
+                    "answer": { "entry": null },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "comment": "Interactive: Hide if 2020-03-d-01-01 is no; noninteractive: hide if that's no.",
+                        "hide_if": {
+                          "target": "$..*[?(@.id=='2020-03-d-01-01')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no"]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "id": "2020-03-d-01-04",
+                    "type": "text_multiline",
+                    "label": "Approximately how many families exceeded the 5% cap in the last federal fiscal year?",
+                    "answer": { "entry": null },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "comment": "Interactive: Hide if 2020-03-d-01-01 is no; noninteractive: hide if that's no.",
+                        "hide_if": {
+                          "target": "$..*[?(@.id=='2020-03-d-01-01')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no"]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "id": "2020-03-d-01-05",
+                    "type": "radio",
+                    "label": "Have you assessed the effects of charging premiums and enrollment fees on whether eligible families enroll in CHIP?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-03-d-01-05-a",
+                        "type": "text_multiline",
+                        "label": "What did you find in your assessment?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-d-01-05 is no or unanswered; noninteractive: hide if that's no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-d-01-05')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "comment": "Interactive: Hide if 2020-03-d-01-01 is no; noninteractive: hide if that's no.",
+                        "hide_if": {
+                          "target": "$..*[?(@.id=='2020-03-d-01-01')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no"]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "id": "2020-03-d-01-06",
+                    "type": "radio",
+                    "label": "Have you assessed the effects of charging co-payments and other out-of-pocket fees on whether enrolled families use CHIP services?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-03-d-01-06-a",
+                        "type": "text_multiline",
+                        "label": "What did you find in your assessment?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-d-01-06 is no or unanswered; noninteractive: hide if that's no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-d-01-06')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "comment": "Interactive: Hide if 2020-03-d-01-01 is no; noninteractive: hide if that's no.",
+                        "hide_if": {
+                          "target": "$..*[?(@.id=='2020-03-d-01-01')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no"]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "id": "2020-03-d-01-07",
+                    "type": "text_multiline",
+                    "label": "You indicated in Section 1 that you changed your cost sharing requirements in the past federal fiscal year. How are you monitoring the impact of these changes on whether families apply, enroll, disenroll, and use CHIP health services? What have you found when monitoring the impact?",
+                    "answer": { "entry": null },
+                    "context_data": {
+                      "skip_text": "Hidden based on your answer to the cost sharing questions in Section 1 Parts 3 and 4.",
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "comment": "Interactive: Hide if 2020-03-d-01-01 is no; noninteractive: hide if that's no.",
+                        "hide_if": {
+                          "target": "$..*[?(@.id=='2020-03-d-01-01')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no"]
+                          }
+                        }
+                      },
+                      "interactive_conditional": "In addition to hiding this question if 2020-03-d-01-01 is no, this should also be hidden unless the answer to 2020-01-a-03-08 OR 2020-01-a-04-08 is yes. Logic across sections has to be handled manually.",
+                      "noninteractive_conditional": "See interactive conditional."
+                    }
+                  },
+                  {
+                    "id": "2020-03-d-01-08",
+                    "type": "text_multiline",
+                    "label": "Anything else you’d like to add that wasn’t already covered?",
+                    "answer": { "entry": null },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "comment": "Interactive: Hide if 2020-03-d-01-01 is no; noninteractive: hide if that's no.",
+                        "hide_if": {
+                          "target": "$..*[?(@.id=='2020-03-d-01-01')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no"]
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "title": "Cost Sharing (Out-of-Pocket Costs)"
+          },
+          {
+            "id": "2020-03-e",
+            "type": "subsection",
+            "parts": [
+              {
+                "id": "2020-03-e-01",
+                "text": "States with a premium assistance program can use CHIP funds to purchase coverage through employer sponsored insurance (ESI) on behalf of eligible children and parents.",
+                "type": "part",
+                "questions": [
+                  {
+                    "id": "2020-03-e-01-01",
+                    "hint": "Check all that apply.",
+                    "type": "checkbox",
+                    "label": "Under which authority and statutes does your state offer premium assistance?",
+                    "answer": {
+                      "entry": null,
+                      "options": {
+                        "Section 1115 Demonstration (Title XXI)": "title_xxi",
+                        "Purchase of Family Coverage under CHIP State Plan [2105(c)(3)]": "2105(c)(3)",
+                        "Additional Premium Assistance Option under CHIP State Plan [2105(c)(10)]": "2105(c)(10)"
+                      }
+                    }
+                  },
+                  {
+                    "id": "2020-03-e-01-02",
+                    "type": "radio",
+                    "label": "Does your premium assistance program include coverage for adults",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-03-e-01-02-a",
+                        "type": "checkbox",
+                        "label": "Who do you cover?",
+                        "answer": {
+                          "entry": null,
+                          "options": {
+                            "Parents": "parents",
+                            "Pregnant women": "pregnant_women",
+                            "Caretaker relatives": "caretaker_relatives"
+                          }
+                        },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-e-01-02 is unanswered or no; noninteractive: hide if that's no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-e-01-02')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-03-e-01-03",
+                    "type": "text_multiline",
+                    "label": "How does your premium assistance program operate? How do you coordinate premium assistance with employers? Who receives the subsidy (if applicable)?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-e-01-04",
+                    "type": "text_multiline",
+                    "label": "Which benefit package is offered as part of your premium assistance program?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-e-01-05",
+                    "type": "radio",
+                    "label": "Are there any minimum coverage requirements as part of the benefit package?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    }
+                  },
+                  {
+                    "id": "2020-03-e-01-06",
+                    "type": "radio",
+                    "label": "Does your premium assistance program provide wrap-around coverage for gaps in coverage?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    }
+                  },
+                  {
+                    "id": "2020-03-e-01-07",
+                    "type": "radio",
+                    "label": "Are there limits on cost sharing for children in your premium assistance program?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    }
+                  },
+                  {
+                    "id": "2020-03-e-01-08",
+                    "type": "radio",
+                    "label": "Are there limits on cost sharing for adults in your premium assistance program?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "N/A": "na", "Yes": "yes" }
+                    }
+                  },
+                  {
+                    "id": "2020-03-e-01-09",
+                    "type": "radio",
+                    "label": "Are there protections on cost sharing for children (such as the 5% out-of-pocket maximum) in your premium assistance program?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-03-e-01-09-a",
+                        "type": "text_multiline",
+                        "label": "How do you track cost sharing to ensure families don’t pay more than 5% of the aggregate household income in a year?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-03-e-01-09 is unanswered or no; noninteractive: hide if that's no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-e-01-09')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-03-e-01-10",
+                    "type": "text_multiline",
+                    "label": "How many children were enrolled monthly in the premium assistance program on average each month in the last FFY?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-e-01-11",
+                    "type": "text_multiline",
+                    "label": "What’s the average monthly enrollment of adults ever enrolled in the premium assistance program in the last FFY?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "hint": "Your answers will auto-populate the table below.",
+                    "type": "fieldset",
+                    "label": "Coverage breakdown for children",
+                    "questions": [
+                      {
+                        "id": "2020-03-e-01-12",
+                        "type": "money",
+                        "label": "What’s the average monthly contribution the state pays towards coverage of a child?",
+                        "answer": { "entry": null }
+                      },
+                      {
+                        "id": "2020-03-e-01-13",
+                        "type": "money",
+                        "label": "What’s the average monthly contribution the employer pays towards coverage of a child?",
+                        "answer": { "entry": null }
+                      },
+                      {
+                        "id": "2020-03-e-01-14",
+                        "type": "money",
+                        "label": "What’s the average monthly contribution the employee pays towards coverage of a child?",
+                        "answer": { "entry": null }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "fieldset",
+                    "label": "Coverage breakdown for parents",
+                    "questions": [
+                      {
+                        "id": "2020-03-e-01-15",
+                        "type": "money",
+                        "label": "What’s the average monthly contribution the state pays towards coverage of the eligible parent?",
+                        "answer": { "entry": null }
+                      },
+                      {
+                        "id": "2020-03-e-01-16",
+                        "type": "money",
+                        "label": "What’s the average monthly contribution the employer pays towards coverage of the eligible parent?",
+                        "answer": { "entry": null }
+                      },
+                      {
+                        "id": "2020-03-e-01-17",
+                        "type": "money",
+                        "label": "What’s the average monthly contribution the employee pays towards coverage of the eligible parent?",
+                        "answer": { "entry": null }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "fieldset",
+                    "label": "Table: Coverage breakdown",
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "label": "Child",
+                        "questions": [],
+                        "fieldset_info": {
+                          "rows": [
+                            [
+                              {
+                                "target": "$..*[?(@.id=='2020-03-e-01-12')].answer.entry"
+                              },
+                              {
+                                "target": "$..*[?(@.id=='2020-03-e-01-13')].answer.entry"
+                              },
+                              {
+                                "target": "$..*[?(@.id=='2020-03-e-01-14')].answer.entry"
+                              }
+                            ]
+                          ],
+                          "headers": [
+                            { "contents": "State" },
+                            { "contents": "Employer" },
+                            { "contents": "Employee" }
+                          ]
+                        },
+                        "fieldset_type": "synthesized_table"
+                      },
+                      {
+                        "type": "fieldset",
+                        "label": "Parent",
+                        "questions": [],
+                        "fieldset_info": {
+                          "rows": [
+                            [
+                              {
+                                "target": "$..*[?(@.id=='2020-03-e-01-15')].answer.entry"
+                              },
+                              {
+                                "target": "$..*[?(@.id=='2020-03-e-01-16')].answer.entry"
+                              },
+                              {
+                                "target": "$..*[?(@.id=='2020-03-e-01-17')].answer.entry"
+                              }
+                            ]
+                          ],
+                          "headers": [
+                            { "contents": "State" },
+                            { "contents": "Employer" },
+                            { "contents": "Employee" }
+                          ]
+                        },
+                        "fieldset_type": "synthesized_table"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "fieldset",
+                    "label": "Range in monthly contributions paid by state",
+                    "questions": [
+                      {
+                        "id": "2020-03-e-01-18",
+                        "type": "ranges",
+                        "label": "What’s the range in the average monthly contribution paid by the state on behalf of a child?",
+                        "answer": {
+                          "entry": null,
+                          "header": "Average Monthly Contribution",
+                          "entry_max": 1,
+                          "entry_min": 1,
+                          "range_type": ["money"],
+                          "range_categories": [["Starts at", "Ends at"]]
+                        }
+                      },
+                      {
+                        "id": "2020-03-e-01-19",
+                        "type": "ranges",
+                        "label": "What’s the range in the average monthly contribution paid by the state on behalf of a parent?",
+                        "answer": {
+                          "entry": null,
+                          "header": "Average Monthly Contribution",
+                          "entry_max": 1,
+                          "entry_min": 1,
+                          "range_type": ["money"],
+                          "range_categories": [["Starts at", "Ends at"]]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "fieldset",
+                    "label": "Range in family income levels",
+                    "questions": [
+                      {
+                        "id": "2020-03-e-01-20",
+                        "type": "ranges",
+                        "label": "What’s the range in income levels for children who receive premium assistance?",
+                        "answer": {
+                          "entry": null,
+                          "header": "Federal Poverty Levels",
+                          "entry_max": 1,
+                          "entry_min": 1,
+                          "range_type": ["percentage"],
+                          "range_categories": [["Starts at", "Ends at"]]
+                        }
+                      },
+                      {
+                        "id": "2020-03-e-01-21",
+                        "type": "ranges",
+                        "label": "What’s the range in income levels for children who receive premium assistance?",
+                        "answer": {
+                          "entry": null,
+                          "header": "Federal Poverty Levels",
+                          "entry_max": 1,
+                          "entry_min": 1,
+                          "range_type": ["percentage"],
+                          "range_categories": [["Starts at", "Ends at"]]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-03-e-01-22",
+                    "type": "text_multiline",
+                    "label": "What strategies have been most effective in reducing the administrative barriers in order to provide premium assistance?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-e-01-23",
+                    "type": "text_multiline",
+                    "label": "What impact do you estimate your premium assistance program has on enrollment and retention rates? If you’ve measured this impact, how have you done so?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-e-01-24",
+                    "type": "text_multiline",
+                    "label": "What challenges did you experience with your premium assistance program in the last federal fiscal year (FFY)?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-e-01-25",
+                    "type": "text_multiline",
+                    "label": "What accomplishments did you experience with your premium assistance program in the last FFY?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-e-01-26",
+                    "type": "text_multiline",
+                    "label": "Anything else you’d like to add that wasn’t already covered?",
+                    "answer": { "entry": null }
+                  }
+                ],
+                "context_data": {
+                  "comment": "Only show this section to states with a premium assistance program. As of 2020-07-31, this means six states: MA, NJ, OK, RI, VA, WI.",
+                  "skip_text": "This section only applies to states with a premium assistance program. Skip to the next section."
+                }
+              }
+            ],
+            "title": "Employer Sponsored Insurance and Premium Assistance"
+          },
+          {
+            "id": "2020-03-f",
+            "type": "subsection",
+            "parts": [
+              {
+                "id": "2020-03-f-01",
+                "text": "States with a premium assistance program can use CHIP funds to purchase coverage through employer sponsored insurance (ESI) on behalf of eligible children and parents.",
+                "type": "part",
+                "questions": [
+                  {
+                    "id": "2020-03-f-01-01",
+                    "type": "radio",
+                    "label": "Do you have a written plan with safeguards and procedures in place for the prevention of fraud and abuse cases?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    }
+                  },
+                  {
+                    "id": "2020-03-f-01-02",
+                    "type": "radio",
+                    "label": "Do you have a written plan with safeguards and procedures in place for the investigation of fraud and abuse cases? ",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    }
+                  },
+                  {
+                    "id": "2020-03-f-01-03",
+                    "type": "radio",
+                    "label": "Do you have a written plan with safeguards and procedures in place for the referral of fraud and abuse cases?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    }
+                  },
+                  {
+                    "id": "2020-03-f-01-04",
+                    "type": "file_upload",
+                    "label": "What safeguards and procedures are in place for the prevention, investigation, and referral of fraud and abuse cases? Attach any relevant documents.  ",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-f-01-05",
+                    "type": "radio",
+                    "label": "Do the Managed Care plans with which your separate CHIP program contracts have written plans?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "N/A": "na", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-03-f-01-05-a",
+                        "type": "file_upload",
+                        "label": "What safeguards and procedures do the Managed Care plans have in place? Attach any relevant documents.",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-f-01-05')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no", "na"],
+                                "noninteractive": ["no", "na"]
+                              },
+                              "comment": "Interactive: Hide if 2020-03-f-01-05 is unanswered, N/A, or no; noninteractive: hide if that's N/A or no."
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-03-f-01-06",
+                    "type": "integer",
+                    "label": "How many eligibility denials have been appealed in a fair hearing in the last federal fiscal year (FFY)?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "id": "2020-03-f-01-07",
+                    "type": "integer",
+                    "label": "How many cases have been found in favor of the beneficiary in the last FFY?",
+                    "answer": { "entry": null }
+                  },
+                  {
+                    "type": "fieldset",
+                    "label": "Provider Credentialing",
+                    "questions": [
+                      {
+                        "id": "2020-03-f-01-08",
+                        "type": "integer",
+                        "label": "How many cases related to provider credentialing were investigated in the last FFY?",
+                        "answer": { "entry": null }
+                      },
+                      {
+                        "id": "2020-03-f-01-09",
+                        "type": "integer",
+                        "label": "How many cases related to provider credentialing were referred to appropriate law enforcement officials in the last FFY?",
+                        "answer": { "entry": null }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "fieldset",
+                    "label": "Provider Billing",
+                    "questions": [
+                      {
+                        "id": "2020-03-f-01-10",
+                        "type": "integer",
+                        "label": "How many cases related to provider billing were investigated in the last FFY?",
+                        "answer": { "entry": null }
+                      },
+                      {
+                        "id": "2020-03-f-01-11",
+                        "type": "integer",
+                        "label": "How many cases were referred to appropriate law enforcement officials in the last FFY?",
+                        "answer": { "entry": null }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "fieldset",
+                    "label": "Beneficiary Eligibility",
+                    "questions": [
+                      {
+                        "id": "2020-03-f-01-12",
+                        "type": "integer",
+                        "label": "How many cases related to beneficiary eligibility were investigated in the last FFY?",
+                        "answer": { "entry": null }
+                      },
+                      {
+                        "id": "2020-03-f-01-13",
+                        "type": "integer",
+                        "label": "How many cases related to beneficiary eligibility were referred to appropriate law enforcement officials in the last FFY?",
+                        "answer": { "entry": null }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-03-f-01-14",
+                    "type": "radio",
+                    "label": "Does your data for Questions 8–13 include cases for separate CHIP only or for Medicaid and CHIP combined? ",
+                    "answer": {
+                      "entry": null,
+                      "options": {
+                        "Separate CHIP only": "separate_chip_only",
+                        "Medicaid and separate CHIP combined": "medicaid_separate_chip_combined"
+                      }
+                    }
+                  },
+                  {
+                    "id": "2020-03-f-01-15",
+                    "type": "radio",
+                    "label": "Do you rely on contractors for the prevention, investigation, and  referral of fraud and abuse cases? ",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-03-f-01-15-a",
+                        "type": "text_multiline",
+                        "label": "How do you provide oversight of the contractors? ",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-f-01-15')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              },
+                              "comment": "Interactive: Hide if 2020-03-f-01-15 is unanswered, N/A, or no; noninteractive: hide if that's N/A or no."
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-03-f-01-16",
+                    "type": "radio",
+                    "label": "Do you contract with Managed Care health plans and/or a third party contractor to provide this oversight? ",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-03-f-01-16-a",
+                        "type": "text_multiline",
+                        "label": "What specifically are they responsible for in terms of oversight?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-03-f-01-16')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              },
+                              "comment": "Interactive: Hide if 2020-03-f-01-16 is unanswered, N/A, or no; noninteractive: hide if that's N/A or no."
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-03-f-01-17",
+                    "type": "text_multiline",
+                    "label": "Anything else you’d like to add that wasn’t already covered?",
+                    "answer": { "entry": null }
+                  }
+                ],
+                "context_data": {
+                  "skip_text": "This section only applies to states with a separate CHIP program. Skip to the next section.",
+                  "show_if_state_program_type_in": ["separate_chip", "combo"]
+                }
+              }
+            ],
+            "title": "Program Integrity"
+          },
+          {
+            "id": "2020-03-g",
+            "text": "",
+            "type": "subsection",
+            "parts": [],
+            "title": "Section 3G; not yet implemented"
+          },
+          {
+            "id": "2020-03-h",
+            "text": "",
+            "type": "subsection",
+            "parts": [],
+            "title": "Section 3H; not yet implemented"
+          },
+          {
+            "id": "2020-03-i",
+            "text": "States can use up to 10% of their actual or estimated federal expenditures to develop Health Services Initiatives (HSI) that provide direct services and other public health initiatives for low-income children. [See Section 2105(a)(1)(D)(ii) of the Social Security Act.] States can only develop HSI programs after funding other costs to administer their CHIP State Plan, as defined in regulations at 42 CFR 457.10.\n All states with approved HSI program(s) should complete this section.",
+            "type": "subsection",
+            "parts": [
+              {
+                "id": "2020-03-i-01",
+                "type": "part",
+                "questions": [
+                  {
+                    "id": "2020-03-i-01-01",
+                    "type": "radio",
+                    "label": "Does your state operate Health Service Initiatives using CHIP (Title XXI) funds?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "2020-03-i-02",
+                "text": "Tell us about each of your HSI programs.",
+                "type": "part",
+                "questions": [
+                  {
+                    "id": "2020-03-i-02-01",
+                    "type": "repeatables",
+                    "questions": [
+                      {
+                        "id": "2020-03-i-02-01-01",
+                        "type": "repeatable",
+                        "questions": [
+                          {
+                            "id": "2020-03-i-02-01-01-01",
+                            "type": "text_multiline",
+                            "label": "What is the name of your HSI program?",
+                            "answer": { "entry": null }
+                          },
+                          {
+                            "id": "2020-03-i-02-01-01-02",
+                            "type": "text_multiline",
+                            "label": "Which populations are served by your HSI program?",
+                            "answer": { "entry": null }
+                          },
+                          {
+                            "id": "2020-03-i-02-01-01-03",
+                            "type": "integer",
+                            "label": "How many children do you estimate are served by your HSI program?",
+                            "answer": { "entry": null }
+                          },
+                          {
+                            "hint": "Skip the following sections if you're already reporting this information elsewhere to CMS.",
+                            "type": "fieldset",
+                            "questions": []
+                          },
+                          {
+                            "id": "2020-03-i-02-01-01-04",
+                            "type": "integer",
+                            "label": "How many children in the HSI program are below your state's FPL threshold? ",
+                            "answer": { "entry": null }
+                          },
+                          {
+                            "id": "2020-03-i-02-01-01-05",
+                            "type": "text_multiline",
+                            "label": "How do you measure the HSI program’s impact on the health of low-income children in your state? Define a metric to measure the impact.",
+                            "answer": { "entry": null }
+                          },
+                          {
+                            "id": "2020-03-i-02-01-01-06",
+                            "type": "text_multiline",
+                            "label": "What outcomes have you found in measuring the impact?",
+                            "answer": { "entry": null }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "context_data": {
+                  "conditional_display": {
+                    "type": "conditional_display",
+                    "comment": "Interactive: Hide if 2020-03-i-01-01 is no or unanswered; noninteractive: hide if that's no.",
+                    "hide_if": {
+                      "target": "$..*[?(@.id=='2020-03-i-01-01')].answer.entry",
+                      "values": {
+                        "interactive": [null, "no"],
+                        "noninteractive": ["no"]
+                      }
+                    },
+                    "skip_text": "This section only applies to states with Health Service Initiatives. Skip to the next section."
+                  }
+                }
+              },
+              {
+                "id": "2020-03-i-03",
+                "type": "part",
+                "questions": [
+                  {
+                    "id": "2020-03-i-03-01",
+                    "type": "text_multiline",
+                    "label": "Anything else you’d like to add about your HSI programs?",
+                    "answer": { "entry": "null" }
+                  }
+                ],
+                "context_data": {
+                  "conditional_display": {
+                    "type": "conditional_display",
+                    "comment": "Interactive: Hide if 2020-03-i-01-01 is no or unanswered; noninteractive: hide if that's no.",
+                    "hide_if": {
+                      "target": "$..*[?(@.id=='2020-03-i-01-01')].answer.entry",
+                      "values": {
+                        "interactive": [null, "no"],
+                        "noninteractive": ["no"]
+                      }
+                    },
+                    "skip_text": "This section only applies to states with Health Service Initiatives. Skip to the next section."
+                  }
+                }
+              }
+            ],
+            "title": "Health Service Initiative (HSI) Programs"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "contents": {
+      "section": {
+        "id": "2020-02",
+        "type": "section",
+        "year": 2020,
+        "state": "AK",
+        "title": "Eligibility and Enrollment",
+        "valid": null,
+        "ordinal": 2,
+        "subsections": [
+          {
+            "id": "2020-02-a",
+            "type": "subsection",
+            "parts": [
+              {
+                "id": "2020-02-a-01",
+                "text": "This table is pre-filled with your SEDS data for the two most recent federal fiscal years. If the information is inaccurate, adjust your data in SEDS (go to line 7:  “Unduplicated Number Ever Enrolled” in your fourth quarter SEDS report) and refresh the page. If you’re adjusting data in SEDS, allow one business day for the CARTS data below to update.",
+                "type": "part",
+                "title": "Number of Children Enrolled in CHIP",
+                "questions": [
+                  {
+                    "type": "fieldset",
+                    "questions": [
+                      {
+                        "id": "2020-02-a-01-01",
+                        "type": "text_multiline",
+                        "label": "What are some possible reasons why your state had more than a 10% change in enrollment numbers?",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "skip_text": "Since your percent change didn’t exceed 10%, you can skip to Part 2.",
+                          "interactive_conditional": "Hide if percent change values in parent's table are all under 10.",
+                          "noninteractive_conditional": "Hide if percent change values in parent's table are all under 10."
+                        }
+                      }
+                    ],
+                    "fieldset_info": {
+                      "rows": [
+                        ["Medicaid expansion CHIP", 284143, 300579, 5.78],
+                        ["Separate CHIP", 478542, 511473, 6.88]
+                      ],
+                      "headers": [
+                        "Program",
+                        "Number of children enrolled in FFY 2019",
+                        "Number of children enrolled in FFY 2020",
+                        "Percent change"
+                      ]
+                    },
+                    "fieldset_type": "noninteractive_table"
+                  }
+                ]
+              },
+              {
+                "id": "2020-02-a-02",
+                "text": "This table is pre-filled with data on uninsured children (age 19 and under) who are below 200% of the Federal Poverty Line (FPL) based on annual estimates from the American Community Survey.",
+                "type": "part",
+                "title": "Number of Uninsured Children in Your State",
+                "questions": [
+                  {
+                    "type": "fieldset",
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "questions": [
+                          {
+                            "id": "2020-02-a-02-01",
+                            "type": "text_multiline",
+                            "label": "What are some possible reasons why your state had more than a 10% change in the number of uninsured children?",
+                            "answer": { "entry": null },
+                            "context_data": {
+                              "skip_text": "Since your percent change didn’t exceed 10%, you can skip to the next question.",
+                              "interactive_conditional": "Hide if percent change values in parent's table are all under 10.",
+                              "noninteractive_conditional": "Hide if percent change values in parent's table are all under 10."
+                            }
+                          }
+                        ],
+                        "fieldset_info": {
+                          "rows": [[-1.7]],
+                          "headers": ["Percent Change between 2019 and 2020"]
+                        },
+                        "fieldset_type": "noninteractive_table"
+                      }
+                    ],
+                    "fieldset_info": {
+                      "rows": [
+                        ["2014", "103", "7.0", "2.3", ".2"],
+                        ["2015", "86", "7.0", "2.0", ".2"],
+                        ["2016", "61", "6.0", "1.4", ".1"],
+                        ["2017", "58", "7.0", "1.3", ".2"],
+                        ["2018", "57", "7.0", "1.3", ".2"]
+                      ],
+                      "headers": [
+                        "Year",
+                        "Estimated number of uninsured children",
+                        "Margin of error for estimated number",
+                        "Uninsured children as a percentage of total children",
+                        "Margin of error for percentage"
+                      ]
+                    },
+                    "fieldset_type": "noninteractive_table"
+                  },
+                  {
+                    "id": "2020-02-a-02-02",
+                    "type": "radio",
+                    "label": "Are there any reasons why the American Community Survey estimates wouldn’t be an accurate representation of the number of uninsured children in your state?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-02-a-02-02-a",
+                        "type": "text_multiline",
+                        "label": "What are some reasons why the American Community Survey estimates might not be accurate? ",
+                        "answer": { "entry": null },
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-02-a-02-02 is unanswered or no; noninteractive: hide if no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-02-a-02-02')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-02-a-02-03",
+                    "type": "radio",
+                    "label": "Do you have any alternate data source(s) or methodology for measuring the number and/or percent of uninsured children in your state?",
+                    "answer": {
+                      "entry": null,
+                      "options": { "No": "no", "Yes": "yes" }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "questions": [
+                          {
+                            "id": "2020-02-a-02-03-a",
+                            "type": "text_multiline",
+                            "label": "What is the alternate data source or methodology?",
+                            "answer": { "entry": null }
+                          },
+                          {
+                            "id": "2020-02-a-02-03-b",
+                            "type": "daterange",
+                            "label": "Give a date range for your data",
+                            "answer": {
+                              "entry": null,
+                              "labels": ["Start", "End"]
+                            }
+                          },
+                          {
+                            "id": "2020-02-a-02-03-c",
+                            "type": "text_multiline",
+                            "label": "Define the population you’re measuring, including ages and federal poverty levels.",
+                            "answer": { "entry": null }
+                          },
+                          {
+                            "id": "2020-02-a-02-03-d",
+                            "type": "text_multiline",
+                            "label": "Give numbers and/or the percent of uninsured children for at least two points in time.",
+                            "answer": { "entry": null }
+                          },
+                          {
+                            "id": "2020-02-a-02-03-e",
+                            "type": "text_multiline",
+                            "label": "Why did your state choose to adopt this alternate data source?",
+                            "answer": { "entry": null }
+                          },
+                          {
+                            "id": "2020-02-a-02-03-f",
+                            "type": "text_multiline",
+                            "label": "How reliable are these estimates? Provide standard errors, confidence intervals, and/or p-values if available.",
+                            "answer": { "entry": null }
+                          },
+                          {
+                            "id": "2020-02-a-02-03-g",
+                            "type": "text_multiline",
+                            "label": "What are the limitations of this alternate data source or methodology?",
+                            "answer": { "entry": null }
+                          },
+                          {
+                            "id": "2020-02-a-02-03-h",
+                            "type": "text_multiline",
+                            "label": "How do you use this alternate data source in CHIP program planning?",
+                            "answer": { "entry": null }
+                          }
+                        ],
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "comment": "Interactive: Hide if 2020-02-a-02-03 is unanswered or no; noninteractive: hide if no.",
+                            "hide_if": {
+                              "target": "$..*[?(@.id=='2020-02-a-02-03')].answer.entry",
+                              "values": {
+                                "interactive": [null, "no"],
+                                "noninteractive": ["no"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "2020-02-a-02-04",
+                    "type": "text_multiline",
+                    "label": "Anything else you’d like to add about your data?",
+                    "answer": { "entry": null }
+                  }
+                ]
+              }
+            ],
+            "title": "Enrollment and Uninsured Data"
+          },
+          {
+            "id": "2020-02-b",
+            "type": "subsection",
+            "parts": [
+              {
+                "id": "2020-02-b-01",
+                "text": "Your performance goals should match those reflected in your CHIP State Plan, Section 9. If your objectives or goals are different, submit a State Plan Amendment (SPA) to reconcile these differences.",
+                "type": "part",
+                "title": "State Plan Goals and Objectives",
+                "questions": [
+                  {
+                    "id": "2020-02-b-01-01",
+                    "type": "objectives",
+                    "questions": [
+                      {
+                        "id": "2020-02-b-01-01-01",
+                        "type": "objective",
+                        "questions": [
+                          {
+                            "id": "2020-02-b-01-01-01-01",
+                            "hint": "For example: Our objective is to increase enrollment in our CHIP program.",
+                            "type": "text_multiline",
+                            "label": "What is your objective as listed in your state plan?",
+                            "answer": {
+                              "entry": null,
+                              "readonly": true,
+                              "default_entry": "Reduce the number of uninsured children."
+                            }
+                          },
+                          {
+                            "id": "2020-02-b-01-01-01-02",
+                            "type": "repeatables",
+                            "questions": [
+                              {
+                                "id": "2020-02-b-01-01-01-02-01",
+                                "type": "repeatable",
+                                "questions": [
+                                  {
+                                    "id": "2020-02-b-01-01-01-02-01-01",
+                                    "hint": "For example: Enroll 75% of eligible children in the CHIP program.",
+                                    "type": "text_multiline",
+                                    "label": "Briefly describe your goal.",
+                                    "answer": { "entry": null }
+                                  },
+                                  {
+                                    "id": "2020-02-b-01-01-01-02-01-02",
+                                    "type": "radio",
+                                    "label": "What type of goal is it?",
+                                    "answer": {
+                                      "entry": null,
+                                      "options": {
+                                        "New goal": "goal_new",
+                                        "Continuing goal": "goal_continuing",
+                                        "Discontinued goal": "goal_discontinued"
+                                      },
+                                      "default_entry": "goal_new"
+                                    },
+                                    "questions": [
+                                      {
+                                        "id": "2020-02-b-01-01-01-02-01-02-a",
+                                        "type": "text_multiline",
+                                        "label": "Why was this goal discontinued?",
+                                        "answer": { "entry": null },
+                                        "context_data": {
+                                          "conditional_display": {
+                                            "type": "conditional_display",
+                                            "comment": "Interactive: Hide if 2020-02-b-01-01-01-02-01-02 is null, continuing goal, or new goal; noninteractive: hide if that's continuing goal or new goal.",
+                                            "hide_if": {
+                                              "target": "$..*[?(@.id=='2020-02-b-01-01-01-02-01-02')].answer.entry",
+                                              "values": {
+                                                "interactive": [
+                                                  null,
+                                                  "goal_continuing",
+                                                  "goal_new"
+                                                ],
+                                                "noninteractive": [
+                                                  "goal_continuing",
+                                                  "goal_new"
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "fieldset",
+                                    "label": "Define the numerator you're measuring",
+                                    "questions": [
+                                      {
+                                        "id": "2020-02-b-01-01-01-02-01-03",
+                                        "hint": "For example: The number of children enrolled in CHIP in the last federal fiscal year.",
+                                        "type": "integer",
+                                        "label": "Which population are you measuring in the numerator?",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-02-b-01-01-01-02-01-04",
+                                        "type": "integer",
+                                        "label": "Numerator (total number)",
+                                        "answer": { "entry": null }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "fieldset",
+                                    "label": "Define the denominator you're measuring",
+                                    "questions": [
+                                      {
+                                        "id": "2020-02-b-01-01-01-02-01-05",
+                                        "hint": "For example: The total number of eligible children in the last federal fiscal year.",
+                                        "type": "integer",
+                                        "label": "Which population are you measuring in the denominator?",
+                                        "answer": { "entry": null }
+                                      },
+                                      {
+                                        "id": "2020-02-b-01-01-01-02-01-06",
+                                        "type": "integer",
+                                        "label": "Denominator (total number)",
+                                        "answer": { "entry": null }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "fieldset",
+                                    "questions": [],
+                                    "fieldset_info": {
+                                      "actions": ["percentage"],
+                                      "targets": [
+                                        "$..*[?(@.id=='2020-02-b-01-01-01-02-01-04')].answer.entry",
+                                        "$..*[?(@.id=='2020-02-b-01-01-01-02-01-06')].answer.entry"
+                                      ]
+                                    },
+                                    "fieldset_type": "synthesized_value"
+                                  },
+                                  {
+                                    "id": "2020-02-b-01-01-01-02-01-07",
+                                    "type": "daterange",
+                                    "label": "What is the date range of your data?",
+                                    "answer": {
+                                      "entry": null,
+                                      "labels": ["Start", "End"]
+                                    }
+                                  },
+                                  {
+                                    "id": "2020-02-b-01-01-01-02-01-08",
+                                    "type": "radio",
+                                    "label": "Which data source did you use?",
+                                    "answer": {
+                                      "entry": null,
+                                      "options": {
+                                        "Survey data": "goal_survey_data",
+                                        "Another data source": "goal_other_data",
+                                        "Eligibility or enrollment data": "goal_enrollment_data"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "id": "2020-02-b-01-01-01-02-01-09",
+                                    "type": "text_multiline",
+                                    "label": "How did your progress towards your goal last year compare to your previous year’s progress?",
+                                    "answer": { "entry": null }
+                                  },
+                                  {
+                                    "id": "2020-02-b-01-01-01-02-01-10",
+                                    "type": "text_multiline",
+                                    "label": "What are you doing to continually make progress towards your goal?",
+                                    "answer": { "entry": null }
+                                  },
+                                  {
+                                    "id": "2020-02-b-01-01-01-02-01-11",
+                                    "type": "text_multiline",
+                                    "label": "Anything else you'd like to tell us about this goal?",
+                                    "answer": { "entry": null }
+                                  },
+                                  {
+                                    "id": "2020-02-b-01-01-01-02-01-12",
+                                    "hint": "Optional",
+                                    "type": "file_upload",
+                                    "label": "Do you have any supporting documentation?",
+                                    "answer": { "entry": null }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "context_data": {
+                  "show_if_state_program_type_in": [
+                    "medicaid_exp_chip",
+                    "separate_chip",
+                    "combo"
+                  ]
+                }
+              }
+            ],
+            "title": "Enrollment and Uninsured Data"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "contents": {
+      "section": {
+        "id": "2020-00",
+        "type": "section",
+        "year": 2020,
+        "state": "AK",
+        "title": "Carts Basic Info",
+        "valid": null,
+        "ordinal": 0,
+        "subsections": [
+          {
+            "id": "2020-00-a",
+            "type": "subsection",
+            "parts": [
+              {
+                "id": "2020-00-a-01",
+                "type": "part",
+                "title": "Welcome!",
+                "questions": [
+                  {
+                    "id": "2020-00-a-01-01",
+                    "type": "text_multiline",
+                    "label": "State or territory name:",
+                    "answer": {
+                      "entry": "AK",
+                      "readonly": true,
+                      "prepopulated": true
+                    }
+                  },
+                  {
+                    "id": "2020-00-a-01-02",
+                    "type": "radio",
+                    "label": "Program type:",
+                    "answer": {
+                      "entry": "medicaid_exp_chip",
+                      "options": {
+                        "Separate CHIP only": "separate_chip",
+                        "Medicaid Expansion CHIP only": "medicaid_exp_chip",
+                        "Combination (Medicaid Expansion CHIP and Separate CHIP)": "combo"
+                      },
+                      "readonly": true,
+                      "prepopulated": true
+                    }
+                  },
+                  {
+                    "id": "2020-00-a-01-03",
+                    "type": "text_multiline",
+                    "label": "CHIP program name(s): ",
+                    "answer": {
+                      "entry": "All, Denali KidCare",
+                      "readonly": true,
+                      "prepopulated": true
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "2020-00-a-02",
+                "text": "Who should we contact if we have any questions about your report?",
+                "type": "part",
+                "title": "Contact information",
+                "questions": [
+                  {
+                    "id": "2020-00-a-02-01",
+                    "type": "text_small",
+                    "label": "Contact name:",
+                    "answer": { "entry": "Firstname Lastname" }
+                  },
+                  {
+                    "id": "2020-00-a-02-02",
+                    "type": "text_small",
+                    "label": "Job title:",
+                    "answer": { "entry": "Deathless Functionary" }
+                  },
+                  {
+                    "id": "2020-00-a-02-03",
+                    "type": "email",
+                    "label": "Email:",
+                    "answer": { "entry": "example@example.com" }
+                  },
+                  {
+                    "id": "2020-00-a-02-04",
+                    "type": "mailing_address",
+                    "label": "Full mailing address:",
+                    "answer": { "entry": "Some mailing address" }
+                  },
+                  {
+                    "id": "2020-00-a-02-05",
+                    "type": "phone_number",
+                    "label": "Phone number:",
+                    "answer": { "entry": "Some phone number" }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+]


### PR DESCRIPTION
A very temporary stopgap to get the demo site to load until the API is served over HTTPS. Instead of reaching out to the API for section data, the frontend will now read the section data from a locally-stored file that was created by saving the results of a functioning API call.

### NOTE
Until the API is served over HTTPS, this local file will need to be regenerated if section data is changed. That includes adding new section data, rearranging stuff, etc.