### PR TITLE
Change API health check to work with auth

### DIFF
--- a/frontend/aws/ecs_shared.tf
+++ b/frontend/aws/ecs_shared.tf
@@ -1,6 +1,3 @@
-locals {
-  deployment_minimum_healthy_percent = terraform.workspace == "prod" ? 100 : 0
-}
 
 ####################################################################################################
 # Create some base IAM objects for ECS tasks and services, often shared

--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -115,7 +115,7 @@ resource "aws_ecs_service" "api_postgres" {
     container_name   = "api_postgres"
     container_port   = 8000
   }
-  deployment_minimum_healthy_percent = local.deployment_minimum_healthy_percent
+  deployment_minimum_healthy_percent = 100
 }
 
 resource "null_resource" "wait_for_ecs_stability_api_postgres" {
@@ -175,7 +175,9 @@ resource "aws_alb_target_group" "api_postgres" {
   protocol             = "HTTP"
   deregistration_delay = "1"
   vpc_id               = data.aws_vpc.app.id
-
+  health_check {
+    matcher = "200,403"
+  }
   depends_on = [aws_alb.api_postgres]
 }
 


### PR DESCRIPTION
API has auth added.  This is a dirt simple but hopefully acceptable way to test health.
AWS hits the API tasks for health checks; we are now accepting a 403 as a healthy report.

We're also changing the minimum deployment healthy percentage to 100 for all environemnts.
This will help catch ECS deploy errors earlier.