### PR TITLE
Save UI

### DIFF
--- a/frontend/api_postgres/carts/carts_api/views.py
+++ b/frontend/api_postgres/carts/carts_api/views.py
@@ -112,6 +112,9 @@ def sections_by_year_and_state(request, year, state):
                                        context={"request": request})
         return Response(serializer.data)
 
+@api_view(["POST"])
+def temp_post_endpoint(request, year, state):
+    return HttpResponse(status=204)
 
 @api_view(["GET"])
 def section_by_year_and_state(request, year, state, section):

--- a/frontend/api_postgres/carts/urls.py
+++ b/frontend/api_postgres/carts/urls.py
@@ -29,6 +29,8 @@ router.register(r'fmap', views.FMAPViewSet)
 api_patterns = [
     path("sections/<int:year>/<str:state>",
          views.sections_by_year_and_state),
+    path("sections/<int:year>/<str:state>/temp",
+         views.temp_post_endpoint),
     path("sections/<int:year>/<str:state>/<int:section>",
          views.section_by_year_and_state),
     path("sections/<int:year>/<str:state>/<int:section>/<str:subsection>",

--- a/frontend/react/package-lock.json
+++ b/frontend/react/package-lock.json
@@ -10058,6 +10058,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.28.0.tgz",
+      "integrity": "sha512-Z5KOjYmnHyd/ukynmFd/WwyXHd7L4J9vTI/nn5Ap9AVUgaAE15VvQ9MOGmJJygEUklupqIrFnor/tjTwRU+tQw=="
+    },
     "moo": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",

--- a/frontend/react/package.json
+++ b/frontend/react/package.json
@@ -17,6 +17,7 @@
     "axios": "^0.19.2",
     "font-awesome": "^4.7.0",
     "jsonpath": "^1.0.2",
+    "moment": "^2.28.0",
     "node-sass": "^4.14.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/frontend/react/src/components/layout/Autosave.js
+++ b/frontend/react/src/components/layout/Autosave.js
@@ -1,23 +1,74 @@
-import React from 'react'
+import React, { useState } from "react";
+import { connect } from "react-redux";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCheck, faSpinner } from "@fortawesome/free-solid-svg-icons";
+
+import SaveMessage from "./SaveMessage";
+import { selectLastSave, selectIsSaving } from "../../store/save.selectors";
+
+const Check = () => <FontAwesomeIcon icon={faCheck} />;
+const Spinner = () => <FontAwesomeIcon icon={faSpinner} spin />;
 
 /**
- * 
- * Autosave status message. 
+ *
+ * Autosave status message.
  * Should connect to store for latest status.
  * @returns styled autosave text or an empty column.
  * excluded - Array of pages to that do not show the Autosave message.
  */
-const Autosave = _ => {
-  const path = window.location.path
-  const excluded = ['/', 'no-access']
-  const autosaveText = `Autosave`
-  return (
-    (excluded.indexOf(path) > -1)
-      ?
-      <div className="save-status ds-l-col--6 ds-u-border--0"></div>
-      :
-      <div className="save-status ds-l-col--6">{autosaveText}</div>
-  )
-}
+const Autosave = ({ isSaving, lastSaved }) => {
+  const [active, setActive] = useState(isSaving);
+  const [delayTimer, setDelayTimer] = useState();
 
-export default Autosave
+  const path = window.location.path;
+  const excluded = ["/", "no-access"];
+
+  if (excluded.indexOf(path) > -1) {
+    return <div className="save-status ds-l-col--6 ds-u-border--0"></div>;
+  }
+
+  if (isSaving !== active) {
+    if (isSaving) {
+      // If we have switched from not saving to saving, make the UI change
+      // immediately.
+      setActive(true);
+
+      // If there's already a save delay timer, clear it.
+      clearTimeout(delayTimer);
+
+      // Wait 750ms after the last save began before changing the UI back to
+      // "saved" from the spinner.
+      setDelayTimer(
+        setTimeout(() => {
+          // This prompts a re-render. If the isSaving prop is still true, then
+          // the conditional at the start will pass, and we'll end up back in
+          // the block that creates the delay timer. This ensures that we don't
+          // switch to the "last saved" UI state if the saving action is not
+          // yet completed.
+          setActive(false);
+        }, 750)
+      );
+    }
+  }
+
+  return (
+    <div className="save-status ds-l-col--6">
+      {active ? (
+        <>
+          <Spinner /> Saving...
+        </>
+      ) : (
+        <>
+          <Check /> <SaveMessage lastSaved={lastSaved} />
+        </>
+      )}
+    </div>
+  );
+};
+
+const mapStateToProps = (state) => ({
+  isSaving: selectIsSaving(state),
+  lastSaved: selectLastSave(state),
+});
+
+export default connect(mapStateToProps)(Autosave);

