### PR TITLE
Don't apply focus ring on forms during a click

### DIFF
--- a/frontend/react/src/scss/_form.scss
+++ b/frontend/react/src/scss/_form.scss
@@ -1,7 +1,8 @@
 /**********************
   FORM
 **********************/
-.errors, .error {
+.errors,
+.error {
   color: #e31c3d;
 }
 
@@ -15,6 +16,10 @@
   button {
     margin-right: ($padding * 3);
   }
+}
+
+[role="region"]:active:focus {
+  outline: none;
 }
 
 .accordion-title {
@@ -140,7 +145,6 @@
 }
 
 .cmsranges {
-
   h3 {
     margin: 2.2rem 0 0 0;
   }
@@ -198,7 +202,6 @@
   text-align: center;
   width: 48%;
 
- 
   .form-buttons {
     @media only screen and (min-width: 767px) {
       text-align: right;
@@ -221,7 +224,7 @@
 .autosave {
   float: left;
   margin: 64px 0 16px;
-  text-align: center;  
+  text-align: center;
   width: 48%;
 }
 
@@ -278,7 +281,7 @@
   .action-buttons {
     display: none;
   }
-  
+
   .unanswered-text {
     margin-bottom: 70px;
   }


### PR DESCRIPTION
The issue here is the browser stylesheet's focus style being applied briefly when clicking on something in the form that isn't an input:

![before](https://user-images.githubusercontent.com/6290/95118857-fcfd4b80-0718-11eb-9550-bd40259c301d.gif)

This PR fixes the issue by disabling the focus ring during the click:

![after](https://user-images.githubusercontent.com/6290/95119079-64b39680-0719-11eb-9e0c-1f4c526115bc.gif)

One small caveat that we shouldn't make changes to focus states that are more extensive than this, for accessibility purposes.

fixes #707 