### PR TITLE
Remove autologout on auth fail

### DIFF
--- a/frontend/react/src/actions/initial.js
+++ b/frontend/react/src/actions/initial.js
@@ -84,7 +84,7 @@ export const loadUserThenSections = ({ userData, stateCode }) => {
 
 export const secureLoadUserThenSections = ({
   authState,
-  authService,
+  // authService,
   stateCode,
 }) => {
   const xhrURL = `${
@@ -128,7 +128,7 @@ export const secureLoadUserThenSections = ({
          * can't get backend authorization. This crude fix forces logout if the
          * backend calls fail, which is fragile in other ways.
          */
-        authService.logout("/");
+        // authService.logout("/");
         throw err;
       });
   };


### PR DESCRIPTION
While automatic,
It doesn't always make sense
So we remove it.

Removes logging out as soon as auth fails, because it makes troubleshooting hard.