### PR TITLE
Check for conditional when rendering parts

### DIFF
--- a/frontend/react/src/components/layout/Part.js
+++ b/frontend/react/src/components/layout/Part.js
@@ -21,11 +21,11 @@ const showPart = (context_data, programType, state) => {
   return true;
 }
 
-const Part = ({ partId, text, title, context_data, programType, state }) => {
+const Part = ({ partId, text, title, context_data, show }) => {
   // Determine Part Number from partId
   let partNum = Number(partId.split("-").pop());
 
-  if (showPart(context_data, programType, state)) {
+  if (show) {
     return (
       <div id={partId}>
         <h2>Part {partNum}{title ? ": " + title : null}</h2>
@@ -50,12 +50,14 @@ const Part = ({ partId, text, title, context_data, programType, state }) => {
 
 const mapStateToProps = (state, { partId }) => {
   const part = selectFragment(state, partId);
+  const contextData = _.has(part, "context_data") ? part.context_data : null;
+
   return {
     text: part ? part.text : null,
     title: part ? part.title : null,
     context_data: _.has(part, "context_data") ? part.context_data : null,
     programType: state.stateUser.programType,
-    state: state,
+    show: showPart(contextData, state.stateUser.programType, state),
   };
 };
 

--- a/frontend/react/src/components/layout/Part.js
+++ b/frontend/react/src/components/layout/Part.js
@@ -4,14 +4,20 @@ import { selectFragment } from "../../store/formData";
 import { _ } from "underscore";
 import QuestionComponent from "../fields/QuestionComponent";
 import { Alert } from "@cmsgov/design-system-core";
+import { shouldDisplay } from "../../util/shouldDisplay";
 
-const showPart = (context_data, programType) => {
+const showPart = (context_data, programType, state) => {
   if (context_data &&
     programType &&
     _.has(context_data, "show_if_state_program_type_in") &&
     !context_data.show_if_state_program_type_in.includes(programType)) {
     return false;
   }
+
+  if (context_data && _.has(context_data, "conditional_display")) {
+    return shouldDisplay(state, context_data);
+  }
+
   return true;
 }
 
@@ -49,6 +55,7 @@ const mapStateToProps = (state, { partId }) => {
     title: part ? part.title : null,
     context_data: _.has(part, "context_data") ? part.context_data : null,
     programType: state.stateUser.programType,
+    state: state,
   };
 };
 


### PR DESCRIPTION
Previously, parts were only hidden based on programType. This allows parts to check shouldDisplay for parts.

Ticket #600, #584 