### PR TITLE
Make CMSLegend always display label/hint, even if there is no ID

### DIFF
--- a/frontend/react/src/components/fields/CMSLegend.js
+++ b/frontend/react/src/components/fields/CMSLegend.js
@@ -2,23 +2,27 @@ import React from "react";
 import PropTypes from "prop-types";
 
 const CMSLegend = ({ hint, id, label }) => {
+  let labelBits = "";
   if (id) {
     const lastHunk = Number.parseInt(id.substring(id.length - 2), 10);
-
-    return (
-      <legend className="ds-c-label">
-        {Number.isNaN(lastHunk)
-          ? `${Number.parseInt(
-              id.substring(id.length - 4, id.length - 2),
-              10
-            )}${id.substring(id.length - 1)}. ${label}`
-          : `${lastHunk}. ${label}`}
-        {hint && <div className="ds-c-field__hint">{hint}</div>}
-      </legend>
-    );
+    if (Number.isNaN(lastHunk)) {
+      const numberBit = Number.parseInt(
+        id.substring(id.length - 4, id.length - 2),
+        10
+      );
+      labelBits = `${numberBit}${lastHunk} `;
+    } else {
+      labelBits = `${lastHunk}. `;
+    }
   }
 
-  return <legend className="ds-c-label" />;
+  return (
+    <legend className="ds-c-label">
+      {labelBits}
+      {label}
+      {hint && <div className="ds-c-field__hint">{hint}</div>}
+    </legend>
+  );
 };
 CMSLegend.propTypes = {
   hint: PropTypes.string,

--- a/frontend/react/src/components/fields/CMSLegend.js
+++ b/frontend/react/src/components/fields/CMSLegend.js
@@ -10,7 +10,7 @@ const CMSLegend = ({ hint, id, label }) => {
         id.substring(id.length - 4, id.length - 2),
         10
       );
-      labelBits = `${numberBit}${lastHunk} `;
+      labelBits = `${numberBit}${id.substring(id.length - 1)}. `;
     } else {
       labelBits = `${lastHunk}. `;
     }


### PR DESCRIPTION
- addresses the need to replace the help drawer for 3G