### PR TITLE
Feature/alerts skip text

### DIFF
--- a/frontend/react/src/components/fields/QuestionComponent.js
+++ b/frontend/react/src/components/fields/QuestionComponent.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import CMSChoice from "./CMSChoice";
 import CMSLegend from "./CMSLegend";
-import { TextField, ChoiceList } from "@cmsgov/design-system-core";
+import { Alert, TextField, ChoiceList } from "@cmsgov/design-system-core";
 import DateRange from "../layout/DateRange";
 import CMSRanges from "./CMSRanges";
 import { setAnswerEntry } from "../../actions/initial";
@@ -432,17 +432,26 @@ class QuestionComponent extends Component {
                 />
               ) : null}
 
-              {question.questions && question.type === "fieldset" ? (
-                <div className="cmsfieldset">
-                  {
-                    <QuestionComponent
-                      subquestion={true}
-                      setAnswer={this.props.setAnswer}
-                      data={question.questions} //Array of subquestions to map through
-                    />
-                  }
-                </div>
-              ) : null}
+              {question.questions &&
+                question.type === "fieldset" &&
+                question.context_data &&
+                (question.context_data.skip_text ? (
+                  <Alert>
+                    <p className="ds-c-alert__text">
+                      {question.context_data.skip_text}
+                    </p>
+                  </Alert>
+                ) : (
+                  <div className="cmsfieldset">
+                    {
+                      <QuestionComponent
+                        subquestion={true}
+                        setAnswer={this.props.setAnswer}
+                        data={question.questions}
+                      />
+                    }
+                  </div>
+                ))}
 
               {question.type === "fieldset" &&
               question.fieldset_type === "noninteractive_table"

--- a/frontend/react/src/components/fields/QuestionComponent.js
+++ b/frontend/react/src/components/fields/QuestionComponent.js
@@ -72,8 +72,7 @@ class QuestionComponent extends Component {
           [evt.target.name + "Err"]: validNumberRegex.test(evt.target.value),
         });
       }
-    }
-    else {
+    } else {
       this.props.setAnswer(evt.target.name, evt.target.value);
     }
   }
@@ -168,45 +167,45 @@ class QuestionComponent extends Component {
               </legend>
               {question.type === "radio"
                 ? question.answer.options.map(({ label, value }, index) => {
-                  return (
-                    <CMSChoice
-                      name={question.id}
-                      value={value}
-                      label={label}
-                      type={question.type}
-                      answer={question.answer.entry}
-                      conditional={question.conditional}
-                      children={question.questions}
-                      valueFromParent={this.state[question.id]}
-                      onChange={this.handleChangeArray}
-                      key={index}
-                      setAnswer={this.props.setAnswer}
-                      disabled={question.answer.readonly}
-                      disabledFromParent={question.answer.readonly}
-                    />
-                  );
-                })
+                    return (
+                      <CMSChoice
+                        name={question.id}
+                        value={value}
+                        label={label}
+                        type={question.type}
+                        answer={question.answer.entry}
+                        conditional={question.conditional}
+                        children={question.questions}
+                        valueFromParent={this.state[question.id]}
+                        onChange={this.handleChangeArray}
+                        key={index}
+                        setAnswer={this.props.setAnswer}
+                        disabled={question.answer.readonly}
+                        disabledFromParent={question.answer.readonly}
+                      />
+                    );
+                  })
                 : null}
 
               {question.type === "checkbox"
                 ? question.answer.options.map(({ label, value }, index) => {
-                  return (
-                    <CMSChoice
-                      name={question.id}
-                      value={value}
-                      label={label}
-                      type={question.type}
-                      answer={question.answer.entry}
-                      conditional={question.conditional}
-                      children={question.questions}
-                      valueFromParent={this.state[question.id]}
-                      onChange={this.handleCheckboxInput}
-                      key={index}
-                      setAnswer={this.props.setAnswer}
-                      disabled={question.answer.readonly}
-                    />
-                  );
-                })
+                    return (
+                      <CMSChoice
+                        name={question.id}
+                        value={value}
+                        label={label}
+                        type={question.type}
+                        answer={question.answer.entry}
+                        conditional={question.conditional}
+                        children={question.questions}
+                        valueFromParent={this.state[question.id]}
+                        onChange={this.handleCheckboxInput}
+                        key={index}
+                        setAnswer={this.props.setAnswer}
+                        disabled={question.answer.readonly}
+                      />
+                    );
+                  })
                 : null}
 
               {/* If textarea */}
