### PR TITLE
Fix - Section 3G not working as expected on dev branches + local deploy.sh workflow

### DIFF
--- a/.jenkins/groovy/JenkinsUtils.groovy
+++ b/.jenkins/groovy/JenkinsUtils.groovy
@@ -123,6 +123,7 @@ void terraformApply(String stateBucket, String workspace, String action, Map tfv
   tfvars.each { k, v -> varString += " -var " + k + "=" + v }
   sh """
     PATH=~/.local/bin:$PATH
+    export TF_LOG=TRACE
     terraform $action ${varString} -input=false -auto-approve
   """
 }

--- a/.jenkins/groovy/JenkinsUtils.groovy
+++ b/.jenkins/groovy/JenkinsUtils.groovy
@@ -123,7 +123,6 @@ void terraformApply(String stateBucket, String workspace, String action, Map tfv
   tfvars.each { k, v -> varString += " -var " + k + "=" + v }
   sh """
     PATH=~/.local/bin:$PATH
-    terraform plan ${varString} > log_tfplan.txt
     terraform $action ${varString} -input=false -auto-approve
   """
 }

--- a/.jenkins/groovy/JenkinsUtils.groovy
+++ b/.jenkins/groovy/JenkinsUtils.groovy
@@ -123,7 +123,6 @@ void terraformApply(String stateBucket, String workspace, String action, Map tfv
   tfvars.each { k, v -> varString += " -var " + k + "=" + v }
   sh """
     PATH=~/.local/bin:$PATH
-    export TF_LOG=TRACE
     terraform $action ${varString} -input=false -auto-approve
   """
 }

--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -239,16 +239,16 @@ resource "aws_wafv2_web_acl" "apiwaf" {
     sampled_requests_enabled   = true
   }
 
