### PR TITLE
Toggle between age breakdowns with calculated total and just the total

### DIFF
--- a/frontend/api_postgres/utils/section-schemas/backend-json-section-3.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-section-3.json
@@ -5237,102 +5237,85 @@
               {
                 "type": "fieldset",
                 "label": "Note on age groups",
-                "hint": "Children should be in age groups based on their age on September 30th, the end of the federal fiscal year (FFY). For example, if a child turns three years old on September 15th, the child should be included in the “ages 3-5'' group. Even if the child received dental services on September 1st while they were still two years old, all dental services should be counted as their age at the end of the FFY.",
+                "hint": "Children should be in age groups based on their age on September 30th, the end of the federal fiscal year (FFY). For example, if a child turns three years old on September 15th, the child should be included in the “ages 3–5'' group. Even if the child received dental services on September 1st while they were still two years old, all dental services should be counted as their age at the end of the FFY.",
                 "questions": []
+              },
+              {
+                "id": "2020-03-g-01-01",
+                "type": "radio",
+                "label": "Do you have data for individual age groups?",
+                "hint": "If not, you’ll report the total number for all age groups (0-18 years) instead.",
+                "answer": {
+                  "entry": null,
+                  "options": [
+                    {
+                      "label": "Yes",
+                      "value": "yes"
+                    },
+                    { "label": "No", "value": "no" }
+                  ]
+                }
               },
               {
                 "type": "fieldset",
                 "fieldset_type": "marked",
                 "label": "How many children were enrolled in Separate CHIP for at least 90 continuous days during FFY 2020?",
                 "fieldset_info": {
-                  "id": "2020-03-g-01-01"
-                },
-                "questions": [
-                  {
-                    "type": "fieldset",
-                    "fieldset_type": "datagrid",
-                    "questions": [
-                      {
-                        "comment": "This is the first real question so far in this part…",
-                        "type": "integer",
-                        "id": "2020-03-g-01-01-a",
-                        "label": "All ages 0-18",
-                        "answer": {
-                          "entry": null
-                        }
-                      },
-                      {
-                        "type": "integer",
-                        "id": "2020-03-g-01-01-b",
-                        "label": "Ages 0-1",
-                        "answer": {
-                          "entry": null
-                        }
-                      },
-                      {
-                        "type": "integer",
-                        "id": "2020-03-g-01-01-c",
-                        "label": "Ages 1-2",
-                        "answer": {
-                          "entry": null
-                        }
-                      },
-                      {
-                        "type": "integer",
-                        "id": "2020-03-g-01-01-d",
-                        "label": "Ages 3-5",
-                        "answer": {
-                          "entry": null
-                        }
-                      },
-                      {
-                        "type": "integer",
-                        "id": "2020-03-g-01-01-e",
-                        "label": "Ages 6-9",
-                        "answer": {
-                          "entry": null
-                        }
-                      },
-                      {
-                        "type": "integer",
-                        "id": "2020-03-g-01-01-f",
-                        "label": "Ages 10-14",
-                        "answer": {
-                          "entry": null
-                        }
-                      },
-                      {
-                        "type": "integer",
-                        "id": "2020-03-g-01-01-g",
-                        "label": "Ages 15-18",
-                        "answer": {
-                          "entry": null
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "fieldset",
-                "fieldset_type": "marked",
-                "label": "How many children (who were enrolled in Separate CHIP for at least 90 continuous days) received at least one dental care service during FFY 2020?",
-                "fieldset_info": {
                   "id": "2020-03-g-01-02"
                 },
                 "questions": [
                   {
+                    "id": "2020-03-g-01-02-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-18)",
+                    "answer": {
+                      "entry": null
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-g-01-01')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
                     "type": "fieldset",
                     "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-g-01-01')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
                     "questions": [
                       {
-                        "comment": "This is the first real question so far in this part…",
-                        "type": "integer",
-                        "id": "2020-03-g-01-02-a",
-                        "label": "All ages 0-18",
-                        "answer": {
-                          "entry": null
-                        }
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-18)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-g-01-02-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-02-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-02-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-02-e')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-02-f')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-02-g')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
                       },
                       {
                         "type": "integer",
@@ -5388,30 +5371,64 @@
               },
               {
                 "type": "fieldset",
-                "label": "Dental codes and definitions",
-                "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D0100 - D9999 (or equivalent CDT codes D0100 - D9999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
-                "questions": []
-              },
-              {
-                "type": "fieldset",
                 "fieldset_type": "marked",
-                "label": "How many children (who were enrolled in Separate CHIP for at least 90 continuous days) received at least one preventative dental care service during FFY 2020?",
+                "label": "How many children (who were enrolled in Separate CHIP for at least 90 continuous days) received at least one dental care service during FFY 2020?",
                 "fieldset_info": {
                   "id": "2020-03-g-01-03"
                 },
                 "questions": [
                   {
+                    "id": "2020-03-g-01-03-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-18)",
+                    "answer": {
+                      "entry": null
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-g-01-01')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
                     "type": "fieldset",
                     "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-g-01-01')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
                     "questions": [
                       {
-                        "comment": "This is the first real question so far in this part…",
-                        "type": "integer",
-                        "id": "2020-03-g-01-03-a",
-                        "label": "All ages 0-18",
-                        "answer": {
-                          "entry": null
-                        }
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-18)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-g-01-03-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-03-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-03-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-03-e')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-03-f')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-03-g')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
                       },
                       {
                         "type": "integer",
@@ -5467,30 +5484,70 @@
               },
               {
                 "type": "fieldset",
-                "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D0100 - D9999 (or equivalent CDT codes D0100 - D9999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
+                "label": "Dental care service codes and definitions",
+                "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D0100–D9999 (or equivalent CDT codes D0100–D9999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
                 "questions": []
               },
               {
                 "type": "fieldset",
                 "fieldset_type": "marked",
-                "label": "How many children (who were enrolled in Separate CHIP for at least 90 continuous days) received dental treatment services during FFY 2020?",
-                "hint": "This includes orthodontics, periodontics, implants, oral and maxillofacial surgery, and other treatments.",
+                "label": "How many children (who were enrolled in Separate CHIP for at least 90 continuous days) received at least one dental care service during FFY 2020?",
                 "fieldset_info": {
                   "id": "2020-03-g-01-04"
                 },
                 "questions": [
                   {
+                    "id": "2020-03-g-01-04-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-18)",
+                    "answer": {
+                      "entry": null
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-g-01-01')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
                     "type": "fieldset",
                     "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-g-01-01')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
                     "questions": [
                       {
-                        "comment": "This is the first real question so far in this part…",
-                        "type": "integer",
-                        "id": "2020-03-g-01-04-a",
-                        "label": "All ages 0-18",
-                        "answer": {
-                          "entry": null
-                        }
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-18)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-g-01-04-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-04-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-04-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-04-e')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-04-f')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-04-g')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
                       },
                       {
                         "type": "integer",
@@ -5546,26 +5603,145 @@
               },
               {
                 "type": "fieldset",
-                "label": "Dental codes and definitions",
-                "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D2000 - D9999 (or equivalent CDT codes D2000 - D9999 or equivalent CPT codes that involve periodontics, maxillofacial prosthetics, implants, oral and maxillofacial surgery, orthodontics, adjunctive general services) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
+                "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D0100 - D9999 (or equivalent CDT codes D0100 - D9999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
+                "questions": []
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children (who were enrolled in Separate CHIP for at least 90 continuous days) received dental treatment services during FFY 2020?",
+                "hint": "This includes orthodontics, periodontics, implants, oral and maxillofacial surgery, and other treatments.",
+                "fieldset_info": {
+                  "id": "2020-03-g-01-05"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-g-01-05-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-18)",
+                    "answer": {
+                      "entry": null
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-g-01-01')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-g-01-01')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-18)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-g-01-05-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-05-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-05-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-05-e')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-05-f')].answer.entry",
+                            "$..*[?(@.id=='2020-03-g-01-05-g')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-g-01-05-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-g-01-05-c",
+                        "label": "Ages 1-2",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-g-01-05-d",
+                        "label": "Ages 3-5",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-g-01-05-e",
+                        "label": "Ages 6-9",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-g-01-05-f",
+                        "label": "Ages 10-14",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-g-01-05-g",
+                        "label": "Ages 15-18",
+                        "answer": {
+                          "entry": null
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "label": "Dental treatment service codes and definitions",
+                "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D2000–D9999 (or equivalent CDT codes D2000–D9999 or equivalent CPT codes that involve periodontics, maxillofacial prosthetics, implants, oral and maxillofacial surgery, orthodontics, adjunctive general services) based on an unduplicated paid, unpaid, or denied claim.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
                 "questions": []
               },
               {
                 "type": "integer",
-                "id": "2020-03-g-01-05",
-                "label": "How many children in the “ages 6-9” group received a sealant on at least one permanent molar tooth during FFY 2020?",
+                "id": "2020-03-g-01-06",
+                "label": "How many children in the “ages 6–9” group received a sealant on at least one permanent molar tooth during FFY 2020?",
                 "answer": {
                   "entry": null
                 }
               },
               {
                 "type": "fieldset",
-                "label": "Dental codes and definitions",
-                "hint": "The sealant on a permanent molar tooth is provided by a dental professional for whom placing a sealant is within their scope of practice. It’s defined by HCPCS code D1351 (or equivalent CDT code D1351) based on an unduplicated paid, unpaid, or denied claim. Permanent molars are teeth numbered 2, 3, 14, 15, 18, 19, 30, and 31, and additionally—for states covering sealants on third molars (“wisdom teeth”)—teeth numbered 1, 16, 17, and 32. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
+                "label": "Sealant codes and definitions",
+                "hint": "The sealant on a permanent molar tooth is provided by a dental professional for whom placing a sealant is within their scope of practice. It’s defined by HCPCS code D1351 (or equivalent CDT code D1351) based on an unduplicated paid, unpaid, or denied claim. Permanent molars are teeth numbered 2, 3, 14, 15, 18, 19, 30, and 31, and additionally — for states covering sealants on third molars (“wisdom teeth”) — teeth numbered 1, 16, 17, and 32.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
                 "questions": []
               },
               {
-                "id": "2020-03-g-01-06",
+                "id": "2020-03-g-01-07",
                 "label": "Do you provide supplemental dental coverage?",
                 "type": "radio",
                 "answer": {
@@ -5583,104 +5759,83 @@
                 },
                 "questions": [
                   {
-                    "id": "2020-03-g-01-06-a",
-                    "label": "How many children were enrolled in supplemental dental coverage during FFY 2020?",
-                    "type": "integer",
-                    "answer": {
-                      "entry": null
-                    },
-                    "context_data": {
-                      "conditional_display": {
-                        "type": "conditional_display",
-                        "comment": "Interactive: Hide if 2020-03-g-01-06 is null, or no; noninteractive: hide if that's no.",
-                        "hide_if": {
-                          "target": "$..*[?(@.id=='2020-03-g-01-06')].answer.entry",
-                          "values": {
-                            "interactive": [null, "no"],
-                            "noninteractive": ["no"]
-                          }
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "id": "2020-03-g-01-06-b",
-                    "label": "How many children were enrolled in Separate CHIP for at least 90 continuous days during FFY 2020?",
-                    "hint": "This is the total number for all children between 0-18 years from question 1.",
-                    "type": "integer",
-                    "answer": {
-                      "entry": null
-                    },
-                    "context_data": {
-                      "conditional_display": {
-                        "type": "conditional_display",
-                        "comment": "Interactive: Hide if 2020-03-g-01-06 is null, or no; noninteractive: hide if that's no.",
-                        "hide_if": {
-                          "target": "$..*[?(@.id=='2020-03-g-01-06')].answer.entry",
-                          "values": {
-                            "interactive": [null, "no"],
-                            "noninteractive": ["no"]
-                          }
-                        }
-                      }
-                    }
-                  },
-                  {
                     "type": "fieldset",
-                    "fieldset_type": "synthesized_table",
-                    "fieldset_info": {
-                      "headers": [
-                        {
-                          "contents": "Children enrolled in supplemental dental coverage"
-                        },
-                        {
-                          "contents": "Children enrolled in Separate CHIP"
-                        },
-                        {
-                          "contents": "Percentage"
-                        }
-                      ],
-                      "rows": [
-                        [
-                          {
-                            "targets": [
-                              "$..*[?(@.id=='2020-03-g-01-06-a')].answer.entry"
-                            ]
-                          },
-                          {
-                            "targets": [
-                              "$..*[?(@.id=='2020-03-g-01-06-b')].answer.entry"
-                            ]
-                          },
-                          {
-                            "targets": [
-                              "$..*[?(@.id=='2020-03-g-01-06-a')].answer.entry",
-                              "$..*[?(@.id=='2020-03-g-01-06-b')].answer.entry"
-                            ],
-                            "actions": ["percentage"]
-                          }
-                        ]
-                      ]
-                    },
-                    "questions": [],
                     "context_data": {
                       "conditional_display": {
                         "type": "conditional_display",
-                        "comment": "Interactive: Hide if 2020-03-g-01-06 is null, or no; noninteractive: hide if that's no.",
+                        "comment": "Interactive: Hide if 2020-03-g-01-07 is null, or no; noninteractive: hide if that's no.",
                         "hide_if": {
-                          "target": "$..*[?(@.id=='2020-03-g-01-06')].answer.entry",
+                          "target": "$..*[?(@.id=='2020-03-g-01-07')].answer.entry",
                           "values": {
                             "interactive": [null, "no"],
                             "noninteractive": ["no"]
                           }
                         }
                       }
-                    }
+                    },
+                    "questions": [
+                      {
+                        "id": "2020-03-g-01-07-a",
+                        "label": "How many children were enrolled in supplemental dental coverage during FFY 2020?",
+                        "type": "integer",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "id": "2020-03-g-01-07-b",
+                        "label": "How many children were enrolled in Separate CHIP for at least 90 continuous days during FFY 2020?",
+                        "hint": "This is the total number for all children between 0-18 years from question 1.",
+                        "type": "integer",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_table",
+                        "fieldset_info": {
+                          "headers": [
+                            {
+                              "contents": "Children enrolled in supplemental dental coverage"
+                            },
+                            {
+                              "contents": "Children enrolled in Separate CHIP"
+                            },
+                            {
+                              "contents": "Percentage"
+                            }
+                          ],
+                          "rows": [
+                            [
+                              {
+                                "targets": [
+                                  "$..*[?(@.id=='2020-03-g-01-07-a')].answer.entry"
+                                ]
+                              },
+                              {
+                                "targets": [
+                                  "$..*[?(@.id=='2020-03-g-01-07-b')].answer.entry"
+                                ]
+                              },
+                              {
+                                "targets": [
+                                  "$..*[?(@.id=='2020-03-g-01-07-a')].answer.entry",
+                                  "$..*[?(@.id=='2020-03-g-01-07-b')].answer.entry"
+                                ],
+                                "actions": ["percentage"]
+                              }
+                            ]
+                          ]
+                        },
+                        "questions": []
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "id": "2020-03-g-01-07",
+                "id": "2020-03-g-01-08",
                 "label": "Is there anything else you’d like to add about your dental benefits? If you weren’t able to provide data, let us know why.",
                 "type": "text_multiline",
                 "answer": {
@@ -5688,7 +5843,7 @@
                 }
               },
               {
-                "id": "2020-03-g-01-08",
+                "id": "2020-03-g-01-09",
                 "label": "Optional: Attach any additional documents here.",
                 "type": "file_upload",
                 "answer": {

--- a/frontend/api_postgres/utils/section-schemas/backend-json-section-3.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-section-3.json
@@ -884,118 +884,149 @@
           {
             "id": "2020-03-c-04",
             "type": "part",
+            "title": "Redetermination in Medicaid"
+          },
+          {
+            "id": "2020-03-c-05",
+            "type": "part",
             "title": "Tracking a CHIP cohort over 18 months",
-            "text": "Tracking a cohort of children enrolled in CHIP (Title XXI) will indicate how long a specific group of children stays enrolled over an 18-month period. This information is required by Section 402(a) of CHIPRA.\n\nTo track your cohort, identify a group of children ages 0 to 17years who are newly enrolled in CHIP (Medicaid Expansion CHIP, Separate CHIP, or both) as of the first three months (Jan-Mar) of the last federal fiscal year.\n\nChildren must be 16.5 years or younger when they enroll to ensure they don’t age out of the program by the end of the 18-month tracking period.\n\nIf your eligibility system doesn’t have the ability to track a cohort, you may need to use a unique identifier or flag to track each child over the 18-month period.",
+            "text": "Tracking a cohort of children enrolled in CHIP (Title XXI) will indicate how long a specific group of children stays enrolled over an 18-month period. This information is required by Section 402(a) of CHIPRA.\n\nTo track your cohort, identify a group of children ages 0 to 16 years who are newly enrolled in CHIP and/or Medicaid as of January through March 2020 (the second quarter of FFY 2020). Children in this cohort must be younger than 16 years when they enroll to ensure they don't age out of the program by the end of the 18-month tracking period.\n\nYou’ll identify a new cohort every two years. This year you’ll report on the number of children at the start of the cohort (Jan - Mar 2020) and six months later (July - Sept 2020). Next year you’ll report numbers for the same cohort at 12 months (Jan - Mar 2021) and 18 months later (July - Sept 2021). If data is unknown or unavailable, leave it blank — don’t enter a zero unless the data is known to be zero.",
             "questions": [
               {
                 "type": "fieldset",
-                "label": "January – March 2019 (start of the cohort)",
+                "label": "Helpful hints on age groups",
+                "hint": "Children should be in age groups based on their age at the start of the cohort, when they’re identified as newly enrolled in January, February, or March of 2020. For example, if a child is four years old when they’re newly enrolled, they should continue to be reported in the “ages 1-5” group at 6 months, 12 months, and 18 months later.\n\nThe oldest children in the cohort must be no older than 16 years (and 0 months) to ensure they don’t age out of the program at the end of the 18-month tracking period. That means children in the “ages 13-16” group who are newly enrolled in January 2020 must be born after January 2003. Similarly, children who are newly enrolled in February 2020 must be born after February 2003, and children newly enrolled in March 2020 must be born after March 2003.",
+                "questions": []
+              },
+              {
+                "id": "2020-03-c-05-01",
+                "type": "radio",
+                "label": "How does your state define “newly enrolled” for this cohort?",
+                "answer": {
+                  "entry": null,
+                  "options": [
+                    {
+                      "label": "Newly enrolled in CHIP: Children in this cohort weren’t enrolled in CHIP (Title XXI) during the previous month. For example: Newly enrolled children in January 2020 weren’t enrolled in CHIP in December 2019.",
+                      "value": "new_in_chip"
+                    },
+                    {
+                      "label": "Newly enrolled in CHIP and Medicaid: Children in this cohort weren’t enrolled in CHIP (Title XXI) or Medicaid (Title XIX) during the previous month. For example: Newly enrolled children in January 2020 weren’t enrolled in CHIP or Medicaid in December 2019.",
+                      "value": "new_in_chip_and_medicaid"
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "2020-03-c-05-02",
+                "type": "radio",
+                "label": "Do you have data for individual age groups?",
+                "hint": "If not, you’ll report the total number for all age groups (0-16 years) instead.",
+                "answer": {
+                  "entry": null,
+                  "options": [
+                    {
+                      "label": "Yes",
+                      "value": "yes"
+                    },
+                    { "label": "No", "value": "no" }
+                  ]
+                }
+              },
+              {
+                "type": "fieldset",
+                "label": "January - March 2020 (start of the cohort)",
+                "questions": []
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children were newly enrolled in CHIP between January and March 2020?",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-03"
+                },
                 "questions": [
                   {
-                    "id": "2020-03-c-04-01-unmarked_descendants",
-                    "type": "checkbox",
+                    "id": "2020-03-c-05-03-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
                     "answer": {
-                      "entry": [],
-                      "options": [
-                        {
-                          "label": "I don’t have data for the individual age groups. I’ll report data for the total number for all age groups (0-18 years) instead.",
-                          "value": "true"
+                      "entry": null
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
                         }
-                      ]
+                      }
                     }
                   },
                   {
                     "type": "fieldset",
-                    "label": "How many children were newly enrolled in CHIP between January and March of the last federal fiscal year?",
-                    "hint": "Only include children that weren’t enrolled in CHIP the previous month. (For example: Children who enrolled in January 2020 are “newly enrolled” if they weren’t enrolled in the CHIP in December 2019.)",
-                    "fieldset_info": {
-                      "id": "2020-03-c-04-01"
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
                     },
                     "questions": [
                       {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-03-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-03-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-03-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-03-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
                         "type": "integer",
-                        "label": "Total for all ages",
+                        "id": "2020-03-c-05-03-b",
+                        "label": "Ages 0-1",
                         "answer": {
                           "entry": null
-                        },
-                        "id": "2020-03-c-04-01-a",
-                        "context_data": {
-                          "conditional_display": {
-                            "type": "conditional_display",
-                            "hide_if": {
-                              "target": "$..[?(@.id=='2020-03-c-04-01-unmarked_descendants')].answer.entry",
-                              "values": {
-                                "interactive": [],
-                                "noninteractive": []
-                              }
-                            }
-                          }
                         }
                       },
                       {
-                        "type": "fieldset",
-                        "fieldset_type": "datagrid",
-                        "context_data": {
-                          "conditional_display": {
-                            "type": "conditional_display",
-                            "hide_if": {
-                              "target": "$..[?(@.id=='2020-03-c-04-01-unmarked_descendants')].answer.entry",
-                              "values": {
-                                "interactive": ["true"],
-                                "noninteractive": ["true"]
-                              }
-                            }
-                          }
-                        },
-                        "questions": [
-                          {
-                            "type": "fieldset",
-                            "fieldset_type": "synthesized_value",
-                            "label": "Total for all ages",
-                            "fieldset_info": {
-                              "targets": [
-                                "$..*[?(@.id=='2020-03-c-04-01-b')].answer.entry",
-                                "$..*[?(@.id=='2020-03-c-04-01-c')].answer.entry",
-                                "$..*[?(@.id=='2020-03-c-04-01-d')].answer.entry",
-                                "$..*[?(@.id=='2020-03-c-04-01-e')].answer.entry"
-                              ],
-                              "actions": ["sum"]
-                            },
-                            "questions": []
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-01-b",
-                            "label": "0–1 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-01-c",
-                            "label": "1–5 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-01-d",
-                            "label": "6–12 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-01-e",
-                            "label": "13–18 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          }
-                        ]
+                        "type": "integer",
+                        "id": "2020-03-c-05-03-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-03-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-03-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null
+                        }
                       }
                     ]
                   }
@@ -1003,584 +1034,100 @@
               },
               {
                 "type": "fieldset",
-                "label": "July – September 2019 (6 months later)",
+                "label": "July - September 2020 (6 months later)",
+                "questions": []
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children were continuously enrolled in CHIP six months later?",
+                "hint": "Only include children that didn’t have a break in coverage during the six-month period.",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-04"
+                },
                 "questions": [
                   {
-                    "type": "fieldset",
-                    "fieldset_type": "marked",
-                    "label": "How many children were still continuously enrolled in CHIP six months later?",
-                    "hint": "Only include children that didn’t have a break in coverage during the six-month period.",
-                    "fieldset_info": {
-                      "id": "2020-03-c-04-02"
-                    },
-                    "questions": [
-                      {
-                        "type": "fieldset",
-                        "fieldset_type": "datagrid",
-                        "questions": [
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-02-a",
-                            "label": "Total for all ages",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-02-b",
-                            "label": "0–1 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-02-c",
-                            "label": "1–5 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-02-d",
-                            "label": "6–12 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-02-e",
-                            "label": "13–18 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "type": "fieldset",
-                    "fieldset_type": "marked",
-                    "label": "How many children had a break in CHIP coverage but were re-enrolled in CHIP six months later?",
-                    "fieldset_info": {
-                      "id": "2020-03-c-04-03"
-                    },
-                    "questions": [
-                      {
-                        "type": "fieldset",
-                        "fieldset_type": "datagrid",
-                        "questions": [
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-03-a",
-                            "label": "Total for all ages",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-03-b",
-                            "label": "0–1 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-03-c",
-                            "label": "1–5 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-03-d",
-                            "label": "6–12 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-03-e",
-                            "label": "13–18 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "fieldset",
-                            "fieldset_type": "marked",
-                            "label": "How many children had a break in CHIP coverage but were re-enrolled in Medicaid six months later?",
-                            "fieldset_info": {
-                              "id": "2020-03-c-04-03-f"
-                            },
-                            "questions": [
-                              {
-                                "type": "fieldset",
-                                "fieldset_type": "datagrid",
-                                "questions": [
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-03-f-01",
-                                    "label": "Total for all ages",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-03-f-02",
-                                    "label": "0–1 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-03-f-03",
-                                    "label": "1–5 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-03-f-04",
-                                    "label": "6–12 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-03-f-05",
-                                    "label": "13–18 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "type": "fieldset",
-                    "fieldset_type": "marked",
-                    "label": "How many children were no longer enrolled in CHIP at the end of the six-month period?",
-                    "hint": "Possible reasons for disenrollment:\n•  Transferred to another health insurance program other than CHIP.\n•  Didn’t meet eligibility criteria anymore.\n•  Didn’t complete documentation.\n•  Didn’t pay a premium or enrollment fee.",
-                    "fieldset_info": {
-                      "id": "2020-03-c-04-04"
-                    },
-                    "questions": [
-                      {
-                        "type": "fieldset",
-                        "fieldset_type": "datagrid",
-                        "questions": [
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-04-a",
-                            "label": "Total for all ages",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-04-b",
-                            "label": "0–1 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-04-c",
-                            "label": "1–5 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-04-d",
-                            "label": "6–12 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-04-e",
-                            "label": "13–18 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "fieldset",
-                            "fieldset_type": "marked",
-                            "label": "How many children were no longer enrolled in CHIP but enrolled in Medicaid six months later?",
-                            "fieldset_info": {
-                              "id": "2020-03-c-04-04-f"
-                            },
-                            "questions": [
-                              {
-                                "type": "fieldset",
-                                "fieldset_type": "datagrid",
-                                "questions": [
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-04-f-01",
-                                    "label": "Total for all ages",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-04-f-02",
-                                    "label": "0–1 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-04-f-03",
-                                    "label": "1–5 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-04-f-04",
-                                    "label": "6–12 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-04-f-05",
-                                    "label": "13–18 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "id": "2020-03-c-04-05",
-                    "label": "Anything else you’d like to add about your data?",
-                    "type": "text_multiline",
+                    "id": "2020-03-c-05-04-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
                     "answer": {
                       "entry": null
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
                     }
-                  }
-                ]
-              },
-              {
-                "type": "fieldset",
-                "label": "January – March 2020 (12 months later)",
-                "hint": "Next year you’ll submit the rest of your data at 12 months and 18 months later of tracking your cohort",
-                "questions": [
-                  {
-                    "type": "fieldset",
-                    "fieldset_type": "marked",
-                    "label": "How many children were still continuously enrolled in CHIP 12 months later?",
-                    "hint": "Only include children that didn’t have a break in coverage during the 12-month period.",
-                    "fieldset_info": {
-                      "id": "2020-03-c-04-06"
-                    },
-                    "questions": [
-                      {
-                        "type": "fieldset",
-                        "fieldset_type": "datagrid",
-                        "questions": [
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-06-a",
-                            "label": "Total for all ages",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-06-b",
-                            "label": "0–1 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-06-c",
-                            "label": "1–5 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-06-d",
-                            "label": "6–12 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-06-e",
-                            "label": "13–18 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          }
-                        ]
-                      }
-                    ]
                   },
                   {
                     "type": "fieldset",
-                    "fieldset_type": "marked",
-                    "label": "How many children had a break in CHIP coverage but were re-enrolled in CHIP 12 months later?",
-                    "fieldset_info": {
-                      "id": "2020-03-c-04-07"
-                    },
-                    "questions": [
-                      {
-                        "type": "fieldset",
-                        "fieldset_type": "datagrid",
-                        "questions": [
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-07-a",
-                            "label": "Total for all ages",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-07-b",
-                            "label": "0–1 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-07-c",
-                            "label": "1–5 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-07-d",
-                            "label": "6–12 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-07-e",
-                            "label": "13–18 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "fieldset",
-                            "fieldset_type": "marked",
-                            "label": "How many children had a break in CHIP coverage but were re-enrolled in Medicaid 12 months later?",
-                            "fieldset_info": {
-                              "id": "2020-03-c-04-07-f"
-                            },
-                            "questions": [
-                              {
-                                "type": "fieldset",
-                                "fieldset_type": "datagrid",
-                                "questions": [
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-07-f-01",
-                                    "label": "Total for all ages",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-07-f-02",
-                                    "label": "0–1 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-07-f-03",
-                                    "label": "1–5 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-07-f-04",
-                                    "label": "6–12 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-07-f-05",
-                                    "label": "13–18 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  }
-                                ]
-                              }
-                            ]
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
                           }
-                        ]
+                        }
                       }
-                    ]
-                  },
-                  {
-                    "type": "fieldset",
-                    "fieldset_type": "marked",
-                    "label": "How many children were no longer enrolled in CHIP at the end of the 12-month period?",
-                    "hint": "Possible reasons for disenrollment:\n•  Transferred to another health insurance program other than CHIP.\n•  Didn’t meet eligibility criteria anymore.\n•  Didn’t complete documentation.\n•  Didn’t pay a premium or enrollment fee.",
-                    "fieldset_info": {
-                      "id": "2020-03-c-04-08"
                     },
                     "questions": [
                       {
                         "type": "fieldset",
-                        "fieldset_type": "datagrid",
-                        "questions": [
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-08-a",
-                            "label": "Total for all ages",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-08-b",
-                            "label": "0–1 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-08-c",
-                            "label": "1–5 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-08-d",
-                            "label": "6–12 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-08-e",
-                            "label": "13–18 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "fieldset",
-                            "fieldset_type": "marked",
-                            "label": "How many children were no longer enrolled in CHIP at the end of the 12-month period, and enrolled in Medicaid instead?",
-                            "fieldset_info": {
-                              "id": "2020-03-c-04-08-f"
-                            },
-                            "questions": [
-                              {
-                                "type": "fieldset",
-                                "fieldset_type": "datagrid",
-                                "questions": [
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-08-f-01",
-                                    "label": "Total for all ages",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-08-f-02",
-                                    "label": "0–1 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-08-f-03",
-                                    "label": "1–5 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-08-f-04",
-                                    "label": "6–12 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-08-f-05",
-                                    "label": "13–18 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-04-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-04-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-04-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-04-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-04-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-04-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-04-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-04-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null
+                        }
                       }
                     ]
                   }
@@ -1588,291 +1135,3070 @@
               },
               {
                 "type": "fieldset",
-                "label": "July – September 2020 (18 months later)",
+                "fieldset_type": "marked",
+                "label": "How many children had a break in CHIP coverage but were re-enrolled in CHIP six months later?",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-05"
+                },
                 "questions": [
                   {
-                    "type": "fieldset",
-                    "fieldset_type": "marked",
-                    "label": "How many children were still continuously enrolled in CHIP 18 months later?",
-                    "hint": "Only include children that didn’t have a break in coverage during the 18-month period.",
-                    "fieldset_info": {
-                      "id": "2020-03-c-04-09"
+                    "id": "2020-03-c-05-05-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null
                     },
-                    "questions": [
-                      {
-                        "type": "fieldset",
-                        "fieldset_type": "datagrid",
-                        "questions": [
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-09-a",
-                            "label": "Total for all ages",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-09-b",
-                            "label": "0–1 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-09-c",
-                            "label": "1–5 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-09-d",
-                            "label": "6–12 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-09-e",
-                            "label": "13–18 year olds",
-                            "answer": {
-                              "entry": null
-                            }
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
                           }
-                        ]
+                        }
                       }
-                    ]
+                    }
                   },
                   {
                     "type": "fieldset",
-                    "fieldset_type": "marked",
-                    "label": "How many children had a break in CHIP coverage but were re-enrolled in CHIP 18 months later?",
-                    "fieldset_info": {
-                      "id": "2020-03-c-04-10"
-                    },
-                    "questions": [
-                      {
-                        "type": "fieldset",
-                        "fieldset_type": "datagrid",
-                        "questions": [
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-10-a",
-                            "label": "Total for all ages",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-10-b",
-                            "label": "0–1 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-10-c",
-                            "label": "1–5 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-10-d",
-                            "label": "6–12 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-10-e",
-                            "label": "13–18 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "fieldset",
-                            "fieldset_type": "marked",
-                            "label": "How many children had a break in CHIP coverage but were re-enrolled in Medicaid 18 months later?",
-                            "fieldset_info": {
-                              "id": "2020-03-c-04-10-f"
-                            },
-                            "questions": [
-                              {
-                                "type": "fieldset",
-                                "fieldset_type": "datagrid",
-                                "questions": [
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-10-f-01",
-                                    "label": "Total for all ages",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-10-f-02",
-                                    "label": "0–1 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-10-f-03",
-                                    "label": "1–5 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-10-f-04",
-                                    "label": "6–12 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-10-f-05",
-                                    "label": "13–18 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  }
-                                ]
-                              }
-                            ]
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
                           }
-                        ]
+                        }
                       }
-                    ]
-                  },
-                  {
-                    "type": "fieldset",
-                    "fieldset_type": "marked",
-                    "label": "How many children were no longer enrolled in CHIP at the end of the 18-month period?",
-                    "hint": "Possible reasons for disenrollment:\n•  Transferred to another health insurance program other than CHIP.\n•  Didn’t meet eligibility criteria anymore.\n•  Didn’t complete documentation.\n•  Didn’t pay a premium or enrollment fee.",
-                    "fieldset_info": {
-                      "id": "2020-03-c-04-11"
                     },
                     "questions": [
                       {
                         "type": "fieldset",
-                        "fieldset_type": "datagrid",
-                        "questions": [
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-11-a",
-                            "label": "Total for all ages",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-11-b",
-                            "label": "0–1 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-11-c",
-                            "label": "1–5 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-11-d",
-                            "label": "6–12 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "integer",
-                            "id": "2020-03-c-04-11-e",
-                            "label": "13–18 year olds",
-                            "answer": {
-                              "entry": null
-                            }
-                          },
-                          {
-                            "type": "fieldset",
-                            "fieldset_type": "marked",
-                            "label": "How many children were no longer enrolled in CHIP at the end of the 12-month period, and enrolled in Medicaid instead?",
-                            "fieldset_info": {
-                              "id": "2020-03-c-04-11-f"
-                            },
-                            "questions": [
-                              {
-                                "type": "fieldset",
-                                "fieldset_type": "datagrid",
-                                "questions": [
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-11-f-01",
-                                    "label": "Total for all ages",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-11-f-02",
-                                    "label": "0–1 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-11-f-03",
-                                    "label": "1–5 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-11-f-04",
-                                    "label": "6–12 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "id": "2020-03-c-04-11-f-05",
-                                    "label": "13–18 year olds",
-                                    "answer": {
-                                      "entry": null
-                                    }
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-05-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-05-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-05-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-05-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-05-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-05-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-05-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-05-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null
+                        }
                       }
                     ]
                   }
                 ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "Of the children who had a break in CHIP coverage (in the previous question), how many were enrolled in Medicaid during the break?",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-06"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-05-06-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-06-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-06-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-06-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-06-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-06-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-06-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-06-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-06-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children were no longer enrolled in CHIP six months later?",
+                "hint": "Possible reasons for no longer being enrolled:\n• Transferred to another health insurance program other than CHIP\n• Didn’t meet eligibility criteria anymore\n• Didn’t complete documentation\n• Didn’t pay a premium or enrollment fee",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-07"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-05-07-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-07-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-07-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-07-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-07-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-07-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-07-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-07-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-07-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "Of the children who were no longer enrolled in CHIP (in the previous question), how many were enrolled in Medicaid six months later?",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-08"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-05-08-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-08-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-08-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-08-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-08-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-08-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-08-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-08-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-08-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "2020-03-c-05-09",
+                "type": "text_multiline",
+                "label": "Is there anything else you’d like to add about your data?",
+                "answer": { "entry": null }
+              },
+              {
+                "type": "fieldset",
+                "label": "January - March 2021 (12 months later)",
+                "hint": "Next year you’ll submit this data about your cohort.",
+                "questions": []
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children were continuously enrolled in CHIP 12 months later?",
+                "hint": "Only include children that didn’t have a break in coverage during the 12-month period.",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-10"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-05-10-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-10-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-10-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-10-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-10-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-10-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-10-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-10-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-10-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children had a break in CHIP coverage but were re-enrolled in CHIP 12 months later?",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-11"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-05-11-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-11-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-11-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-11-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-11-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-11-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-11-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-11-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-11-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "Of the children who had a break in CHIP coverage (in the previous question), how many were enrolled in Medicaid during the break?",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-12"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-05-12-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-12-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-12-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-12-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-12-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-12-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-12-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-12-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-12-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children were no longer enrolled in CHIP 12 months later?",
+                "hint": "Possible reasons for not being enrolled:\n• Transferred to another health insurance program other than CHIP\n• Didn’t meet eligibility criteria anymore\n• Didn’t complete documentation\n• Didn’t pay a premium or enrollment fee",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-13"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-05-13-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-13-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-13-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-13-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-13-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-13-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-13-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-13-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-13-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "Of the children who were no longer enrolled in CHIP (in the previous question), how many were enrolled in Medicaid 12 months later?",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-14"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-05-14-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-14-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-14-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-14-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-14-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-14-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-14-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-14-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-14-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "label": "July - September of 2021 (18 months later)",
+                "hint": "Next year you’ll submit this data about your cohort.",
+                "questions": []
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children were continuously enrolled in CHIP 18 months later?",
+                "hint": "Only include children that didn’t have a break in coverage during the 18-month period.",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-15"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-05-15-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-15-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-15-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-15-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-15-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-15-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-15-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-15-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-15-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children had a break in CHIP coverage but were re-enrolled in CHIP 18 months later?",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-16"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-05-16-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-16-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-16-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-16-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-16-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-16-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-16-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-16-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-16-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "Of the children who had a break in CHIP coverage (in the previous question), how many were enrolled in Medicaid during the break?",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-17"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-05-17-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-17-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-17-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-17-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-17-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-17-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-17-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-17-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-17-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children were no longer enrolled in CHIP 18 months later?",
+                "hint": "Possible reasons for not being enrolled:\n• Transferred to another health insurance program other than CHIP\n• Didn’t meet eligibility criteria anymore\n• Didn’t complete documentation\n• Didn’t pay a premium or enrollment fee",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-18"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-05-18-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-18-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-18-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-18-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-18-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-18-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-18-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-18-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-18-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "Of the children who were no longer enrolled in CHIP (in the previous question), how many were enrolled in Medicaid 18 months later?",
+                "fieldset_info": {
+                  "id": "2020-03-c-05-19"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-05-19-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-05-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-05-19-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-19-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-19-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-05-19-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-19-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-19-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-19-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-05-19-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "2020-03-c-05-20",
+                "type": "text_multiline",
+                "label": "Is there anything else you’d like to add about your data?",
+                "answer": { "entry": null }
+              }
+            ]
+          },
+          {
+            "id": "2020-03-c-06",
+            "type": "part",
+            "title": "Tracking a Medicaid (Title XIX) cohort over 18 months",
+            "text": "Tracking a cohort of children enrolled in Medicaid (Title XIX) will indicate how long a specific group of children stays enrolled over an 18-month period. This information is required by Section 402(a) of CHIPRA.\n\nTo track your cohort, identify a group of children ages 0 to 16 years, who are newly enrolled in Medicaid and/or CHIP as of January through March 2020 (the second quarter of FFY 2020). Children in this cohort must be 16 years or younger when they enroll to ensure they don’t age out of the program by the end of the 18-month tracking period.\n\nYou’ll identify a new cohort every two years. This year you’ll report the number of children identified at the start of the cohort (Jan–Mar 2020) and six months later (July–Sept 2020). Next year you’ll report numbers for the same cohort at 12 months (Jan–Mar 2021) and 18 months later (July–Sept 2021). If data is unknown or unavailable, leave it blank — don’t enter a zero unless the data is known to be zero.",
+            "questions": [
+              {
+                "type": "fieldset",
+                "label": "Helpful hints on age groups",
+                "hint": "Children should be in age groups based on their age at the start of the cohort, when they’re identified as newly enrolled in January, February, or March of 2020. For example, if a child is four years old at the start of the cohort, they should continue to be reported in the “ages 1–5” group at 6 months, 12 months, and 18 months later as well.\n\nThe oldest children in the cohort must be no older than 16 years (and 0 months) to ensure they don’t age out of the program at the end of the 18-month tracking period. That means children in the “ages 13–16” group who are newly enrolled in January 2020 must be born after January 2003. Similarly, children who are newly enrolled in February 2020 must be born after February 2003, and children newly enrolled in March 2020 must be born after March 2003.",
+                "questions": []
+              },
+              {
+                "id": "2020-03-c-06-01",
+                "type": "radio",
+                "label": "How does your state define “newly enrolled” for this cohort?",
+                "answer": {
+                  "entry": null,
+                  "options": [
+                    {
+                      "label": "Newly enrolled in CHIP: Children in this cohort weren’t enrolled in CHIP (Title XXI) during the previous month. For example: Newly enrolled children in January 2020 weren’t enrolled in CHIP in December 2019.",
+                      "value": "new_in_chip"
+                    },
+                    {
+                      "label": "Newly enrolled in CHIP and Medicaid: Children in this cohort weren’t enrolled in CHIP (Title XXI) or Medicaid (Title XIX) during the previous month. For example: Newly enrolled children in January 2020 weren’t enrolled in CHIP or Medicaid in December 2019.",
+                      "value": "new_in_chip_and_medicaid"
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "2020-03-c-06-02",
+                "type": "radio",
+                "label": "Do you have data for individual age groups?",
+                "hint": "If not, you’ll report the total number for all age groups (0-16 years) instead.",
+                "answer": {
+                  "entry": null,
+                  "options": [
+                    {
+                      "label": "Yes",
+                      "value": "yes"
+                    },
+                    { "label": "No", "value": "no" }
+                  ]
+                }
+              },
+              {
+                "type": "fieldset",
+                "label": "January - March 2020 (start of the cohort)",
+                "questions": []
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children were newly enrolled in Medicaid between January and March 2020?",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-03"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-03-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-03-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-03-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-03-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-03-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-03-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-03-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-03-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-03-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "label": "July - September 2020 (6 months later)",
+                "questions": []
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children were continuously enrolled in Medicaid six months later?",
+                "hint": "Only include children that didn’t have a break in coverage during the six-month period.",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-04"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-04-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-04-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-04-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-04-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-04-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-04-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-04-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-04-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-04-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children had a break in Medicaid coverage but were re-enrolled in Medicaid six months later?",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-05"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-05-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-05-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-05-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-05-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-05-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-05-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-05-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-05-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-05-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "Of the children who had a break in Medicaid coverage (in the previous question), how many were enrolled in CHIP during the break?",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-06"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-06-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-06-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-06-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-06-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-06-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-06-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-06-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-06-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-06-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children were no longer enrolled in Medicaid six months later?",
+                "hint": "Possible reasons for no longer being enrolled:\n• Transferred to another health insurance program other than Medicaid\n• Didn’t meet eligibility criteria anymore\n• Didn’t complete documentation\n• Didn’t pay a premium or enrollment fee",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-07"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-07-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-07-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-07-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-07-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-07-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-07-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-07-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-07-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-07-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "Of the children who were no longer enrolled in Medicaid (in the previous question), how many were enrolled in CHIP six months later?",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-08"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-08-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-08-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-08-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-08-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-08-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-08-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-08-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-08-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-08-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "2020-03-c-06-09",
+                "type": "text_multiline",
+                "label": "Is there anything else you’d like to add about your data?",
+                "answer": { "entry": null }
+              },
+              {
+                "type": "fieldset",
+                "label": "January - March 2021 (12 months later)",
+                "hint": "Next year you’ll submit this data on your CARTS report.",
+                "questions": []
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children were continuously enrolled in Medicaid 12 months later?",
+                "hint": "Only include children that didn’t have a break in coverage during the 12-month period.",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-10"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-10-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-10-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-10-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-10-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-10-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-10-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-10-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-10-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-10-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children had a break in Medicaid coverage but were re-enrolled in Medicaid 12 months later?",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-11"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-11-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-11-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-11-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-11-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-11-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-11-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-11-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-11-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-11-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "Of the children who had a break in Medicaid coverage (in the previous question), how many were enrolled in CHIP during the break?",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-12"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-12-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-12-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-12-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-12-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-12-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-12-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-12-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-12-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-12-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children were no longer enrolled in Medicaid 12 months later?",
+                "hint": "Possible reasons for not being enrolled:\n• Transferred to another health insurance program other than Medicaid\n• Didn’t meet eligibility criteria anymore\n• Didn’t complete documentation\n• Didn’t pay a premium or enrollment fee",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-13"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-13-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-13-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-13-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-13-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-13-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-13-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-13-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-13-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-13-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "Of the children who were no longer enrolled in Medicaid (in the previous question), how many were enrolled in CHIP 12 months later?",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-14"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-14-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-14-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-14-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-14-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-14-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-14-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-14-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-14-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-14-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "label": "July - September of 2021 (18 months later)",
+                "hint": "Next year you’ll submit this data on your CARTS report.",
+                "questions": []
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children were continuously enrolled in Medicaid 18 months later?",
+                "hint": "Only include children that didn’t have a break in coverage during the 18-month period.",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-15"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-15-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-15-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-15-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-15-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-15-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-15-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-15-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-15-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-15-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children had a break in Medicaid coverage but were re-enrolled in Medicaid 18 months later?",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-16"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-16-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-16-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-16-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-16-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-16-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-16-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-16-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-16-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-16-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "Of the children who had a break in Medicaid coverage (in the previous question), how many were enrolled in CHIP during the break?",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-17"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-17-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-17-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-17-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-17-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-17-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-17-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-17-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-17-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-17-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "How many children were no longer enrolled in Medicaid 18 months later?",
+                "hint": "Possible reasons for not being enrolled:\n• Transferred to another health insurance program other than Medicaid\n• Didn’t meet eligibility criteria anymore\n• Didn’t complete documentation\n• Didn’t pay a premium or enrollment fee",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-18"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-18-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-18-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-18-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-18-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-18-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-18-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-18-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-18-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-18-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "fieldset",
+                "fieldset_type": "marked",
+                "label": "Of the children who were no longer enrolled in Medicaid (in the previous question), how many were enrolled in CHIP 18 months later?",
+                "fieldset_info": {
+                  "id": "2020-03-c-06-19"
+                },
+                "questions": [
+                  {
+                    "id": "2020-03-c-06-19-a",
+                    "type": "integer",
+                    "label": "Total for all ages (0-16)",
+                    "answer": {
+                      "entry": null,
+                      "readonly": true
+                    },
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["yes", null],
+                            "noninteractive": ["yes", null]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "fieldset",
+                    "fieldset_type": "datagrid",
+                    "context_data": {
+                      "conditional_display": {
+                        "type": "conditional_display",
+                        "hide_if": {
+                          "target": "$..[?(@.id=='2020-03-c-06-02')].answer.entry",
+                          "values": {
+                            "interactive": ["no"],
+                            "noninteractive": ["no", null]
+                          }
+                        }
+                      }
+                    },
+                    "questions": [
+                      {
+                        "type": "fieldset",
+                        "fieldset_type": "synthesized_value",
+                        "label": "Total for all ages (0-16)",
+                        "fieldset_info": {
+                          "targets": [
+                            "$..*[?(@.id=='2020-03-c-06-19-b')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-19-c')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-19-d')].answer.entry",
+                            "$..*[?(@.id=='2020-03-c-06-19-e')].answer.entry"
+                          ],
+                          "actions": ["sum"]
+                        },
+                        "questions": []
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-19-b",
+                        "label": "Ages 0-1",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-19-c",
+                        "label": "Ages 1-5",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-19-d",
+                        "label": "Ages 6-12",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      },
+                      {
+                        "type": "integer",
+                        "id": "2020-03-c-06-19-e",
+                        "label": "Ages 13-16",
+                        "answer": {
+                          "entry": null,
+                          "readonly": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "2020-03-c-06-20",
+                "type": "text_multiline",
+                "label": "Is there anything else you’d like to add about your data?",
+                "answer": { "entry": null }
               }
             ]
           }
@@ -2897,7 +5223,7 @@
       {
         "type": "subsection",
         "id": "2020-03-g",
-        "title": "Section 3G: Dental Benefits",
+        "title": "Dental Benefits",
         "parts": [
           {
             "id": "2020-03-g-01",

--- a/frontend/api_postgres/utils/section-schemas/backend-json-section-3.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-section-3.json
@@ -892,9 +892,20 @@
                 "label": "January – March 2019 (start of the cohort)",
                 "questions": [
                   {
-                    "comment": "The “sum” question, that they answer if they don't have the breakdowns, can't really be a true top-level question, because then we couldn't hide it in the case where the breakdown data is available. So it has to be a subquestion, meaning that the top-level question isn't real and can't actually be answered. This introduces the need for the special fieldset used here; see the schema docs for more details.",
+                    "id": "2020-03-c-04-01-unmarked_descendants",
+                    "type": "checkbox",
+                    "answer": {
+                      "entry": [],
+                      "options": [
+                        {
+                          "label": "I don’t have data for the individual age groups. I’ll report data for the total number for all age groups (0-18 years) instead.",
+                          "value": "true"
+                        }
+                      ]
+                    }
+                  },
+                  {
                     "type": "fieldset",
-                    "fieldset_type": "marked",
                     "label": "How many children were newly enrolled in CHIP between January and March of the last federal fiscal year?",
                     "hint": "Only include children that weren’t enrolled in CHIP the previous month. (For example: Children who enrolled in January 2020 are “newly enrolled” if they weren’t enrolled in the CHIP in December 2019.)",
                     "fieldset_info": {
@@ -902,17 +913,55 @@
                     },
                     "questions": [
                       {
+                        "type": "integer",
+                        "label": "Total for all ages",
+                        "answer": {
+                          "entry": null
+                        },
+                        "id": "2020-03-c-04-01-a",
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "hide_if": {
+                              "target": "$..[?(@.id=='2020-03-c-04-01-unmarked_descendants')].answer.entry",
+                              "values": {
+                                "interactive": [],
+                                "noninteractive": []
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
                         "type": "fieldset",
                         "fieldset_type": "datagrid",
+                        "context_data": {
+                          "conditional_display": {
+                            "type": "conditional_display",
+                            "hide_if": {
+                              "target": "$..[?(@.id=='2020-03-c-04-01-unmarked_descendants')].answer.entry",
+                              "values": {
+                                "interactive": ["true"],
+                                "noninteractive": ["true"]
+                              }
+                            }
+                          }
+                        },
                         "questions": [
                           {
-                            "comment": "This is the first real question so far in this part…",
-                            "type": "integer",
-                            "id": "2020-03-c-04-01-a",
+                            "type": "fieldset",
+                            "fieldset_type": "synthesized_value",
                             "label": "Total for all ages",
-                            "answer": {
-                              "entry": null
-                            }
+                            "fieldset_info": {
+                              "targets": [
+                                "$..*[?(@.id=='2020-03-c-04-01-b')].answer.entry",
+                                "$..*[?(@.id=='2020-03-c-04-01-c')].answer.entry",
+                                "$..*[?(@.id=='2020-03-c-04-01-d')].answer.entry",
+                                "$..*[?(@.id=='2020-03-c-04-01-e')].answer.entry"
+                              ],
+                              "actions": ["sum"]
+                            },
+                            "questions": []
                           },
                           {
                             "type": "integer",

--- a/frontend/react/src/components/fields/CMSLegend.js
+++ b/frontend/react/src/components/fields/CMSLegend.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import Text from "../layout/Text";
 
 const CMSLegend = ({ hideNumber, hint, id, label }) => {
   let labelBits = "";
@@ -23,9 +24,7 @@ const CMSLegend = ({ hideNumber, hint, id, label }) => {
       {label}
       {hint && (
         <div className="ds-c-field__hint">
-          {hint.split("\n").map((line) => (
-            <div>{line}</div>
-          ))}
+          <Text>{hint}</Text>
         </div>
       )}
     </legend>

--- a/frontend/react/src/components/fields/DataGrid.js
+++ b/frontend/react/src/components/fields/DataGrid.js
@@ -11,11 +11,7 @@ export const DataGrid = ({ question }) => {
   return (
     <div className={`ds-l-row input-grid__group ${rowStyle}`}>
       {question.questions.map((input) => (
-        <div
-          className={
-            input.type === "fieldset" ? "ds-c-choice__checkedChild" : "ds-l-col"
-          }
-        >
+        <div className="ds-l-col">
           <Question hideNumber={input.type !== "fieldset"} question={input} />
         </div>
       ))}

--- a/frontend/react/src/components/fields/Question.js
+++ b/frontend/react/src/components/fields/Question.js
@@ -71,8 +71,7 @@ const Question = ({ hideNumber, question, setAnswer, ...props }) => {
 
   const shouldRenderChildren =
     (question.type !== "fieldset" ||
-      (question.type === "fieldset" &&
-        question.fieldset_type === "noninteractive_table")) &&
+      question.fieldset_type === "noninteractive_table") &&
     question.type !== "objectives" &&
     question.type !== "radio" &&
     question.type !== "repeatables" &&

--- a/frontend/react/src/components/layout/Part.js
+++ b/frontend/react/src/components/layout/Part.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Alert } from "@cmsgov/design-system-core";
 
+import Text from "./Text";
 import { selectFragment } from "../../store/formData";
 import Question from "../fields/Question";
 import { selectQuestionsForPart } from "../../store/selectors";
@@ -37,7 +38,7 @@ const Part = ({
   if (show) {
     innards = (
       <>
-        {text ? <p>{text}</p> : <></>}
+        {text ? <Text>{text}</Text> : null}
 
         {questions.map((question) => (
           <Question key={question.id} question={question} />

--- a/frontend/react/src/components/layout/Part.js
+++ b/frontend/react/src/components/layout/Part.js
@@ -33,7 +33,7 @@ const Part = ({
 }) => {
   let innards = null;
 
-  const [_, section] = partId.split("-");
+  const [, section] = partId.split("-");
 
   if (show) {
     innards = (

--- a/frontend/react/src/components/layout/Part.js
+++ b/frontend/react/src/components/layout/Part.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Alert } from "@cmsgov/design-system-core";
 
-import Text from "./Text";
 import { selectFragment } from "../../store/formData";
 import Question from "../fields/Question";
 import { selectQuestionsForPart } from "../../store/selectors";
@@ -38,7 +37,7 @@ const Part = ({
   if (show) {
     innards = (
       <>
-        {text ? <Text>{text}</Text> : null}
+        {text ? <p>{text}</p> : null}
 
         {questions.map((question) => (
           <Question key={question.id} question={question} />

--- a/frontend/react/src/components/layout/Subsection.js
+++ b/frontend/react/src/components/layout/Subsection.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { selectSubsectionTitleAndPartIDs } from "../../store/selectors";
 import Part from "./Part";
+import Text from "./Text";
 
 const Subsection = ({ partIds, subsectionId, title, text }) => {
   return (
@@ -10,9 +11,7 @@ const Subsection = ({ partIds, subsectionId, title, text }) => {
       <h2>{title}</h2>
       {text ? (
         <div className="helper-text">
-          {text.split("\n").map((paragraph) => (
-            <p>{paragraph}</p>
-          ))}
+          <Text>{text}</Text>
         </div>
       ) : null}
       {partIds.map((partId, index) => (

--- a/frontend/react/src/components/layout/Text.js
+++ b/frontend/react/src/components/layout/Text.js
@@ -1,0 +1,24 @@
+import React, { useMemo } from "react";
+
+const Text = ({ children }) => {
+  return useMemo(() => {
+    if (children.split) {
+      return children.split("\n\n").map((paragraph, index) => {
+        const lines = paragraph.split("\n");
+
+        const brokenLines = [lines[0]];
+        for (let i = 1; i < lines.length; i += 1) {
+          brokenLines.push(<br />, lines[i]);
+        }
+
+        if (index > 0) {
+          return <p>{brokenLines}</p>;
+        }
+        return brokenLines;
+      });
+    }
+    return children;
+  }, [children]);
+};
+
+export default Text;

--- a/frontend/react/src/util/shouldDisplay.js
+++ b/frontend/react/src/util/shouldDisplay.js
@@ -11,13 +11,6 @@ const hideIf = (state, hideIfInfo) => {
   const targetAnswer = jsonpath.query(state, hideIfInfo.target)[0]; // User's selection from associated question
   const interactiveValues = hideIfInfo.values.interactive; // Array of values which if selected, should hide a question
 
-  if (Array.isArray(targetAnswer)) {
-    if (interactiveValues.length === 0) {
-      return targetAnswer.length === 0;
-    }
-
-    return targetAnswer.some((target) => interactiveValues.includes(target));
-  }
   if (interactiveValues.includes(targetAnswer)) {
     // If the associated answer IS in the interactive array, remove it
     return true;

--- a/frontend/react/src/util/shouldDisplay.js
+++ b/frontend/react/src/util/shouldDisplay.js
@@ -4,25 +4,32 @@ import jsonpath from "./jsonpath";
  * This function determines whether a radio's conditional subquestion should hide
  * @function hideIf
  * @param {object} state - The application state from redux, the object required for jsonpath to query
- * @param {object} hideIf - the hide_if object from a question's context_data
+ * @param {object} hideIfInfo - the hide_if object from a question's context_data
  * @returns {boolean} - determines if an element should be filtered out, returning true hides a question
  */
-const hideIf = (state, hideIf) => {
-  const targetAnswer = jsonpath.query(state, hideIf.target)[0]; // User's selection from associated question
-  const interactiveValues = hideIf.values.interactive; // Array of values which if selected, should hide a question
+const hideIf = (state, hideIfInfo) => {
+  const targetAnswer = jsonpath.query(state, hideIfInfo.target)[0]; // User's selection from associated question
+  const interactiveValues = hideIfInfo.values.interactive; // Array of values which if selected, should hide a question
 
+  if (Array.isArray(targetAnswer)) {
+    if (interactiveValues.length === 0) {
+      return targetAnswer.length === 0;
+    }
+
+    return targetAnswer.some((target) => interactiveValues.includes(target));
+  }
   if (interactiveValues.includes(targetAnswer)) {
     // If the associated answer IS in the interactive array, remove it
     return true;
-  } else {
-    // If the associated answer IS NOT in the interactive array, keep it
-    return false;
   }
+
+  // If the associated answer IS NOT in the interactive array, keep it
+  return false;
 };
 
-const hideIfAll = (state, hideIfAll) => {
-  const answers = hideIfAll.values.interactive;
-  return hideIfAll.targets
+const hideIfAll = (state, hideIfAllInfo) => {
+  const answers = hideIfAllInfo.values.interactive;
+  return hideIfAllInfo.targets
     .map((target) => jsonpath.query(state, target)[0])
     .every((answer) => answers.includes(answer));
 };
@@ -31,12 +38,12 @@ const hideIfAll = (state, hideIfAll) => {
  * This function determines whether a checkbox conditional subquestion should hide
  * @function hideIfNot
  * @param {object} state - The application state from redux, the object required for jsonpath to query
- * @param {object} hideIfNot - the hide_if_not object from a question's context_data
+ * @param {object} hideIfNotInfo - the hide_if_not object from a question's context_data
  * @returns {boolean} - determines if an element should be filtered out, returning true hides a question
  */
-const hideIfNot = (state, hideIfNot) => {
-  const targetAnswer = jsonpath.query(state, hideIfNot.target)[0]; // Array of user selections from associated question
-  const interactiveValues = hideIfNot.values.interactive; // Array of values which if present in a user's selections, should hide a question
+const hideIfNot = (state, hideIfNotInfo) => {
+  const targetAnswer = jsonpath.query(state, hideIfNotInfo.target)[0]; // Array of user selections from associated question
+  const interactiveValues = hideIfNotInfo.values.interactive; // Array of values which if present in a user's selections, should hide a question
 
   const includedBoolean =
     targetAnswer === null
@@ -53,7 +60,7 @@ const hideIfNot = (state, hideIfNot) => {
  * @param {object} context - the context_data from a question
  * @returns {boolean} - determines if an element should be filtered out, returning true means a question will display
  */
-export const shouldDisplay = (state, context) => {
+const shouldDisplay = (state, context) => {
   if (!context || !context.conditional_display) {
     // if there is no context_data or if there is no conditional_display in the context_data object
     return true;
@@ -75,4 +82,12 @@ export const shouldDisplay = (state, context) => {
   if (context.conditional_display.hide_if_not) {
     return !hideIfNot(state, context.conditional_display.hide_if_not);
   }
+
+  // If we don't know what the heck is going on, just return true. Better to
+  // display a question we shouldn't than not.
+  return true;
 };
+
+export default shouldDisplay;
+
+export { shouldDisplay };


### PR DESCRIPTION
Addresses #718 

- puts back the "age breakdown" checkbox
- the checkbox toggles a single input for all ages OR a data grid for the age breakdown that includes a computed total
- updates all the text content to match the document
- disables questions for the future (questions 11-19)
- adds a placeholder for Section 3C part 4, and moves the old part 4 to part 5
- adds section 3C part 6 (basically a repeat of part 5, so it was mostly copy+paste)
- gives the same treatment to section 3G
- adds a helper `<Text>` component that handles breaking big JSON text into multiple lines or paragraphs, so we don't have that logic in multiple places, and updates the `Subsection` and `CMSLegend` components to use the `Text` helper