### PR TITLE
Allow DateRange to read from API

### DIFF
--- a/frontend/react/src/components/layout/DateRange.js
+++ b/frontend/react/src/components/layout/DateRange.js
@@ -149,8 +149,11 @@ class DateRange extends Component {
 
   // This method takes all user input and sets it to state
   handleInput(evt) {
+
+    let tempValue = evt.target.value ? evt.target.value : [];
+
     this.setState({
-      [evt.target.name]: evt.target.value,
+      [evt.target.name]: tempValue,
     });
   }
 

--- a/frontend/react/src/components/layout/DateRange.js
+++ b/frontend/react/src/components/layout/DateRange.js
@@ -2,7 +2,6 @@ import React, { Component, Fragment } from "react";
 import { connect } from "react-redux";
 import { TextField } from "@cmsgov/design-system-core";
 import PropTypes from "prop-types";
-import { faGrinTongueSquint } from "@fortawesome/free-solid-svg-icons";
 
 class DateRange extends Component {
   constructor(props) {

--- a/frontend/react/src/components/layout/DateRange.js
+++ b/frontend/react/src/components/layout/DateRange.js
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from "react";
 import { connect } from "react-redux";
 import { TextField } from "@cmsgov/design-system-core";
 import PropTypes from "prop-types";
+import { faGrinTongueSquint } from "@fortawesome/free-solid-svg-icons";
 
 class DateRange extends Component {
   constructor(props) {
@@ -189,9 +190,7 @@ class DateRange extends Component {
                 onChange={this.handleInput}
                 onBlur={this.validateStartInput}
                 value={
-                  this.props.previousEntry === true
-                    ? this.state.dummyDigit - 5
-                    : this.state.monthStart
+                  this.state["monthStart"] ? this.state["monthStart"] : this.props.question.answer.entry[0].split("-")[2]
                 }
               />
               <div className="ds-c-datefield__separator">/</div>
@@ -204,9 +203,7 @@ class DateRange extends Component {
                 onBlur={this.validateStartInput}
                 numeric
                 value={
-                  this.props.previousEntry === true
-                    ? this.state.dummyDigit * 202 - 1
-                    : this.state.yearStart
+                  this.state["yearStart"] ? this.state["yearStart"] : this.props.question.answer.entry[0].split("-")[0]
                 }
               />
             </div>
@@ -238,9 +235,7 @@ class DateRange extends Component {
                 onChange={this.handleInput}
                 onBlur={this.validateEndInput}
                 value={
-                  this.props.previousEntry === true
-                    ? this.state.dummyDigit
-                    : this.state.monthEnd
+                  this.state["monthEnd"] ? this.state["monthEnd"] : this.props.question.answer.entry[1].split("-")[2]
                 }
               />
               <div className="ds-c-datefield__separator">/</div>
@@ -254,9 +249,7 @@ class DateRange extends Component {
                 onBlur={this.validateEndInput}
                 numeric
                 value={
-                  this.props.previousEntry === true
-                    ? this.state.dummyDigit * 202
-                    : this.state.yearEnd
+                  this.state["yearEnd"] ? this.state["yearEnd"] : this.props.question.answer.entry[1].split("-")[0]
                 }
               />
             </div>


### PR DESCRIPTION
Update `value`s for textfields to read from API initially then fallback to local state.

Set local state to empty array if the value is empty. Without this an empty value in the textfield would revert to the API entry