### PR TITLE
Add Part number prefix to part titles

### DIFF
--- a/frontend/react/src/components/layout/Part.js
+++ b/frontend/react/src/components/layout/Part.js
@@ -16,15 +16,12 @@ const showPart = (context_data, programType) => {
 
 const Part = ({ partId, text, title, context_data, programType }) => {
   if (showPart(context_data, programType)) {
-
     // Determine Part Number from partId
     let partNum = Number(partId.split("-").pop());
     return (
       <div id={partId}>
-
         <h2>Part {partNum}{title ? ": " + title : <></>}</h2>
         {text ? <p>{text}</p> : <></>}
-
         <QuestionComponent partId={partId} />
       </div>
     );

--- a/frontend/react/src/components/layout/Part.js
+++ b/frontend/react/src/components/layout/Part.js
@@ -6,9 +6,9 @@ import QuestionComponent from "../fields/QuestionComponent";
 
 const showPart = (context_data, programType) => {
   if (context_data &&
-      programType &&
-      _.has(context_data, "show_if_state_program_type_in") &&
-      !context_data.show_if_state_program_type_in.includes(programType)) {
+    programType &&
+    _.has(context_data, "show_if_state_program_type_in") &&
+    !context_data.show_if_state_program_type_in.includes(programType)) {
     return false;
   }
   return true;
@@ -16,6 +16,8 @@ const showPart = (context_data, programType) => {
 
 const Part = ({ partId, text, title, context_data, programType }) => {
   if (showPart(context_data, programType)) {
+
+    // Determine Part Number from partId
     let partNum = Number(partId.split("-").pop());
     return (
       <div id={partId}>
@@ -31,7 +33,7 @@ const Part = ({ partId, text, title, context_data, programType }) => {
       <div id={partId}>
         {title ? <h2>{title}</h2> : <></>}
         {context_data.skip_text ? <p>{context_data.skip_text}</p> : <></>}
-  
+
       </div>
     );
 

--- a/frontend/react/src/components/layout/Part.js
+++ b/frontend/react/src/components/layout/Part.js
@@ -16,11 +16,13 @@ const showPart = (context_data, programType) => {
 
 const Part = ({ partId, text, title, context_data, programType }) => {
   if (showPart(context_data, programType)) {
+    let partNum = Number(partId.split("-").pop());
     return (
       <div id={partId}>
-        {title ? <h2>{title}</h2> : <></>}
+
+        <h2>Part {partNum}{title ? ": " + title : <></>}</h2>
         {text ? <p>{text}</p> : <></>}
-  
+
         <QuestionComponent partId={partId} />
       </div>
     );


### PR DESCRIPTION
Add `Part n: ` to all part titles.
Generate `n` from partId (already available)

Satisfies AC from #527 and #542 