### PR TITLE
Strip extraneous auth checks

### DIFF
--- a/frontend/react/src/components/Utils/JobCodeRoleAssociations.js
+++ b/frontend/react/src/components/Utils/JobCodeRoleAssociations.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { CSVReader } from "react-papaparse";
-import { useOktaAuth } from "@okta/okta-react";
 import postDataToEndpointWithToken from "../../util/postDataToEndpointWithToken";
 
 const buttonRef = React.createRef();
@@ -13,7 +12,7 @@ const handleOpenDialog = (e) => {
   }
 };
 
-const handleOnFileLoad = (token, data) => {
+const handleOnFileLoad = (data) => {
   data.forEach((row) => {
     if (!row.data.job_code) {
       return;
@@ -23,7 +22,7 @@ const handleOnFileLoad = (token, data) => {
       job_code: row.data.job_code.trim(),
       user_roles: userRoles,
     };
-    postDataToEndpointWithToken(postData, "/roles_assoc/", token);
+    postDataToEndpointWithToken(postData, "/roles_assoc/");
   });
 };
 
@@ -32,11 +31,6 @@ const handleOnError = (err, file, inputElem, reason) => {
 };
 
 const JobCodeRoleAssociation = ({ currentUser }) => {
-  const { authState } = useOktaAuth();
-  const wrappedHandle = (data) => {
-    const { accessToken } = authState;
-    handleOnFileLoad(accessToken, data);
-  };
   const authorized = (
     <>
       <div>
@@ -71,7 +65,7 @@ const JobCodeRoleAssociation = ({ currentUser }) => {
       <div>
         <CSVReader
           ref={buttonRef}
-          onFileLoad={wrappedHandle}
+          onFileLoad={handleOnFileLoad}
           onError={handleOnError}
           config={{ header: true }}
           noClick

--- a/frontend/react/src/components/Utils/StateAssociations.js
+++ b/frontend/react/src/components/Utils/StateAssociations.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { CSVReader } from "react-papaparse";
-import { useOktaAuth } from "@okta/okta-react";
 import postDataToEndpointWithToken from "../../util/postDataToEndpointWithToken";
 
 const buttonRef = React.createRef();
@@ -13,7 +12,7 @@ const handleOpenDialog = (e) => {
   }
 };
 
-const handleOnFileLoad = (token, data) => {
+const handleOnFileLoad = (data) => {
   data.forEach((row) => {
     if (!row.data.username) {
       return;
@@ -23,8 +22,7 @@ const handleOnFileLoad = (token, data) => {
       .map((code) => code.trim());
     postDataToEndpointWithToken(
       { username: row.data.username, state_codes: stateCodes },
-      "/state_assoc/",
-      token
+      "/state_assoc/"
     );
   });
 };
@@ -34,11 +32,6 @@ const handleOnError = (err, file, inputElem, reason) => {
 };
 
 const StateAssociation = ({ currentUser }) => {
-  const { authState } = useOktaAuth();
-  const wrappedHandle = (data) => {
-    const { accessToken } = authState;
-    handleOnFileLoad(accessToken, data);
-  };
   const authorized = (
     <>
       <div>
@@ -64,7 +57,7 @@ const StateAssociation = ({ currentUser }) => {
       <div>
         <CSVReader
           ref={buttonRef}
-          onFileLoad={wrappedHandle}
+          onFileLoad={handleOnFileLoad}
           onError={handleOnError}
           config={{ header: true }}
           noClick

--- a/frontend/react/src/components/Utils/UserRoleAssociations.js
+++ b/frontend/react/src/components/Utils/UserRoleAssociations.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { CSVReader } from "react-papaparse";
-import { useOktaAuth } from "@okta/okta-react";
 import postDataToEndpointWithToken from "../../util/postDataToEndpointWithToken";
 
 const buttonRef = React.createRef();
@@ -13,7 +12,7 @@ const handleOpenDialog = (e) => {
   }
 };
 
-const handleOnFileLoad = (token, data) => {
+const handleOnFileLoad = (data) => {
   data.forEach((row) => {
     if (!row.data.username) {
       return;
@@ -22,7 +21,7 @@ const handleOnFileLoad = (token, data) => {
       username: row.data.username.trim(),
       user_role: row.data.user_role.trim(),
     };
-    postDataToEndpointWithToken(postData, "/role_user_assoc/", token);
+    postDataToEndpointWithToken(postData, "/role_user_assoc/");
   });
 };
 
@@ -31,11 +30,6 @@ const handleOnError = (err, file, inputElem, reason) => {
 };
 
 const UserRoleAssociation = ({ currentUser }) => {
-  const { authState } = useOktaAuth();
-  const wrappedHandle = (data) => {
-    const { accessToken } = authState;
-    handleOnFileLoad(accessToken, data);
-  };
   const authorized = (
     <>
       <div>
@@ -61,7 +55,7 @@ const UserRoleAssociation = ({ currentUser }) => {
       <div>
         <CSVReader
           ref={buttonRef}
-          onFileLoad={wrappedHandle}
+          onFileLoad={handleOnFileLoad}
           onError={handleOnError}
           config={{ header: true }}
           noClick


### PR DESCRIPTION
If we're going to ask
We should ask in just one place
And not repeat things.

Change the way the user-association pages handle authentication to work with the changes in `385-certify-and-submit`.