### PR TITLE
Create repeatables label and update json

### DIFF
--- a/frontend/api_postgres/utils/section-schemas/backend-json-section-3.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-section-3.json
@@ -6501,6 +6501,7 @@
               {
                 "id": "2020-03-i-02-01",
                 "type": "repeatables",
+                "typeLabel": "HSI Program",
                 "questions": [
                   {
                     "id": "2020-03-i-02-01-01",

--- a/frontend/api_postgres/utils/section-schemas/backend-json-section-4.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-section-4.json
@@ -40,6 +40,7 @@
                       {
                         "id": "2020-04-a-01-01-01-02",
                         "type": "repeatables",
+                        "typeLabel": "Goal",
                         "questions": [
                           {
                             "id": "2020-04-a-01-01-01-02-01",

--- a/frontend/api_postgres/utils/section-schemas/backend-json-structure-documentation.rst
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-structure-documentation.rst
@@ -988,6 +988,8 @@ Questions of the type ``objective`` have a ``questions`` property, and the immed
 
 Questions of the type ``repeatables`` have a ``questions`` property, and the immediate children in that array must be questions of the type ``repeatable``.
 
+Questions of the type ``repeatables`` have a ``typeLabel`` property, and this property is what is displayed on the front end as the label for the immediate children questions of type repeatable.
+
 Questions of the type ``repeatable`` have a ``questions`` property, and these questions aren't constrained in terms of their types.
 
 The term “goal” below means a ``repeatable`` construct that's being used to represent a goal that is part of an objective's set of goals. HSI programs in Section 2B are handled similarly, except that there's only one level of repeatable there so it's simpler.

--- a/frontend/api_postgres/utils/section-schemas/backend-section.schema.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-section.schema.json
@@ -210,6 +210,9 @@
         "type": {
           "const": "repeatables"
         },
+        "typeLabel": {
+          "type": "string"
+        },
         "comment": {
           "type": "string"
         },

--- a/frontend/react/src/components/fields/Objective.js
+++ b/frontend/react/src/components/fields/Objective.js
@@ -27,7 +27,7 @@ const Objective = ({ headerRef, objective, objectiveNumber }) => {
       <AccordionPanel>
         {children.map((q) => (
           <div className="ds-c-choice__checkedChild">
-            <Question key={q.id} question={q} type="Goal" />
+            <Question key={q.id} question={q} />
           </div>
         ))}
       </AccordionPanel>

--- a/frontend/react/src/components/fields/Repeatables.js
+++ b/frontend/react/src/components/fields/Repeatables.js
@@ -49,7 +49,7 @@ const Repeatables = ({
               headerRef={ref}
               number={i + 1}
               question={q}
-              type={type}
+              type={question.typeLabel ? question.typeLabel : type}
             />
           </AccordionItem>
         ))}


### PR DESCRIPTION
Relates to #763 

- Create typeLabel (string) that can be used as a repeatables property to pass a Label/Name to display in the repeatable header in backend-section-schema.json

- Update Section 3i repeatables to have a typeLabel of "HSI Program"

- For consistency throughout, update Section 4 repeatables that are goals to have a typeLabel of "Goal"

- Add description of typeLabel to repeatables portion of json documentation