### PR TITLE
Fix - Add missing Django requirements causing build failures

### DIFF
--- a/frontend/api_postgres/requirements.txt
+++ b/frontend/api_postgres/requirements.txt
@@ -10,3 +10,6 @@ jsonschema
 jsonpath_ng
 python_jwt
 requests
+cffi
+pycparser
+cryptography


### PR DESCRIPTION
The prod Dockerfile follows the multi stage docker build pattern.  See:  https://docs.docker.com/develop/develop-images/multistage-build/

In the first stage of that dockerfile, 'builder', we read in the requirements.txt and build the appropriate wheels.
In the second stage, 'runner', the wheels are copied from the 'builder' to the runner.

If the prod image tries to install a wheel but some stuff is missing, it will try to install/build what it needs... but the prod image does not have the right libraries to build stuff... by design.  We want it thin!  So the requirements.txt needs to be complete.

Please read the article above for more information, but the end result is a much thinner production image.  The size diff is 100s of MB.

To catch these errors before they happen, run deploy.sh.  This emulates the production deploy and uses the prod Dockerfile.  
