### PR TITLE
Okta fake user data from server

### DIFF
--- a/frontend/api_postgres/carts/carts_api/views.py
+++ b/frontend/api_postgres/carts/carts_api/views.py
@@ -248,6 +248,70 @@ def report(request, year=None, state=None):
     return HttpResponse(report_template.render(context=context))
 
 
+def fake_user_data(request, username=None):
+    assert username
+    assert "-" in username
+    state = username.split("-")[1].upper()
+
+    host = request.get_host()
+    scheme = "https" if request.is_secure() else "http"
+    full_host = f"{scheme}://{host}"
+
+    fakeUserData = {
+        "AK": {
+            "name": "Alaska",
+            "abbr": "AK",
+            "programType": "medicaid_exp_chip",
+            "programName": "AK Program Name??",
+            "imageURI": f"{full_host}/img/states/ak.svg",
+            "formName": "CARTS FY",
+            "currentUser": {
+                "role": "state_user",
+                "state": {
+                    "id": "AK",
+                    "name": "Alaska"
+                },
+                "username": "dev-jane.doe@alaska.gov",
+            }
+        },
+        "AZ": {
+            "name": "Arizona",
+            "abbr": "AZ",
+            "programType": "separate_chip",
+            "programName": "AZ Program Name??",
+            "imageURI": "{full_host}/img/states/az.svg",
+            "formName": "CARTS FY",
+            "currentUser": {
+                "role": "state_user",
+                "state": {
+                    "id": "AZ",
+                    "name": "Arizona"
+                },
+                "username": "dev-john.smith@arizona.gov",
+            }
+        },
+        "MA": {
+            "name": "Massachusetts",
+            "abbr": "MA",
+            "programType": "combo",
+            "programName": "MA Program Name??",
+            "imageURI": "${full_host}/img/states/ma.svg",
+            "formName": "CARTS FY",
+            "currentUser": {
+                "role": "state_user",
+                "state": {
+                    "id": "MA",
+                    "name": "Massachusetts"
+                },
+                "username": "dev-naoise.murphy@arizona.gov",
+            }
+        }
+    }
+
+    assert state in fakeUserData
+    return HttpResponse(json.dumps(fakeUserData[state]))
+
+
 def _id_from_chunks(year, *args):
     def fill(chunk):
         chunk = str(chunk).lower()

--- a/frontend/api_postgres/carts/carts_api/views.py
+++ b/frontend/api_postgres/carts/carts_api/views.py
@@ -303,7 +303,7 @@ def fake_user_data(request, username=None):
                     "id": "MA",
                     "name": "Massachusetts"
                 },
-                "username": "dev-naoise.murphy@arizona.gov",
+                "username": "dev-naoise.murphy@massachusetts.gov",
             }
         }
     }

--- a/frontend/api_postgres/carts/urls.py
+++ b/frontend/api_postgres/carts/urls.py
@@ -42,6 +42,8 @@ api_patterns = [
          views.sectionbase_by_year_section_subsection),
     path("generic-questions/<slug:id>",
          views.generic_fragment_by_id),