--- a/frontend/react/src/components/layout/SaveError.js
+++ b/frontend/react/src/components/layout/SaveError.js
@@ -1,0 +1,39 @@
+import { Alert } from "@cmsgov/design-system-core";
+import PropTypes from "prop-types";
+import React from "react";
+import { connect } from "react-redux";
+
+import { selectHasError } from "../../store/save.selectors";
+
+const SaveError = ({ hasError }) => {
+  const className = hasError ? "alert--unexpected-error__active" : "";
+
+  return (
+    <div
+      aria-hidden={!hasError}
+      aria-live="polite"
+      className={`alert--unexpected-error ${className}`}
+    >
+      <Alert
+        heading="There's been an unexpected error."
+        role="alertdialog"
+        variation="warn"
+      >
+        We weren&lsquo;t able to save your latest changes. Try saving in a few
+        minutes. If you continue to see this message, refresh your browser.
+        Before this issue is resolved, new changes may be lost if you continue
+        to make edits or if you refresh your browser.
+      </Alert>
+    </div>
+  );
+};
+
+SaveError.propTypes = {
+  hasError: PropTypes.bool.isRequired,
+};
+
+const mapStateToProps = (state) => ({
+  hasError: selectHasError(state),
+});
+
+export default connect(mapStateToProps)(SaveError);

