### PR TITLE
Allow all hosts for Django for now

### DIFF
--- a/frontend/api_postgres/carts/settings.py
+++ b/frontend/api_postgres/carts/settings.py
@@ -25,13 +25,15 @@ SECRET_KEY = 'uilqxg&r93npq*zt3^h+f4te8#%jh^noc7_r3@&t_ad(8lsr7n'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = [
-    'localhost',
-    '127.0.0.1',
-    '[::1]',
-    'api-postgres-master-2052493048.us-east-1.elb.amazonaws.com'
-]
+# Need to provide the url from terraform before we get specific here... * until then
+# ALLOWED_HOSTS = [
+#     'localhost',
+#     '127.0.0.1',
+#     '[::1]',
+#     'api-postgres-master-2052493048.us-east-1.elb.amazonaws.com'
+# ]
 
+ALLOWED_HOSTS = ['*']
 
 # Application definition
 


### PR DESCRIPTION
If we want to be specific about what hosts are allowed, we will need to pass in the 'not figured out until deploy time' balancer url from terraform to django via an ECS task variable.

Let's just allow all hosts for now