### PR TITLE
Improve jsonpath performance

### DIFF
--- a/frontend/react/src/components/Utils/helperFunctions.js
+++ b/frontend/react/src/components/Utils/helperFunctions.js
@@ -1,6 +1,5 @@
 // This function extracts just the unique ID
 // from all objectives & goals, stopping at the underscore
-import jsonpath from "jsonpath";
 
 const sliceId = (id) => {
   let idString = id.toString();

--- a/frontend/react/src/store/formData.js
+++ b/frontend/react/src/store/formData.js
@@ -1,5 +1,5 @@
 import { LOAD_SECTIONS, QUESTION_ANSWERED } from "../actions/initial";
-import jsonpath from "jsonpath";
+import jsonpath from "../util/jsonpath";
 import { _ } from "underscore";
 import { selectQuestion } from "./selectors";
 

--- a/frontend/react/src/store/selectors.js
+++ b/frontend/react/src/store/selectors.js
@@ -1,4 +1,4 @@
-import jsonpath from "jsonpath";
+import jsonpath from "../util/jsonpath";
 
 import { selectFragment, shouldDisplay } from "./formData";
 

--- a/frontend/react/src/util/jsonpath.js
+++ b/frontend/react/src/util/jsonpath.js
@@ -1,0 +1,33 @@
+const jsonpath = require('jsonpath');
+
+const exactPathMap = {};
+
+const getExactPath = (data, path) => {
+  let exact = exactPathMap[path];
+
+  if(!exact) {
+    const paths = jsonpath.paths(data, path);
+    if (paths.length > 0) {
+      exact = jsonpath.stringify(paths[0]);
+    } else {
+      exact = jsonpath.stringify(path);
+    }
+    exactPathMap[path] = exact;
+  }
+
+  return exact;
+};
+
+const methodsToWrap = ['apply', 'nodes', 'parent', 'paths', 'query', 'value'];
+const wrappers = methodsToWrap.reduce((o, methodName) => ({
+  ...o,
+  [methodName]: (obj, path, ...rest) => {
+    const exactPath = getExactPath(obj, path);
+    return jsonpath[methodName](obj, exactPath, ...rest);
+  }
+}), {});
+
+wrappers.parse = jsonpath.parse;
+wrappers.stringify = jsonpath.stringify;
+
+export default wrappers;

--- a/frontend/react/src/util/jsonpath.js
+++ b/frontend/react/src/util/jsonpath.js
@@ -1,32 +1,62 @@
-const jsonpath = require('jsonpath');
+/* What exactly is the point of this whole thing, you may be asking. A valid
+   question. It turns out that the performance of jsonpath is highly dependent
+   on how generic the search path is. The more generic, the worse the
+   performance. And not by just a little bit. In the case of CARTS data, a
+   query on just an ID (something like "?..(id=='2020-01-a-01-01')") takes
+   literally ONE THOUSAND TIMES longer than a query for the same node's exact
+   path.
 
+   So, what if we take all those generic lookups that come in, find the exact
+   path that corresponds to the generic path, and then cache those exact paths?
+   The first queries are still slow, but every subsequent query is suddenly
+   anywhere from 10 to 1000 times faster. So this exists as a drop-in wrapper
+   around jsonpath so that we can get the performance benefits everywhere
+   without having to change anything anywhere else.
+ */
+const jsonpath = require("jsonpath");
+
+// Map of generic paths to their exact counterparts
 const exactPathMap = {};
 
 const getExactPath = (data, path) => {
   let exact = exactPathMap[path];
 
-  if(!exact) {
+  // If we don't already have a matching exact path, we'll need to fetch it.
+  if (!exact) {
     const paths = jsonpath.paths(data, path);
+
     if (paths.length > 0) {
+      // If there are any matching paths, cache off the first one. The paths
+      // we get back above are in array form, but we want to cache the string
+      // form, so stringify it first.
       exact = jsonpath.stringify(paths[0]);
     } else {
-      exact = jsonpath.stringify(path);
+      // If there is NOT a matching path, cache the inexact path so we don't
+      // bother doing the path lookup again in the future.
+      exact = path;
     }
+
     exactPathMap[path] = exact;
   }
 
   return exact;
 };
 
-const methodsToWrap = ['apply', 'nodes', 'parent', 'paths', 'query', 'value'];
-const wrappers = methodsToWrap.reduce((o, methodName) => ({
-  ...o,
-  [methodName]: (obj, path, ...rest) => {
-    const exactPath = getExactPath(obj, path);
-    return jsonpath[methodName](obj, exactPath, ...rest);
-  }
-}), {});
+// These are the methods in jsonpath that actually do lookups into the data
+// object, so these should use the cache. Build those methods here.
+const methodsToWrap = ["apply", "nodes", "parent", "paths", "query", "value"];
+const wrappers = methodsToWrap.reduce(
+  (current, methodName) => ({
+    ...current,
+    [methodName]: (obj, path, ...rest) => {
+      const exactPath = getExactPath(obj, path);
+      return jsonpath[methodName](obj, exactPath, ...rest);
+    },
+  }),
+  {}
+);
 
+// These methods don't do lookups, so we can just pass them straight through.
 wrappers.parse = jsonpath.parse;
 wrappers.stringify = jsonpath.stringify;
 

--- a/frontend/react/src/util/jsonpath.js
+++ b/frontend/react/src/util/jsonpath.js
@@ -30,6 +30,15 @@ const getExactPath = (data, path) => {
       // we get back above are in array form, but we want to cache the string
       // form, so stringify it first.
       exact = jsonpath.stringify(paths[0]);
+
+      // If the incoming path ends with [*], the jsonpath.paths method will
+      // return an array with all of the matching paths, and the first one will
+      // end with [0]. But that's not what is being requested: the [*] at the
+      // end means the request is for ALL of the things, not the first, so in
+      // that case, replace [0] at the end of the exact path with [*].
+      if(path.endsWith('[*]')) {
+        exact = exact.replace(/\[0\]$/, '[*]');
+      }
     } else {
       // If there is NOT a matching path, cache the inexact path so we don't
       // bother doing the path lookup again in the future.


### PR DESCRIPTION
 What exactly is the point of this whole thing, you may be asking. A valid question. It turns out that the performance of `jsonpath` is highly dependent on how generic the search path is. The more generic, the worse the performance. And not by just a little bit. In the case of CARTS data, a query on just an ID (something like `?..(id=='2020-01-a-01-01')`) takes literally **A THOUSAND TIMES** longer than a query for the same node's exact path.

You may have noticed the app seems a little sluggish sometimes. ☝️  That's why. And it got a lot more noticeable with the conditional questions, since they end up doing a lot more jsonpath queries.

So, what if we take all those generic lookups that come in, find the exact path that corresponds to the generic path, and then cache those exact paths? The first queries are still slow, but every subsequent query is suddenly anywhere from 10 to 1000 times faster. So PR creates a drop-in wrapper around `jsonpath` so that we can get the performance benefits everywhere without having to change anything anywhere else, and updates the other bits so that they use this instead of using the `jsonpath` library directly.