### PR TITLE
Support markdown-style links

### DIFF
--- a/frontend/api_postgres/utils/section-schemas/backend-json-section-0.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-section-0.json
@@ -16,7 +16,7 @@
             "id": "2020-00-a-01",
             "type": "part",
             "title": "Welcome!",
-            "text": "We already have some information about your state from our records.\nIf any information is incorrect, please contact the <a href='mailto:cartshelp@cms.hhs.gov'>CARTS Help Desk</a>.",
+            "text": "We already have some information about your state from our records.\nIf any information is incorrect, please contact the [CARTS Help Desk](mailto:cartshelp@cms.hhs.gov).",
             "questions": [
               {
                 "id": "2020-00-a-01-01",

--- a/frontend/react/src/components/layout/Part.js
+++ b/frontend/react/src/components/layout/Part.js
@@ -7,6 +7,7 @@ import { selectFragment } from "../../store/formData";
 import Question from "../fields/Question";
 import { selectQuestionsForPart } from "../../store/selectors";
 import { shouldDisplay } from "../../util/shouldDisplay";
+import Text from "./Text";
 
 const showPart = (contextData, programType, state) => {
   if (
@@ -37,7 +38,7 @@ const Part = ({
   if (show) {
     innards = (
       <>
-        {text ? <p>{text}</p> : null}
+        {text ? <Text>{text}</Text> : null}
 
         {questions.map((question) => (
           <Question key={question.id} question={question} />

--- a/frontend/react/src/components/layout/Text.js
+++ b/frontend/react/src/components/layout/Text.js
@@ -1,14 +1,52 @@
 import React, { useMemo } from "react";
 
+const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+
+const parseLinks = (str) => {
+  let links = linkRegex.exec(str);
+  if (links) {
+    // Copy off the string locally so we can modify it. We'll be chopping bits
+    // off as we go along.
+    let remainingStr = str;
+    const parts = [];
+
+    while (links) {
+      const [fullMatch, text, href] = links;
+
+      // Get the part of the remaining text before the link, then push that
+      // preceding text and the link into the parts.
+      const [precedingText] = remainingStr.split(fullMatch);
+      parts.push(precedingText, <a href={href}>{text}</a>);
+
+      // Recompute the remaining string to remove the preceding text and the
+      // link that we've already added to the parts.
+      remainingStr = remainingStr.substr(
+        remainingStr.indexOf(fullMatch) + fullMatch.length
+      );
+
+      links = linkRegex.exec(str);
+    }
+
+    // Add any remaining string to the parts. This is the part of the string
+    // that follows the last link.
+    parts.push(remainingStr);
+
+    return parts;
+  }
+
+  // If there aren't any links, return the original string in an array.
+  return [str];
+};
+
 const Text = ({ children }) => {
   return useMemo(() => {
     if (children.split) {
       return children.split("\n\n").map((paragraph, index) => {
         const lines = paragraph.split("\n");
 
-        const brokenLines = [lines[0]];
+        const brokenLines = [...parseLinks(lines[0])];
         for (let i = 1; i < lines.length; i += 1) {
-          brokenLines.push(<br />, lines[i]);
+          brokenLines.push(<br />, ...parseLinks(lines[i]));
         }
 
         if (index > 0) {


### PR DESCRIPTION
Since we already have a `<Text>` layout component, it made sense to me that the easiest way to add links to section 0 was to parse them out of the text inside that `<Text>` component. Rather than try to parse HTML-style links, which is messy at best, I opted to switch to Markdown-style links. The upshot is that any part of the app that uses the `<Text>` layout component can now have links embedded by using `[link text](link URL)` format.

- addresses #693 
   
   ![screenshot of link in section 0](https://user-images.githubusercontent.com/1775733/95353901-6d2adf00-0889-11eb-84b3-f12e89e7f9ce.png)