+    path("appusers/<slug:username>",
+         views.fake_user_data),
 ]
 
 urlpatterns = [

--- a/frontend/react/src/actions/initial.js
+++ b/frontend/react/src/actions/initial.js
@@ -1,21 +1,60 @@
 import axios from "axios";
+import fakeUserData from "../store/fakeUserData";
+import { getProgramData, getStateData, getUserData } from "../store/stateUser";
 
 export const LOAD_SECTIONS = "LOAD SECTIONS";
 export const QUESTION_ANSWERED = "QUESTION ANSWERED";
 
 const temp__data = require("./initial.json");
 
-export const loadSections = (userData) => {
-  console.log("loadSections");
+export const loadUserThenSections = ({userData}) => {
+  const userToken = userData.userToken;
+  return async (dispatch) => {
+    const userFromServer = await axios.get(
+      `${window._env_.API_POSTGRES_URL}/api/v1/appusers/${userToken}`
+    )
+      .then((res) => {
+          dispatch(loadSections({userData: res.data}));
+          dispatch(getProgramData(res.data));
+          dispatch(getStateData(res.data));
+          dispatch(getUserData(res.data.currentUser));
+      })
+      .catch((res) => {
+          /*
+           * Error-handling would go here, but for now, since the anticipated
+           * error is trying to run on cartsdemo, we just use the fake data.
+           * This fake user data has AK/AZ/MA, just like the fake data on the server.
+           */
+          const stateAbbr = userToken.split("-")[1].toUpperCase();
+          const userData = fakeUserData[stateAbbr];
+          dispatch(loadSections({userData: userData}))
+          dispatch(getProgramData(userData));
+          dispatch(getStateData(userData));
+          dispatch(getUserData(userData.currentUser));
+      })
+      
+
+  }
+
+};
+
+export const loadSections = ({userData}) => {
   return async (dispatch) => {
     const { data } = await axios.get(
       `${window._env_.API_POSTGRES_URL}/api/v1/sections/2020/${userData.abbr}`
     )
-      .catch((res) => {return {data: temp__data}})
-      .then((caught) => caught);
+      .catch((res) => {
+          /*
+           * Error-handling would go here, but for now, since the anticipated
+           * error is trying to run on cartsdemo, we just use the fake data.
+           * This fake data is only for AK, so if we fail to load it we'll
+           * potentially see the user for a different state but the answers
+           * from the AK fake data.
+           */
+          return {data: temp__data}
+      })
 
     dispatch({ type: LOAD_SECTIONS, data });
-    //dispatch({ type: LOAD_SECTIONS, data: temp__data });
   };
 };
 

--- a/frontend/react/src/actions/initial.js
+++ b/frontend/react/src/actions/initial.js
@@ -5,14 +5,17 @@ export const QUESTION_ANSWERED = "QUESTION ANSWERED";
 
 const temp__data = require("./initial.json");
 
-export const loadSections = () => {
+export const loadSections = (userData) => {
   console.log("loadSections");
   return async (dispatch) => {
-    // const { data } = await axios.get(
-    //   `${window._env_.API_POSTGRES_URL}/api/v1/sections/2020/AK`
-    // );
-    // dispatch({ type: LOAD_SECTIONS, data });
-    dispatch({ type: LOAD_SECTIONS, data: temp__data });
+    const { data } = await axios.get(
+      `${window._env_.API_POSTGRES_URL}/api/v1/sections/2020/${userData.abbr}`
+    )
+      .catch((res) => {return {data: temp__data}})
+      .then((caught) => caught);
+
+    dispatch({ type: LOAD_SECTIONS, data });
+    //dispatch({ type: LOAD_SECTIONS, data: temp__data });
   };
 };
 

--- a/frontend/react/src/components/Utils/InitialDataLoad.js
+++ b/frontend/react/src/components/Utils/InitialDataLoad.js
@@ -1,16 +1,12 @@
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
-import { loadSections } from "../../actions/initial";
-import { getProgramData, getStateData, getUserData } from "../../store/stateUser";
+import { loadUserThenSections } from "../../actions/initial";
 
 const InitialDataLoad = ({userData}) => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(getUserData(userData.currentUser));
-    dispatch(getProgramData(userData));
-    dispatch(getStateData(userData));
-    dispatch(loadSections(userData));
+    dispatch(loadUserThenSections({userData}));
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
   // :point-up: We don't need that lint check because the empty dependencies
   // is what we want: only load the data once, period.

--- a/frontend/react/src/components/Utils/InitialDataLoad.js
+++ b/frontend/react/src/components/Utils/InitialDataLoad.js
@@ -7,10 +7,10 @@ const InitialDataLoad = ({userData}) => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(loadSections());
     dispatch(getUserData(userData.currentUser));
     dispatch(getProgramData(userData));
     dispatch(getStateData(userData));
+    dispatch(loadSections(userData));
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
   // :point-up: We don't need that lint check because the empty dependencies
   // is what we want: only load the data once, period.

--- a/frontend/react/src/store/fakeUserData.js
+++ b/frontend/react/src/store/fakeUserData.js
@@ -44,7 +44,7 @@ const fakeUserData = {
                 "id": "MA",
                 "name": "Massachusetts"
             },
-            "username": "dev-naoise.murphy@arizona.gov",
+            "username": "dev-naoise.murphy@massachusetts.gov",
         }
     }
 };

--- a/frontend/react/src/store/stateUser.js
+++ b/frontend/react/src/store/stateUser.js
@@ -5,8 +5,6 @@ const PROGRAM_INFO = "PROGRAM_INFO";
 
 //ACTION CREATORS
 export const getUserData = (userObject) => {
-  console.log("getUserData");
-  console.log(userObject);
   return {
     type: USER_INFO,
     userObject: userObject,
@@ -45,7 +43,6 @@ const initialState = {
 export default function (state = initialState, action) {
   switch (action.type) {
     case STATE_INFO:
-      console.log(STATE_INFO);
       return {
         ...state,
         name: action.name,
@@ -53,13 +50,11 @@ export default function (state = initialState, action) {
         imageURI: action.imageURI,
       };
     case USER_INFO:
-      console.log(USER_INFO);
       return {
         ...state,
         currentUser: action.userObject,
       };
     case PROGRAM_INFO:
-      console.log(PROGRAM_INFO);
       return {
         ...state,
         programType: action.programType,
@@ -67,8 +62,6 @@ export default function (state = initialState, action) {
         formName: action.formName,
       };
     default:
-      console.log("default in state user reducer");
-      console.log(state, action);
       return state;
   }
 }

--- a/frontend/react/src/wrapSecurity.js
+++ b/frontend/react/src/wrapSecurity.js
@@ -3,7 +3,6 @@ import "font-awesome/css/font-awesome.min.css";
 import "./App.scss";
 import { BrowserRouter as Router, Route, useLocation } from 'react-router-dom';
 import { Security, SecureRoute, LoginCallback } from '@okta/okta-react';
-import fakeUserData from "./store/fakeUserData";
 import Routes from "./reactRouter";
 import Header from "./components/layout/Header";
 import Footer from "./components/layout/Footer";
@@ -19,11 +18,10 @@ const WrappedSecurity = () => {
   let VisibleFooter =
     window.location.pathname.split("/")[1] === "reports" ? null : <Footer />;
 
-  console.dir(useLocation());
   const loc = qs.parse(useLocation().search);
   const devKeys = {"dev-ak": "AK", "dev-az": "AZ", "dev-ma": "MA"}
   if (loc.dev && Object.keys(devKeys).includes(loc.dev)) {
-    const userData = fakeUserData[devKeys[loc.dev]];
+    const userData = {userToken: loc.dev}
 
     return (
       <div className="App" data-test="component-app">


### PR DESCRIPTION
So now the server
Has fake user data too.
Incorporate this.

- When using the fake user bypass, look the user up from an API endpoint, as this will more closely mirror the Okta flow.
- Load the user first, then load the data dependent on which state the user is associated with.
- Handle failure of API lookup by falling back to fake data, instead of assuming we need to fall back (this allows us to work with API data locally while still using fake static data on cartsdemo until the HTTPS issues are worked out (that is, the last item in #199).

Works towards #481.