### PR TITLE
Fix error in state section autogeneration

### DIFF
--- a/frontend/api_postgres/utils/section-schemas/generate_fixtures.py
+++ b/frontend/api_postgres/utils/section-schemas/generate_fixtures.py
@@ -83,7 +83,7 @@ def populate_section_zero(state_info: dict, section: dict) -> dict:
         **contact_element,
         **{"questions": new_contact_qs},
     }
-    updated = new_qs[:1] + [new_contact_fieldset]
+    updated = new_qs[:3] + [new_contact_fieldset]
 
     section["section"]["subsections"][0]["parts"][0]["questions"] = updated
     return section


### PR DESCRIPTION
Three instead of one.
Because as we all must know
Good things come in threes.

Not sure how this ended up as 1 instead of 3—change it to the correct value to ensure that state Section 0 data shows up properly.