@@ -276,21 +275,21 @@ class QuestionComponent extends Component {
 
               {/* If large textarea */}
               {question.type === "text_multiline" ||
-                question.type === "mailing_address" ? (
-                  <div>
-                    <TextField
-                      className="ds-c-input"
-                      label=""
-                      multiline
-                      name={question.id}
-                      onChange={this.handleChange}
-                      rows={6}
-                      type="text"
-                      value={question.answer.entry || ""}
-                      disabled={question.answer.readonly}
-                    />
-                  </div>
-                ) : null}
+              question.type === "mailing_address" ? (
+                <div>
+                  <TextField
+                    className="ds-c-input"
+                    label=""
+                    multiline
+                    name={question.id}
+                    onChange={this.handleChange}
+                    rows={6}
+                    type="text"
+                    value={question.answer.entry || ""}
+                    disabled={question.answer.readonly}
+                  />
+                </div>
+              ) : null}
 
               {/* If FPL Range */}
               {question.type === "ranges" ? (
@@ -423,15 +422,15 @@ class QuestionComponent extends Component {
               ) : null}
               {/*Children of radio and checkboxes are handled in their respective sections (above)*/}
               {question.questions &&
-                question.type !== "fieldset" &&
-                question.type !== "radio" &&
-                question.type !== "checkbox" ? (
-                  <QuestionComponent
-                    subquestion={true}
-                    setAnswer={this.props.setAnswer}
-                    data={question.questions} //Array of subquestions to map through
-                  />
-                ) : null}
+              question.type !== "fieldset" &&
+              question.type !== "radio" &&
+              question.type !== "checkbox" ? (
+                <QuestionComponent
+                  subquestion={true}
+                  setAnswer={this.props.setAnswer}
+                  data={question.questions} //Array of subquestions to map through
+                />
+              ) : null}
 
               {question.questions && question.type === "fieldset" ? (
                 <div className="cmsfieldset">
@@ -446,54 +445,54 @@ class QuestionComponent extends Component {
               ) : null}
 
               {question.type === "fieldset" &&
-                question.fieldset_type === "noninteractive_table"
+              question.fieldset_type === "noninteractive_table"
                 ? Object.entries(question.fieldset_info).map((value) => {
-                  return (
-                    <table className="ds-c-table" width="100%">
-                      {value[0] === "headers" ? (
-                        <thead>
-                          <tr>
-                            {question.fieldset_info.headers.map(function (
-                              value
-                            ) {
-                              return (
-                                <th
-                                  width={`${
-                                    100 /
-                                    question.fieldset_info.headers.length
-                                    }%`}
-                                  name={`${value}`}
-                                >
-                                  {value}
-                                </th>
-                              );
-                            })}
-                          </tr>
-                        </thead>
-                      ) : null}
-                      {value[0] === "rows"
-                        ? question.fieldset_info.rows.map((value) => {
-                          return (
+                    return (
+                      <table className="ds-c-table" width="100%">
+                        {value[0] === "headers" ? (
+                          <thead>
                             <tr>
-                              {value.map((value) => {
+                              {question.fieldset_info.headers.map(function (
+                                value
+                              ) {
                                 return (
-                                  <td
+                                  <th
                                     width={`${
                                       100 /
                                       question.fieldset_info.headers.length
-                                      }%`}
+                                    }%`}
+                                    name={`${value}`}
                                   >
                                     {value}
-                                  </td>
+                                  </th>
                                 );
                               })}
                             </tr>
-                          );
-                        })
-                        : null}
-                    </table>
-                  );
-                })
+                          </thead>
+                        ) : null}
+                        {value[0] === "rows"
+                          ? question.fieldset_info.rows.map((value) => {
+                              return (
+                                <tr>
+                                  {value.map((value) => {
+                                    return (
+                                      <td
+                                        width={`${
+                                          100 /
+                                          question.fieldset_info.headers.length
+                                        }%`}
+                                      >
+                                        {value}
+                                      </td>
+                                    );
+                                  })}
+                                </tr>
+                              );
+                            })
+                          : null}
+                      </table>
+                    );
+                  })
                 : null}
             </fieldset>
           </div>


### PR DESCRIPTION
Show skip text in an Alert component. Only applies to fieldsets with `context_data`.
First commit is just `prettier` formatting. Jump to commit` f81452` for actual Alert addition.
Resolves #210