### PR TITLE
Allow FMAP data to be targets for synthesized value calculation

### DIFF
--- a/docs/section-schemas/backend-json-structure-documentation.rst
+++ b/docs/section-schemas/backend-json-structure-documentation.rst
@@ -646,18 +646,6 @@ Example of using ``rpn``:
 
 The above would display a value equal to ``(((q1 + q2) - q3) / q4) * 3``
 
-One additional type of synthesized value that behaves a bit differently from those that perform calculations is the ``lookupFmapFy`` action. This pulls the enhanced FMAP for the current state. Just add the ``lookupFmapFy`` property to a synthesized table cell and specify the fiscal year as the value. This example shows one such cell in a synthesized table:
-
-..  code:: json
-
-    [
-      { "contents": "FMAP" },
-      {
-        "lookupFmapFy": "2020",
-        "$comment": "This should pull the FMAP data from the API for this state and plug it in (FY20)"
-      },
-    ],
-
 ``synthesized_table``
 ########################
 This displays a table constructed out of values either provided by or indicated in the ``fieldset_info`` property.
@@ -776,6 +764,32 @@ Assuming the answers to the two questions were ``2`` and ``3``, the above would 
              2            3                                                         5
         ======  ===========  ========================================================
 
+Most ``targets`` values will be jsonpath expressions that query the JSON tree, but occasionally it is necessary to pull data in from the Redux store. A target value containing an object with a `lookupFmapFy` key will pull in FMAP data from Redux for the fiscal year specified as the value of that object. For example, this is one row of a synthesized table that has FMAP data for FY20 and FY21:
+
+..   code:: json
+
+    [
+      { "contents": "FMAP" },
+      {
+        "targets": [
+          { "lookupFmapFy": "2020" }
+        ],
+        "actions": ["identity"],
+        "$comment": "This should pull the FMAP data from the API for this state and plug it in (FY20)"
+      },
+      {
+        "targets": [
+          { "lookupFmapFy": "2021" }
+        ],
+        "actions": ["rpn"],
+        "rpn": "@ + 100",
+        "$comment": "This should pull the FMAP data from the API for this state (FY21) and plug it in and add 100 to it"
+      }
+    ],
+
+Because the ``identity`` action is called on the FY20 data, it will be pulled in as is. The FY21 cell shows how the value can be used in further calculation.
+
+If the specified value is not available, the data used in the calculation will be a ``NaN`` and the text displayed in the cell will be "Not available".
 
 ``noninteractive_table``
 ########################

--- a/frontend/api_postgres/utils/section-schemas/backend-json-section-5.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-section-5.json
@@ -717,16 +717,12 @@
                     [
                       { "contents": "FMAP" },
                       {
-                        "targets": [
-                          { "lookupFmapFy": "2020" }
-                        ],
+                        "targets": [{ "lookupFmapFy": "2020" }],
                         "actions": ["identity"],
                         "$comment": "This should pull the FMAP data from the API for this state and plug it in (FY20)"
                       },
                       {
-                        "targets": [
-                          { "lookupFmapFy": "2021" }
-                        ],
+                        "targets": [{ "lookupFmapFy": "2021" }],
                         "actions": ["identity"],
                         "$comment": "This should pull the FMAP data from the API for this state and plug it in (FY21). Since those data are currently unavailable, the cell should say 'Not available'"
                       }

--- a/frontend/api_postgres/utils/section-schemas/backend-json-section-5.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-section-5.json
@@ -717,12 +717,18 @@
                     [
                       { "contents": "FMAP" },
                       {
-                        "lookupFmapFy": "2020",
+                        "targets": [
+                          { "lookupFmapFy": "2020" }
+                        ],
+                        "actions": ["identity"],
                         "$comment": "This should pull the FMAP data from the API for this state and plug it in (FY20)"
                       },
                       {
-                        "contents": "I need custom code to pull FMAP for FFY 2021",
-                        "$comment": "This should pull the FMAP data from the API for this state and plug it in (FY1)"
+                        "targets": [
+                          { "lookupFmapFy": "2021" }
+                        ],
+                        "actions": ["identity"],
+                        "$comment": "This should pull the FMAP data from the API for this state and plug it in (FY21). Since those data are currently unavailable, the cell should say 'Not available'"
                       }
                     ],
                     [

--- a/frontend/react/src/components/fields/SynthesizedTable.js
+++ b/frontend/react/src/components/fields/SynthesizedTable.js
@@ -42,7 +42,13 @@ SynthesizedTable.propTypes = {
 
 const mapStateToProps = (state, { question }) => {
   const rows = question.fieldset_info.rows.map((row) =>
-    row.map((cell) => synthesizeValue(cell, state))
+    row.map((cell) => {
+      const value = synthesizeValue(cell, state);
+
+      return typeof value.contents === "number" && Number.isNaN(value.contents)
+        ? { contents: "Not Available" }
+        : value;
+    })
   );
 
   return { rows };

--- a/frontend/react/src/util/synthesize.js
+++ b/frontend/react/src/util/synthesize.js
@@ -124,11 +124,11 @@ const lookupFMAP = (state, fy) => {
     const stateData = state.allStatesData.filter(
       (st) => st.code === stateAbbr
     )[0];
-    const fmap = stateData?.fmap_set.filter(
-      (year) => year.fiscal_year === +fy
-    )[0].enhanced_FMAP;
+    const fmap =
+      stateData?.fmap_set.filter((year) => year.fiscal_year === +fy)[0]
+        ?.enhanced_FMAP || NaN;
 
-    return `${fmap}`;
+    return fmap;
   }
   return "";
 };
@@ -138,14 +138,13 @@ const synthesizeValue = (value, state) => {
     return value;
   }
 
-  if (value.lookupFmapFy) {
-    return { contents: lookupFMAP(state, value.lookupFmapFy) };
-  }
-
   if (value.targets) {
-    const targets = value.targets.map(
-      (target) => jsonpath.query(state, target)[0]
-    );
+    const targets = value.targets.map((target) => {
+      if (typeof target === "object" && target.lookupFmapFy) {
+        return lookupFMAP(state, target.lookupFmapFy);
+      }
+      return jsonpath.query(state, target)[0];
+    });
 
     if (value.actions) {
       // For now, per the documentation, we only handle a single action, but


### PR DESCRIPTION
This PR revises the implementation of the FMAP lookup to allow those values to behave like other targets and to be used in synthesized value calculations.

As shown here, if the data for the specified FY are unavailable, the value will be displayed as "Not Available". 
![image](https://user-images.githubusercontent.com/6290/94849872-10947380-03f4-11eb-97c5-1b0e9069ed81.png)
The value will remain `NaN` if used in other calculations resulting in further `NaN`s down the chain.

This should hopefully support further work on #727 

closes #733 