### PR TITLE
State image fix

### DIFF
--- a/frontend/api_postgres/carts/carts_api/views.py
+++ b/frontend/api_postgres/carts/carts_api/views.py
@@ -414,7 +414,7 @@ def authenticate_user(request):
             "abbr": "AZ",
             "programType": "separate_chip",
             "programName": "AZ Program Name??",
-            "imageURI": "{full_host}/img/states/az.svg",
+            "imageURI": f"{full_host}/img/states/az.svg",
             "formName": "CARTS FY",
             "currentUser": {
                 "role": "state_user",
@@ -430,7 +430,7 @@ def authenticate_user(request):
             "abbr": "MA",
             "programType": "combo",
             "programName": "MA Program Name??",
-            "imageURI": "${full_host}/img/states/ma.svg",
+            "imageURI": f"{full_host}/img/states/ma.svg",
             "formName": "CARTS FY",
             "currentUser": {
                 "role": "state_user",

--- a/frontend/api_postgres/carts/carts_api/views.py
+++ b/frontend/api_postgres/carts/carts_api/views.py
@@ -379,7 +379,6 @@ def authenticate_user(request):
     email = userinfo.get("email", "no-eua-email@example.com")
     host = request.get_host()
     scheme = "https" if request.is_secure() else "http"
-    full_host = f"{scheme}://{host}"
 
     # Instead of a DB lookup, here we're just assigning one of the fake users
     # according to EUA ID.

--- a/frontend/api_postgres/carts/carts_api/views.py
+++ b/frontend/api_postgres/carts/carts_api/views.py
@@ -398,7 +398,7 @@ def authenticate_user(request):
             "abbr": "AK",
             "programType": "medicaid_exp_chip",
             "programName": "AK Program Name??",
-            "imageURI": f"{full_host}/img/states/ak.svg",
+            "imageURI": "/img/states/ak.svg",
             "formName": "CARTS FY",
             "currentUser": {
                 "role": "state_user",
@@ -414,7 +414,7 @@ def authenticate_user(request):
             "abbr": "AZ",
             "programType": "separate_chip",
             "programName": "AZ Program Name??",
-            "imageURI": f"{full_host}/img/states/az.svg",
+            "imageURI": "/img/states/az.svg",
             "formName": "CARTS FY",
             "currentUser": {
                 "role": "state_user",
@@ -430,7 +430,7 @@ def authenticate_user(request):
             "abbr": "MA",
             "programType": "combo",
             "programName": "MA Program Name??",
-            "imageURI": f"{full_host}/img/states/ma.svg",
+            "imageURI": "/img/states/ma.svg",
             "formName": "CARTS FY",
             "currentUser": {
                 "role": "state_user",


### PR DESCRIPTION
We don't need hostname
To find the state images
And so, remove it.

I was unnecessarily including `full_host` in the image URI for states.

The better fix is to not send it back from the API at all and just determine it from state in the frontend, but we can make that improvement a little later; for now, just make the images work.