### PR TITLE
redo SEDS SQL so it can (hopefully) be pulled into Section 2a

### DIFF
--- a/docs/All_CHIP_Q4_Line7Total.sql
+++ b/docs/All_CHIP_Q4_Line7Total.sql
@@ -1,0 +1,74 @@
+Declare @currentYear as integer
+
+Set @currentYear = 2016;
+
+with MCHIP as (
+	Select StateCode
+		  ,SubmissionDate
+		  ,sum(LineTotal) as Line7Total
+	from (
+		SELECT [StateCode]
+				,[SubmissionDate]
+				,[AgeRange]
+				,[LineNumber]
+				,sum(IsNull([Column1],0) + IsNull([Column2],0) + IsNull([Column3],0) + IsNull([Column4],0) + IsNull([Column5],0)) as LineTotal
+			FROM [SCHIP].[dbo].[tbl64_21E]
+			where LineNumber like '7%' and MONTH(SubmissionDate) = 4
+			group by StateCode, SubmissionDate, AgeRange, LineNumber
+	) a
+	where YEAR(SubmissionDate) = @currentYear or YEAR(SubmissionDate) = (@currentYear - 1)
+	group by StateCode, SubmissionDate
+)
+
+, MedicaidCHIP as (
+	select a.id
+		  ,a.StateCode
+		  ,a.Program
+		  ,(Select Line7Total from MCHIP where MCHIP.StateCode = a.StateCode and YEAR(MCHIP.SubmissionDate) = @currentYear) as CurrentYear
+		  ,(Select Line7Total from MCHIP where MCHIP.StateCode = a.StateCode and YEAR(MCHIP.SubmissionDate) = (@currentYear - 1)) as PrevYear
+	from (
+		Select distinct StateCode
+			  ,'2020-02-a-01' as id
+			  ,'Medicaid expansion CHIP' as Program
+		from MCHIP
+	) a
+)
+
+, SCHIP as (
+	Select StateCode
+		  ,SubmissionDate
+		  ,sum(LineTotal) as Line7Total
+	from (
+		SELECT [StateCode]
+				,[SubmissionDate]
+				,[ProgramCode]
+				,[AgeRange]
+				,[LineNumber]
+				,sum(IsNull([Column1],0) + IsNull([Column2],0) + IsNull([Column3],0) + IsNull([Column4],0) + IsNull([Column5],0)) as LineTotal
+			FROM [SCHIP].[dbo].[tbl21E]
+			where LineNumber like '7%' and MONTH(SubmissionDate) = 4
+			group by StateCode, SubmissionDate, ProgramCode, AgeRange, LineNumber
+	) a
+	where YEAR(SubmissionDate) = @currentYear or YEAR(SubmissionDate) = (@currentYear - 1)
+	group by StateCode, SubmissionDate
+)
+
+, SeparateCHIP as (
+	select a.id
+		  ,a.StateCode
+		  ,a.Program
+		  ,(Select Line7Total from SCHIP where SCHIP.StateCode = a.StateCode and YEAR(SCHIP.SubmissionDate) = @currentYear) as CurrentYear
+		  ,(Select Line7Total from SCHIP where SCHIP.StateCode = a.StateCode and YEAR(SCHIP.SubmissionDate) = (@currentYear - 1)) as PrevYear
+	from (
+		Select distinct StateCode
+			  ,'2020-02-a-01' as id
+			  ,'Separate CHIP' as Program
+		from SCHIP
+	) a
+)
+
+Select * from MedicaidCHIP
+
+UNION
+
+Select * from SeparateCHIP

--- a/docs/All_CHIP_Q4_Line7Total.sql
+++ b/docs/All_CHIP_Q4_Line7Total.sql
@@ -1,6 +1,6 @@
 Declare @currentYear as integer
 