-  rule{
-    name = "${terraform.workspace}-api-DDOSRateLimitRule"
+  rule {
+    name     = "${terraform.workspace}-api-DDOSRateLimitRule"
     priority = 0
-    action{
-      count{}
+    action {
+      count {}
     }
 
     statement {
-      rate_based_statement{
-        limit = 5000
+      rate_based_statement {
+        limit              = 5000
         aggregate_key_type = "IP"
       }
     }
@@ -260,18 +260,18 @@ resource "aws_wafv2_web_acl" "apiwaf" {
     }
   }
 
-  rule{
-    name = "${terraform.workspace}-api-RegAWSCommonRule"
+  rule {
+    name     = "${terraform.workspace}-api-RegAWSCommonRule"
     priority = 1
 
-    override_action{
-      count{}
+    override_action {
+      count {}
     }
 
     statement {
-      managed_rule_group_statement{
+      managed_rule_group_statement {
         vendor_name = "AWS"
-        name = "AWSManagedRulesCommonRuleSet"
+        name        = "AWSManagedRulesCommonRuleSet"
       }
     }
 
@@ -282,18 +282,18 @@ resource "aws_wafv2_web_acl" "apiwaf" {
     }
   }
 
-  rule{
-    name = "${terraform.workspace}-api-AWSManagedRulesAmazonIpReputationList"
+  rule {
+    name     = "${terraform.workspace}-api-AWSManagedRulesAmazonIpReputationList"
     priority = 2
 
-    override_action{
-      none{}
+    override_action {
+      none {}
     }
 
     statement {
-      managed_rule_group_statement{
+      managed_rule_group_statement {
         vendor_name = "AWS"
-        name = "AWSManagedRulesAmazonIpReputationList"
+        name        = "AWSManagedRulesAmazonIpReputationList"
       }
     }
 
@@ -304,18 +304,18 @@ resource "aws_wafv2_web_acl" "apiwaf" {
     }
   }
 
-  rule{
-    name = "${terraform.workspace}-api-RegAWSManagedRulesKnownBadInputsRuleSet"
+  rule {
+    name     = "${terraform.workspace}-api-RegAWSManagedRulesKnownBadInputsRuleSet"
     priority = 3
 
-    override_action{
-      count{}
+    override_action {
+      count {}
     }
 
     statement {
-      managed_rule_group_statement{
+      managed_rule_group_statement {
         vendor_name = "AWS"
-        name = "AWSManagedRulesKnownBadInputsRuleSet"
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
       }
     }
 
@@ -326,15 +326,15 @@ resource "aws_wafv2_web_acl" "apiwaf" {
     }
   }
 
-  rule{
-    name = "${terraform.workspace}-api-allow-usa-plus-territories"
+  rule {
+    name     = "${terraform.workspace}-api-allow-usa-plus-territories"
     priority = 5
-    action{
-      allow{}
+    action {
+      allow {}
     }
 
     statement {
-      geo_match_statement{
+      geo_match_statement {
         country_codes = ["US", "GU", "PR", "UM", "VI", "MP"]
       }
     }

--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -1,5 +1,5 @@
 locals {
-  endpoint_api_postgres = var.acm_certificate_domain_api_postgres == "" ? "http://${aws_alb.api_postgres.dns_name}" : "https://${var.acm_certificate_domain_api_postgres}"
+  endpoint_api_postgres = var.acm_certificate_domain_api_postgres == "" ? "http://${aws_alb.api_postgres.dns_name}:8000" : "https://${var.acm_certificate_domain_api_postgres}"
 }
 
 # Number of container instances to spawn per resource. Default is 1.

--- a/frontend/aws/outputs.tf
+++ b/frontend/aws/outputs.tf
@@ -1,6 +1,6 @@
 
 output "application_endpoint" {
-  value = "https://${aws_cloudfront_distribution.www_distribution.domain_name}"
+  value = local.endpoint_ui
 }
 
 output "api_postgres_endpoint" {

--- a/frontend/aws/s3_cloudfront_ui.tf
+++ b/frontend/aws/s3_cloudfront_ui.tf
@@ -42,7 +42,7 @@ resource "aws_cloudfront_distribution" "www_distribution" {
 
   enabled             = true
   default_root_object = "index.html"
-  web_acl_id = aws_wafv2_web_acl.uiwaf.arn
+  web_acl_id          = aws_wafv2_web_acl.uiwaf.arn
 
   custom_error_response {
     error_caching_min_ttl = 3000
@@ -107,16 +107,16 @@ resource "aws_wafv2_web_acl" "uiwaf" {
     sampled_requests_enabled   = true
   }
 
-  rule{
-    name = "${terraform.workspace}-DDOSRateLimitRule"
+  rule {
+    name     = "${terraform.workspace}-DDOSRateLimitRule"
     priority = 0
-    action{
-      count{}
+    action {
+      count {}
     }
 
     statement {
-      rate_based_statement{
-        limit = 5000
+      rate_based_statement {
+        limit              = 5000
         aggregate_key_type = "IP"
       }
     }
@@ -128,18 +128,18 @@ resource "aws_wafv2_web_acl" "uiwaf" {
     }
   }
 
-  rule{
-    name = "${terraform.workspace}-RegAWSCommonRule"
+  rule {
+    name     = "${terraform.workspace}-RegAWSCommonRule"
     priority = 1
 
-    override_action{
-      count{}
+    override_action {
+      count {}
     }
 
     statement {
-      managed_rule_group_statement{
+      managed_rule_group_statement {
         vendor_name = "AWS"
-        name = "AWSManagedRulesCommonRuleSet"
+        name        = "AWSManagedRulesCommonRuleSet"
       }
     }
 
@@ -150,18 +150,18 @@ resource "aws_wafv2_web_acl" "uiwaf" {
     }
   }
 
-  rule{
-    name = "${terraform.workspace}-AWSManagedRulesAmazonIpReputationList"
+  rule {
+    name     = "${terraform.workspace}-AWSManagedRulesAmazonIpReputationList"
     priority = 2
 
-    override_action{
-      none{}
+    override_action {
+      none {}
     }
 
     statement {
-      managed_rule_group_statement{
+      managed_rule_group_statement {
         vendor_name = "AWS"
-        name = "AWSManagedRulesAmazonIpReputationList"
+        name        = "AWSManagedRulesAmazonIpReputationList"
       }
     }
 
@@ -172,18 +172,18 @@ resource "aws_wafv2_web_acl" "uiwaf" {
     }
   }
 
-  rule{
-    name = "${terraform.workspace}-RegAWSManagedRulesKnownBadInputsRuleSet"
+  rule {
+    name     = "${terraform.workspace}-RegAWSManagedRulesKnownBadInputsRuleSet"
     priority = 3
 
-    override_action{
-      count{}
+    override_action {
+      count {}
     }
 
     statement {
-      managed_rule_group_statement{
+      managed_rule_group_statement {
         vendor_name = "AWS"
-        name = "AWSManagedRulesKnownBadInputsRuleSet"
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
       }
     }
 
@@ -194,15 +194,15 @@ resource "aws_wafv2_web_acl" "uiwaf" {
     }
   }
 
-  rule{
-    name = "${terraform.workspace}-allow-usa-plus-territories"
+  rule {
+    name     = "${terraform.workspace}-allow-usa-plus-territories"
     priority = 5
-    action{
-      allow{}
+    action {
+      allow {}
     }
 
     statement {
-      geo_match_statement{
+      geo_match_statement {
         country_codes = ["US", "GU", "PR", "UM", "VI", "MP"]
       }
     }

--- a/frontend/aws/s3_cloudfront_ui.tf
+++ b/frontend/aws/s3_cloudfront_ui.tf
@@ -4,6 +4,13 @@ resource "aws_s3_bucket" "www" {
   bucket        = "cartsfrontendbucket-${terraform.workspace}"
   acl           = "private"
   force_destroy = true
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "PUT", "POST"]
+    allowed_origins = ["*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
 }
 
 data "aws_iam_policy_document" "s3_policy" {

--- a/frontend/aws/s3_cloudfront_ui.tf
+++ b/frontend/aws/s3_cloudfront_ui.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket" "www" {
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["GET", "PUT", "POST"]
-    allowed_origins = ["*"]
+    allowed_origins = [local.endpoint_api_postgres]
     expose_headers  = ["ETag"]
     max_age_seconds = 3000
   }

--- a/frontend/aws/s3_cloudfront_ui.tf
+++ b/frontend/aws/s3_cloudfront_ui.tf
@@ -54,7 +54,7 @@ resource "aws_cloudfront_distribution" "www_distribution" {
 
   // All values are defaults from the AWS console.
   default_cache_behavior {
-    viewer_protocol_policy = "redirect-to-https"
+    viewer_protocol_policy = "allow-all"
     compress               = true
     allowed_methods        = ["GET", "HEAD"]
     cached_methods         = ["GET", "HEAD"]

--- a/frontend/react/Dockerfile
+++ b/frontend/react/Dockerfile
@@ -10,3 +10,46 @@ CMD ["/bin/bash", "-c", "npm install && ./env.sh && cp ./env-config.js ./public/
 
 
 # ==============================================================================
+# => Build container
+FROM dev as builder
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install modules from the package-lock.json
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Create static build
+RUN npm run build
+
+
+# ==============================================================================
+# => Run container
+FROM nginx:1.19.0-alpine as runner
+
+# Copy nginx config
+RUN rm -rf /etc/nginx/conf.d
+COPY conf /etc/nginx
+
+# Copy static build from the builder container
+COPY --from=builder /app/build /usr/share/nginx/html/
+
+# Expose port 80 for nginx
+EXPOSE 80
+
+# Copy .env file and shell script to container; this sets runtime variables
+WORKDIR /usr/share/nginx/html
+COPY ./env.sh .
+COPY .env .
+
+# Add bash to image, so env.sh can be run
+RUN apk add --no-cache bash
+
+# Make env.sh executable
+RUN chmod +x env.sh
+
+# Start Nginx server; env.sh is run first, setting runtime variables on boot
+CMD ["/bin/bash", "-c", "/usr/share/nginx/html/env.sh && nginx -g \"daemon off;\""]


### PR DESCRIPTION
First, quickly, this has a fix for the local deploy workflow... deploy workflow, distinct from deployDev workflow.
The deploy workflow emulates production by building the static archiving and serving it via a web server, while deployDev runs a react sever hot reloading your node source code.

Second and more importantly, this fixes the underlying cause of Section 3G not appearing in Amazon as expected, at least for dev branches.
`
xhr.js:178 Mixed Content: The page at 'https://d16s94n57997et.cloudfront.net/sections/2020/03/g?dev=dev-ma' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://api-postgres-dev-3g-1422176115.us-east-1.elb.amazonaws.com/api/v1/appusers/dev-ma'. This request has been blocked; the content must be served over HTTPS.

xhr.js:178 Mixed Content: The page at 'https://d16s94n57997et.cloudfront.net/sections/2020/03/g?dev=dev-ma' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://api-postgres-dev-3g-1422176115.us-east-1.elb.amazonaws.com/api/v1/sections/2020/MA'. This request has been blocked; the content must be served over HTTPS.
`
This makes sense for lower environments.  When we use https hitting cloudfront, but then ask the browser to hit the api via http, this error occurs.

This fix allows lower environments without an api certificate/https to accept http traffic on cloudfront.
Accessing the cloudfront distro via http works as expected.