### PR TITLE
Add Python linting/formatting configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+# Not ignoring these will clash with black
+ignore = E203, W503

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.black]
+line-length = 79
+
+[tool.pylint."MESSAGES CONTROL"]
+enable = [
+    "use-symbolic-message-instead",
+    "useless-supression",
+    "fixme",
+]
+disable = [
+    "attribute-defined-outside-init",
+    "duplicate-code",
+    "invalid-name",
+    "missing-docstring",
+    "protected-access",
+    "too-few-public-methods",
+    "import-error",
+    "no-value-for-parameter",
+    "format",
+]


### PR DESCRIPTION
Our Python code style
Should at least agree on these;
Put them in one place.

Config options for `black`, `flake8`, and `pylint`.
None of these are enforced yet, but putting the configs here helps standardize.
The pylint settings are my personal preference, although if they weren't rather annoying I wouldn't have disabled them. `import-error` should definitely be disabled, because otherwise editing in your local environment will cause pylint to complain if a library isn't available—even if the library is available in the Docker container, which is what we care about.