-Set @currentYear = 2016;
+Set @currentYear = 2020;
 
 with MCHIP as (
 	Select StateCode

--- a/docs/MCHIP_Q4_Line7Total.sql
+++ b/docs/MCHIP_Q4_Line7Total.sql
@@ -1,0 +1,34 @@
+Declare @currentYear as integer
+
+Set @currentYear = 2016;
+
+with MCHIP as (
+	Select StateCode
+		  ,SubmissionDate
+		  ,sum(LineTotal) as Line7Total
+	from (
+		SELECT [StateCode]
+				,[SubmissionDate]
+				,[AgeRange]
+				,[LineNumber]
+				,sum(IsNull([Column1],0) + IsNull([Column2],0) + IsNull([Column3],0) + IsNull([Column4],0) + IsNull([Column5],0)) as LineTotal
+			FROM [SCHIP].[dbo].[tbl64_21E]
+			where LineNumber like '7%' and MONTH(SubmissionDate) = 4
+			group by StateCode, SubmissionDate, AgeRange, LineNumber
+	) a
+	where YEAR(SubmissionDate) = @currentYear or YEAR(SubmissionDate) = (@currentYear - 1)
+	group by StateCode, SubmissionDate
+)
+--select * from MCHIP
+
+select a.id
+	  ,a.StateCode
+	  ,a.Program
+	  ,(Select Line7Total from MCHIP where MCHIP.StateCode = a.StateCode and YEAR(MCHIP.SubmissionDate) = @currentYear) as CurrentYear
+	  ,(Select Line7Total from MCHIP where MCHIP.StateCode = a.StateCode and YEAR(MCHIP.SubmissionDate) = (@currentYear - 1)) as PrevYear
+from (
+	Select distinct StateCode
+		  ,'2020-02-a-01' as id
+		  ,'Medicaid expansion CHIP' as Program
+	from MCHIP
+) a

--- a/docs/MCHIP_Q4_Line7Total.sql
+++ b/docs/MCHIP_Q4_Line7Total.sql
@@ -1,6 +1,6 @@
 Declare @currentYear as integer
 
-Set @currentYear = 2016;
+Set @currentYear = 2020;
 
 with MCHIP as (
 	Select StateCode

--- a/docs/SCHIP_Q4_Line7Total.sql
+++ b/docs/SCHIP_Q4_Line7Total.sql
@@ -3,7 +3,7 @@ GO
 
 Declare @currentYear as integer
 
-Set @currentYear = 2016;
+Set @currentYear = 2020;
 
 with SCHIP as (
 	Select StateCode

--- a/docs/SCHIP_Q4_Line7Total.sql
+++ b/docs/SCHIP_Q4_Line7Total.sql
@@ -1,0 +1,39 @@
+USE [SCHIP]
+GO
+
+Declare @currentYear as integer
+
+Set @currentYear = 2016;
+
+with SCHIP as (
+	Select StateCode
+		  ,SubmissionDate
+		  ,sum(LineTotal) as Line7Total
+	from (
+		SELECT [StateCode]
+				,[SubmissionDate]
+				,[ProgramCode]
+				,[AgeRange]
+				,[LineNumber]
+				,sum(IsNull([Column1],0) + IsNull([Column2],0) + IsNull([Column3],0) + IsNull([Column4],0) + IsNull([Column5],0)) as LineTotal
+			FROM [SCHIP].[dbo].[tbl21E]
+			where LineNumber like '7%' and MONTH(SubmissionDate) = 4
+			group by StateCode, SubmissionDate, ProgramCode, AgeRange, LineNumber
+	) a
+	where YEAR(SubmissionDate) = @currentYear or YEAR(SubmissionDate) = (@currentYear - 1)
+	group by StateCode, SubmissionDate
+)
+--select * from SCHIP
+
+select a.id
+	  ,a.StateCode
+	  ,a.Program
+	  ,(Select Line7Total from SCHIP where SCHIP.StateCode = a.StateCode and YEAR(SCHIP.SubmissionDate) = @currentYear) as CurrentYear
+	  ,(Select Line7Total from SCHIP where SCHIP.StateCode = a.StateCode and YEAR(SCHIP.SubmissionDate) = (@currentYear - 1)) as PrevYear
+from (
+	Select distinct StateCode
+		  ,'2020-02-a-01' as id
+		  ,'Separate CHIP' as Program
+	from SCHIP
+) a
+


### PR DESCRIPTION
Three new SQL files that I think will query the SEDS data in a more usable fashion

- SCHIP_Q4_Line7Total for Separate CHIP

- MCHIP_Q4_Line7Total for Medicaid expansion CHIP

- All_CHIP_Q4_Line7Total for showing Separate CHIP and Medicaid expansion CHIP results combined

Results from ALL_CHIP_Q4_Line7Total looks like this (note dummy data is shown below not actuals):
![image](https://user-images.githubusercontent.com/36236589/93081736-ba86a880-f65d-11ea-8526-7da881f42c78.png)
