### PR TITLE
Fix.  Give a valid default value for vpn cidr blocks

### DIFF
--- a/data/aws/postgres.tf
+++ b/data/aws/postgres.tf
@@ -41,11 +41,11 @@ module "db" {
   tags = {
     Environment = terraform.workspace
   }
-  subnet_ids                = data.aws_subnet_ids.private.ids
-  family                    = "postgres9.6"
-  major_engine_version      = "9.6"
-  final_snapshot_identifier = "postgres-${terraform.workspace}"
-  deletion_protection       = false
+  subnet_ids                      = data.aws_subnet_ids.private.ids
+  family                          = "postgres9.6"
+  major_engine_version            = "9.6"
+  final_snapshot_identifier       = "postgres-${terraform.workspace}"
+  deletion_protection             = false
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
 }
 
@@ -55,13 +55,17 @@ resource "aws_security_group" "db" {
 
 # Models the VPN Private Security Group (aws:cloudformation:logical-id = PrivateVpnSg)
 resource "aws_security_group_rule" "vpn" {
-  type                     = "ingress"
-  from_port                = 0
-  to_port                  = 0
-  protocol                 = "-1"
-  security_group_id        = aws_security_group.db.id
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.db.id
 
-  cidr_blocks = lookup(local.vpn_cidr_blocks, terraform.workspace, [])
+  cidr_blocks = lookup(local.vpn_cidr_blocks, terraform.workspace, [
+    "10.251.0.0/16",
+    "10.252.0.0/16",
+    "10.232.32.0/19"
+  ])
 }
 
 resource "aws_db_parameter_group" "db_param_group" {


### PR DESCRIPTION
turns out terraform won't accept a blank array.
No worries, we'll just pass a default arary.