### PR TITLE
Add the allowed hosts asterisk back in.  we beliefve it is causing EL…

### DIFF
--- a/frontend/api_postgres/carts/settings.py
+++ b/frontend/api_postgres/carts/settings.py
@@ -37,7 +37,7 @@ ALLOWED_HOSTS = [
     'localhost'
     '127.0.0.1',
     '[::1]',
-    '10.*',
+    '*',
     os.environ.get('POSTGRES_API_URL')]
 
 # Application definition


### PR DESCRIPTION
…B health check failures, as the tasks are addresssed by private ip.  10.* would be preferred if that works