### PR TITLE
Make preamble just one part

### DIFF
--- a/frontend/api_postgres/utils/section-schemas/backend-json-section-0.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-section-0.json
@@ -60,60 +60,58 @@
                   "readonly": true,
                   "entry": null
                 }
-              }
-            ]
-          },
-          {
-            "id": "2020-00-a-02",
-            "type": "part",
-            "title": "Contact information",
-            "text": "Who should we contact if we have any questions about your report?",
-            "questions": [
-              {
-                "id": "2020-00-a-02-01",
-                "label": "Contact name:",
-                "type": "text",
-                "answer": {
-                  "entry": null
-                }
-              },
-              {
-                "id": "2020-00-a-02-02",
-                "label": "Job title:",
-                "type": "text",
-                "answer": {
-                  "entry": null
-                }
-              },
-              {
-                "id": "2020-00-a-02-03",
-                "label": "Email:",
-                "type": "email",
-                "answer": {
-                  "entry": null
-                }
-              },
-              {
-                "id": "2020-00-a-02-04",
-                "label": "Full mailing address:",
-                "hint": "Include city, state, and zip code.",
-                "type": "mailing_address",
-                "answer": {
-                  "entry": null
-                }
-              },
-              {
-                "id": "2020-00-a-02-05",
-                "label": "Phone number:",
-                "type": "phone_number",
-                "answer": {
-                  "entry": null
-                }
               },
               {
                 "type": "fieldset",
-                "questions": [],
-                "label": "If any of the above information is incorrect, please contact the <a href='mailto:cartshelp@cms.hhs.gov'>CARTS Help Desk</a>."
+                "label": "Who should we contact if we have any questions about your report?",
+                "questions": [
+                  {
+                    "id": "2020-00-a-01-04",
+                    "label": "Contact name:",
+                    "type": "text",
+                    "answer": {
+                      "entry": null
+                    }
+                  },
+                  {
+                    "id": "2020-00-a-01-05",
+                    "label": "Job title:",
+                    "type": "text",
+                    "answer": {
+                      "entry": null
+                    }
+                  },
+                  {
+                    "id": "2020-00-a-01-06",
+                    "label": "Email:",
+                    "type": "email",
+                    "answer": {
+                      "entry": null
+                    }
+                  },
+                  {
+                    "id": "2020-00-a-01-07",
+                    "label": "Full mailing address:",
+                    "hint": "Include city, state, and zip code.",
+                    "type": "mailing_address",
+                    "answer": {
+                      "entry": null
+                    }
+                  },
+                  {
+                    "id": "2020-00-a-01-08",
+                    "label": "Phone number:",
+                    "type": "phone_number",
+                    "answer": {
+                      "entry": null
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "questions": [],
+                    "label": "If any of the above information is incorrect, please contact the <a href='mailto:cartshelp@cms.hhs.gov'>CARTS Help Desk</a>."
+                  }
+                ]
               }
             ]
           }


### PR DESCRIPTION
Single preamble
Without any divisions
Should be just one part.

As per conversation with Erin, make all of the questions in section zero be a single part, with sequential numbering.

This PR depends on #681 and shouldn't be merged before it. If comparing to a branch before #681 is merged, compare to `tadhg/autogenerate-fixtures` to see what's actually changed here: https://github.com/18F/cms-carts-seds/compare/tadhg/autogenerate-fixtures...tadhg/one-part-section-zero