--- a/frontend/react/src/components/layout/SaveMessage.js
+++ b/frontend/react/src/components/layout/SaveMessage.js
@@ -1,0 +1,58 @@
+import moment from "moment";
+import { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+
+// Configure moment to display '1 time-unit ago' instead of 'a time-unit ago'
+// https://github.com/moment/moment/issues/3764
+moment.updateLocale("en", {
+  relativeTime: {
+    s: "seconds",
+    m: "1 minute",
+    mm: "%d minutes",
+    h: "1 hour",
+    hh: "%d hours",
+    d: "1 day",
+    dd: "%d days",
+    M: "1 month",
+    MM: "%d months",
+    y: "1 year",
+    yy: "%d years",
+  },
+});
+
+const SaveMessage = ({ lastSaved }) => {
+  const [currentMoment, setCurrentMoment] = useState(() => moment());
+
+  useEffect(() => {
+    const timerID = setInterval(() => setCurrentMoment(moment()), 1000);
+    return () => clearInterval(timerID);
+  });
+
+  const lastSavedMoment = moment(lastSaved);
+  const difference = currentMoment.diff(lastSavedMoment);
+  const duration = moment.duration(difference);
+  let result = "Last saved ";
+
+  if (duration.asMinutes() < 1) return "Saved";
+
+  if (duration.asDays() < 1) {
+    result += lastSavedMoment.format("h:mm a");
+  } else if (duration.asYears() < 1) {
+    result += lastSavedMoment.format("MMMM D");
+  } else {
+    result += lastSavedMoment.format("MMMM D, YYYY");
+  }
+
+  result += ` (${lastSavedMoment.fromNow()})`;
+  return result;
+};
+
+SaveMessage.propTypes = {
+  lastSaved: PropTypes.oneOfType([
+    PropTypes.instanceOf(Date),
+    PropTypes.instanceOf(moment),
+    PropTypes.string,
+  ]).isRequired,
+};
+
+export default SaveMessage;

--- a/frontend/react/src/reactRouter.js
+++ b/frontend/react/src/reactRouter.js
@@ -27,19 +27,21 @@ import Section from "./components/layout/Section";
 import test from "./components/test";
 
 import Section3AApi from "./components/sections/section3Aapi/Section3A";
+import SaveError from "./components/layout/SaveError";
 
 let VisibleSidebar =
   window.location.pathname === "/" ||
-    window.location.pathname.split("/")[1] === "reports" ||
-    window.location.pathname.split("/")[1] === "coming-soon" ? null : (
-      <Sidebar />
-    );
+  window.location.pathname.split("/")[1] === "reports" ||
+  window.location.pathname.split("/")[1] === "coming-soon" ? null : (
+    <Sidebar />
+  );
 
 const Routes = ({ userData }) => (
   <Router>
     <div className="ds-l-container">
       <div className="ds-l-row">
         {VisibleSidebar}
+        <SaveError />
         <Switch>
           <Route exact path="/" component={Homepage} />
           <Route exact path="/basic-info" component={BasicInfo} />
@@ -88,7 +90,13 @@ const InvokeSection = ({ userData }) => {
     Number(sectionOrdinal),
     filteredMarker
   );
-  return <Section userData={userData} sectionId={sectionId} subsectionId={subsectionId} />;
+  return (
+    <Section
+      userData={userData}
+      sectionId={sectionId}
+      subsectionId={subsectionId}
+    />
+  );
 };
 
 export default Routes;

--- a/frontend/react/src/scss/_alerts.scss
+++ b/frontend/react/src/scss/_alerts.scss
@@ -5,3 +5,16 @@
 .date-range-err {
   border: 2px solid red !important;
 }
+
+.alert--unexpected-error {
+  position: fixed;
+  top: -200px;
+  margin-top: -200px;
+  transition: top 400ms, margin-top 400ms;
+  z-index: 9;
+
+  &.alert--unexpected-error__active {
+    top: 60px;
+    margin-top: 0;
+  }
+}

--- a/frontend/react/src/store/save.js
+++ b/frontend/react/src/store/save.js
@@ -1,0 +1,29 @@
+import { SAVE_FINISHED, SAVE_STARTED } from "./saveMiddleware";
+
+const initial = {
+  error: false,
+  errorMessage: null,
+  lastSave: null,
+  saving: false,
+};
+
+export default (state = initial, action) => {
+  switch (action.type) {
+    case SAVE_STARTED:
+      return {
+        ...state,
+        saving: true,
+      };
+
+    case SAVE_FINISHED:
+      return {
+        error: action.error,
+        errorMessage: action.errorMessage,
+        lastSave: action.error ? state.lastSave : Date.now(),
+        saving: false,
+      };
+
+    default:
+      return state;
+  }
+};

--- a/frontend/react/src/store/save.js
+++ b/frontend/react/src/store/save.js
@@ -19,7 +19,7 @@ export default (state = initial, action) => {
       return {
         error: action.error,
         errorMessage: action.errorMessage,
-        lastSave: action.error ? state.lastSave : Date.now(),
+        lastSave: action.error ? state.lastSave : new Date(),
         saving: false,
       };
 

--- a/frontend/react/src/store/save.selectors.js
+++ b/frontend/react/src/store/save.selectors.js
@@ -1,0 +1,8 @@
+export const selectHasError = (state) => state.save.error;
+
+export const selectIsSaving = (state) => state.save.saving;
+
+export const selectLastSave = (state) => state.save.lastSave;
+
+export const selectSaveError = (state) =>
+  state.save.error ? state.save.errorMessage : null;

--- a/frontend/react/src/store/saveMiddleware.js
+++ b/frontend/react/src/store/saveMiddleware.js
@@ -2,7 +2,10 @@ import axios from "axios";
 
 import { QUESTION_ANSWERED } from "../actions/initial";
 
-const saveMiddleware = () => {
+export const SAVE_STARTED = "automatic save has started";
+export const SAVE_FINISHED = "automated save has finished";
+
+const saveMiddleware = (store) => {
   let isSaving = false;
   const pending = [];
   const queued = [];
@@ -36,22 +39,34 @@ const saveMiddleware = () => {
       isSaving = true;
 
       try {
-        await axios.post(`${window._env_.API_POSTGRES_URL}/api/v1/sections/2020/AK`, pending);
+        store.dispatch({ type: SAVE_STARTED });
+        await axios.post(
+          `${window._env_.API_POSTGRES_URL}/api/v1/sections/2020/AK`,
+          pending
+        );
 
         // If the save is successful, we can clear out the list of pending
         // saves, because they have been persisted on the server.
         pending.length = 0;
+
+        store.dispatch({ type: SAVE_FINISHED, error: false });
       } catch (error) {
         // In the event of an error, we might dispatch some other action here
         // to set a global error state and update the autosave header. TBD.
 
+        let errorMessage = "An unknown error occurred";
+
         if (error.response && error.response.status === 401) {
+          errorMessage = "You are not currently logged in";
           // User is not logged in.
         } else if (error.response && error.response.status === 403) {
           // User does not have permission.
+          errorMessage = "You do not have permission to save";
         } else {
           // Some other server-side error.
         }
+
+        store.dispatch({ type: SAVE_FINISHED, error: true, errorMessage });
       }
 
       // When the save is finished, we can clear that flag.

--- a/frontend/react/src/store/saveMiddleware.js
+++ b/frontend/react/src/store/saveMiddleware.js
@@ -41,8 +41,10 @@ const saveMiddleware = (store) => {
       try {
         store.dispatch({ type: SAVE_STARTED });
         await axios.post(
-          `${window._env_.API_POSTGRES_URL}/api/v1/sections/2020/AK`,
-          pending
+          `${window._env_.API_POSTGRES_URL}/api/v1/sections/2020/AK/temp`,
+          // In a future world, we might save only the pending changes, but for
+          // now, we save by posting the whole document in its current state.
+          store.getState().formData
         );
 
         // If the save is successful, we can clear out the list of pending

--- a/frontend/react/src/store/storeIndex.js
+++ b/frontend/react/src/store/storeIndex.js
@@ -2,18 +2,19 @@ import { createStore, combineReducers, applyMiddleware } from "redux";
 import thunkMiddleware from "redux-thunk";
 import { composeWithDevTools } from "redux-devtools-extension";
 import formData from "./formData";
+import save from "./save";
 import stateUser from "./stateUser";
 import global from "./globalVariables";
 import saveMiddleware from "./saveMiddleware";
 
 // Consolidate reducers
-export const reducer = combineReducers({ formData, stateUser, global });
+export const reducer = combineReducers({ formData, save, stateUser, global });
 
 // Consolidate middleware
 let middlewareArray = [thunkMiddleware, saveMiddleware];
 // log redux only in dev environment
-if (process.env.NODE_ENV === `development`) {
-  const { logger } = require(`redux-logger`);
+if (process.env.NODE_ENV === "development") {
+  const { logger } = require("redux-logger");
 
   middlewareArray = [...middlewareArray, logger];
 }


### PR DESCRIPTION
- addresses half of #475
- adds a "Saving" status to the header, along with the date and relative time of the last save
- catches save errors and displays a warning to the user
- sends the correct data to the API for saves
- adds a dummy endpoint to the API for saving

When the user has entered or changed some data and the autosave process is triggered, the header is now updated with an animated spinner, which will spin until the save has finished. (Note that the spinner will always be visible for at least 750 ms, even if the save finishes faster. eAPD user research showed that users would often not even notice shorter animations and were unaware that their document had been saved. Mentioned in #256 too.)

### Successful save

When the save is complete, the header switches back to showing the most recent successful save time:

![success](https://user-images.githubusercontent.com/1775733/93521506-c4c2d400-f8f5-11ea-9414-1769a9b65cba.gif)

- For less than a minute, no time is shown
- For less than a day, the last save time and relative time will be shown:
   ![image](https://user-images.githubusercontent.com/1775733/93521560-dc01c180-f8f5-11ea-8add-bcf699c7f4a7.png)
- For less than a year, the last save ***date*** and relative time will be shown (e.g., `July 17 (2 months ago)`)
- For more than a year, the last save date is used (e.g., `July 17, 2019 (1 year ago)`)

Hopefully I didn't overstep by putting this behavior in, but this comes from the user-tested autosave UI from eAPD so I thought it made a good starting point, at least.

### Unsuccessful save

If the save fails, this error message pops up:

![error](https://user-images.githubusercontent.com/1775733/93525752-1e2e0180-f8fc-11ea-9bd8-eb550151ebd3.gif)

### Known shortcomings

I think these are just FYI for @StephanieCoppel for future things for possible future refinements.

- The header in eAPD is stuck to the top of the screen so the "saving"/"last saved" information is always visible. The header in CARTS scrolls off the top of the page, so a user who is further down the page may not have any indication that their document has been saved without scrolling back up to look at it.
   - As an aside, making the header stick to the top of the screen is a bigger lift than it seems like it should be. It's especially troublesome if CARTS needs to fully support Internet Explorer. eAPD made the decision to "partially" support IE, which allowed us to ignore its shortcomings and let it just be ugly.
- The error dialog from eAPD was designed to stick to the bottom of the header, which is always visible. For CARTS, the header scrolls off the top of the page, and the error dialog can become detached and float weirdly over the user's work.