### PR TITLE
Add separate landing pages for different user roles

### DIFF
--- a/frontend/react/src/components/Utils/InvokeSection.js
+++ b/frontend/react/src/components/Utils/InvokeSection.js
@@ -1,11 +1,10 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { useParams } from "react-router-dom";
 import { constructIdFromYearSectionAndSubsection } from "../../store/formData";
 import Section from "../layout/Section";
 import SecureInitialDataLoad from "./SecureInitialDataLoad";
 
-const InvokeSection = ({ userData }) => {
+const InvokeSection = () => {
   const { state, year, sectionOrdinal, subsectionMarker } = useParams();
   if (state) {
     SecureInitialDataLoad({ stateCode: state });
@@ -22,17 +21,7 @@ const InvokeSection = ({ userData }) => {
     Number(sectionOrdinal),
     filteredMarker
   );
-  return (
-    <Section
-      userData={userData}
-      sectionId={sectionId}
-      subsectionId={subsectionId}
-    />
-  );
-};
-
-InvokeSection.propTypes = {
-  userData: PropTypes.object.isRequired,
+  return <Section sectionId={sectionId} subsectionId={subsectionId} />;
 };
 
 export default InvokeSection;

--- a/frontend/react/src/components/layout/Home.js
+++ b/frontend/react/src/components/layout/Home.js
@@ -1,0 +1,41 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+
+import AdminHome from "./HomeAdmin";
+import CMSHome from "./HomeCMS";
+import StateHome from "./HomeState";
+
+const Home = ({ role, SecureRouteComponent }) => {
+  let content = null;
+  switch (role) {
+    case "admin_user":
+      content = <AdminHome SecureRouteComponent={SecureRouteComponent} />;
+      break;
+    case "bus_user":
+    case "co_user":
+      content = <CMSHome SecureRouteComponent={SecureRouteComponent} />;
+      break;
+    case "state_user":
+      content = <StateHome SecureRouteComponent={SecureRouteComponent} />;
+      break;
+    default:
+      content = null;
+  }
+
+  return (
+    <div className="ds-l-container">
+      <div className="ds-l-row">{content}</div>
+    </div>
+  );
+};
+Home.propTypes = {
+  role: PropTypes.oneOf([PropTypes.bool, PropTypes.string]).isRequired,
+  SecureRouteComponent: PropTypes.element.isRequired,
+};
+
+const mapState = (state) => ({
+  role: state.stateUser?.currentUser?.role,
+});
+
+export default connect(mapState)(Home);

--- a/frontend/react/src/components/layout/HomeAdmin.js
+++ b/frontend/react/src/components/layout/HomeAdmin.js
@@ -1,0 +1,61 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+
+import JobCodeRoleAssociations from "../Utils/JobCodeRoleAssociations";
+import StateAssociations from "../Utils/StateAssociations";
+import UserRoleAssociations from "../Utils/UserRoleAssociations";
+
+const AdminHome = ({ SecureRouteComponent: SecureRoute }) => (
+  <>
+    <SecureRoute exact path="/">
+      <div className="homepage">
+        <div className="ds-l-container">
+          <div className="ds-l-row">
+            <h1 className="page-title ds-u-margin-bottom--0">
+              CHIP Annual Report Template System (CARTS)
+            </h1>
+          </div>
+          <div className="page-info">
+            <div className="edit-info">admin</div>
+          </div>
+          <div className="ds-l-row">
+            <ul>
+              <li>
+                <Link to="/state_assoc">
+                  Associate usernames (EUA IDs) to states
+                </Link>
+              </li>
+              <li>
+                <Link to="/role_user_assoc">
+                  Associate usernames (EUA IDs) to CARTS roles
+                </Link>
+              </li>
+              <li>
+                <Link to="/role_jobcode_assoc">
+                  Associate EUA job codes to CARTS roles
+                </Link>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </SecureRoute>
+    <SecureRoute exact path="/state_assoc" component={StateAssociations} />
+    <SecureRoute
+      exact
+      path="/role_user_assoc"
+      component={UserRoleAssociations}
+    />
+    <SecureRoute
+      exact
+      path="/role_jobcode_assoc"
+      component={JobCodeRoleAssociations}
+    />
+  </>
+);
+AdminHome.propTypes = {
+  SecureRouteComponent: PropTypes.element.isRequired,
+};
+
+export default AdminHome;

--- a/frontend/react/src/components/layout/HomeCMS.js
+++ b/frontend/react/src/components/layout/HomeCMS.js
@@ -1,0 +1,24 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Switch } from "react-router";
+
+import CMSHomepage from "../sections/homepage/CMSHomepage";
+import SaveError from "./SaveError";
+import ScrollToTop from "../Utils/ScrollToTop";
+
+const CMSHome = ({ SecureRouteComponent: SecureRoute }) => (
+  <>
+    <SecureRoute path="/" />
+    <SaveError />
+    <ScrollToTop />
+    <Switch>
+      <SecureRoute exact path="/" component={CMSHomepage} />
+    </Switch>
+  </>
+);
+
+CMSHome.propTypes = {
+  SecureRouteComponent: PropTypes.element.isRequired,
+};
+
+export default CMSHome;

--- a/frontend/react/src/components/layout/HomeState.js
+++ b/frontend/react/src/components/layout/HomeState.js
@@ -1,0 +1,51 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Switch } from "react-router";
+
+import CertifyAndSubmit from "./CertifyAndSubmit";
+import Homepage from "../sections/homepage/Homepage";
+import InvokeSection from "../Utils/InvokeSection";
+import SaveError from "./SaveError";
+import ScrollToTop from "../Utils/ScrollToTop";
+import Sidebar from "./Sidebar";
+
+const StateHome = ({ SecureRouteComponent: SecureRoute }) => (
+  <>
+    <SecureRoute path="/" />
+    <SaveError />
+    <ScrollToTop />
+    <Switch>
+      <SecureRoute exact path="/" component={Homepage} />
+
+      <SecureRoute
+        exact
+        path="/views/sections/:state/:year/:sectionOrdinal/:subsectionMarker"
+      >
+        <Sidebar />
+        <InvokeSection />
+      </SecureRoute>
+      <SecureRoute path="/views/sections/:state/:year/:sectionOrdinal">
+        <Sidebar />
+        <InvokeSection />
+      </SecureRoute>
+
+      <SecureRoute path="/sections/:year/certify-and-submit" exact>
+        <Sidebar />
+        <CertifyAndSubmit />
+      </SecureRoute>
+      <SecureRoute path="/sections/:year/:sectionOrdinal/:subsectionMarker">
+        <Sidebar />
+        <InvokeSection />
+      </SecureRoute>
+      <SecureRoute path="/sections/:year/:sectionOrdinal">
+        <Sidebar />
+        <InvokeSection />
+      </SecureRoute>
+    </Switch>
+  </>
+);
+StateHome.propTypes = {
+  SecureRouteComponent: PropTypes.element.isRequired,
+};
+
+export default StateHome;

--- a/frontend/react/src/components/sections/homepage/CMSHomepage.js
+++ b/frontend/react/src/components/sections/homepage/CMSHomepage.js
@@ -1,0 +1,34 @@
+import React from "react";
+
+const CMSHomepage = () => (
+  <div className="homepage">
+    <div className="ds-l-container">
+      <div className="ds-l-row ds-u-padding-left--2">
+        <h1 className="page-title ds-u-margin-bottom--0">
+          CHIP Annual Report Template System (CARTS)
+        </h1>
+      </div>
+      <div className="page-info ds-u-padding-left--2">
+        <div className="edit-info">CMS user</div>
+      </div>
+
+      <div className="ds-l-row">
+        <div className="reports ds-l-col--12">
+          <div className="carts-report preview__grid">
+            <div className="ds-l-row">
+              <legend className="ds-u-padding--2 ds-h3">All Reports</legend>
+            </div>
+            <div className="report-header ds-l-row">
+              <div className="name ds-l-col--1">Year</div>
+              <div className="status ds-l-col--2">Status</div>
+              <div className="actions ds-l-col--3">Actions</div>
+            </div>
+            ... here is where we’ll list all the reports...
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default CMSHomepage;

--- a/frontend/react/src/store/stateUser.js
+++ b/frontend/react/src/store/stateUser.js
@@ -33,9 +33,9 @@ const initialState = {
   imageURI: `${process.env.PUBLIC_URL}/img/states/ny.svg`,
   formName: "CARTS FY",
   currentUser: {
-    role: "admin",
-    state: { id: "NY", name: "New York" },
-    username: "karen.dalton@state.gov",
+    role: false,
+    state: { id: "", name: "" },
+    username: "",
   },
 };
 

--- a/frontend/react/src/wrapSecurity.js
+++ b/frontend/react/src/wrapSecurity.js
@@ -1,12 +1,7 @@
 import React from "react";
 import "font-awesome/css/font-awesome.min.css";
 import "./App.scss";
-import {
-  BrowserRouter as Router,
-  Route,
-  Switch,
-  useLocation,
-} from "react-router-dom";
+import { BrowserRouter as Router, Route, useLocation } from "react-router-dom";
 import {
   Security,
   SecureRoute as OktaSecureRoute,
@@ -14,21 +9,13 @@ import {
 } from "@okta/okta-react";
 import * as qs from "query-string";
 import Header from "./components/layout/Header";
+import Home from "./components/layout/Home";
 import Footer from "./components/layout/Footer";
 import Userinfo from "./components/sections/Userinfo";
 import UserProfile from "./components/sections/UserProfile";
-import InvokeSection from "./components/Utils/InvokeSection";
 import SecureInitialDataLoad from "./components/Utils/SecureInitialDataLoad";
-import Sidebar from "./components/layout/Sidebar";
-import ScrollToTop from "./components/Utils/ScrollToTop";
-import StateAssociations from "./components/Utils/StateAssociations";
-import UserRoleAssociations from "./components/Utils/UserRoleAssociations";
-import JobCodeRoleAssociations from "./components/Utils/JobCodeRoleAssociations";
-import SaveError from "./components/layout/SaveError";
 import Profile from "./Profile";
 import config from "./auth-config";
-import CertifyAndSubmit from "./components/layout/CertifyAndSubmit";
-import Homepage from "./components/sections/homepage/Homepage";
 
 const WrappedSecurity = () => {
   const VisibleHeader =
@@ -72,64 +59,14 @@ const WrappedSecurity = () => {
       >
         {VisibleHeader}
         <Router>
-          <div className="ds-l-container">
-            <div className="ds-l-row">
-              <SecureInitialDataLoad
-                stateCode={stateCode}
-                userData={userData}
-              />
-              <SecureRoute path="/" />
-              <SaveError />
-              <ScrollToTop />
-              <Route path={config.callback} component={LoginCallback} />
-              <SecureRoute path="/profile" component={Profile} />
-              <Switch>
-                <SecureRoute exact path="/" component={Homepage} />
-                <SecureRoute path="/user/profile" component={UserProfile} />
+          <SecureInitialDataLoad stateCode={stateCode} userData={userData} />
+          <Route path={config.callback} component={LoginCallback} />
+          <Home SecureRouteComponent={SecureRoute} />
 
-                <SecureRoute
-                  exact
-                  path="/views/sections/:state/:year/:sectionOrdinal/:subsectionMarker"
-                >
-                  <Sidebar />
-                  <InvokeSection />
-                </SecureRoute>
-                <SecureRoute path="/views/sections/:state/:year/:sectionOrdinal">
-                  <Sidebar />
-                  <InvokeSection />
-                </SecureRoute>
-
-                <SecureRoute path="/sections/:year/certify-and-submit" exact>
-                  <Sidebar />
-                  <CertifyAndSubmit />
-                </SecureRoute>
-                <SecureRoute path="/sections/:year/:sectionOrdinal/:subsectionMarker">
-                  <Sidebar />
-                  <InvokeSection userData={userData} />
-                </SecureRoute>
-                <SecureRoute path="/sections/:year/:sectionOrdinal">
-                  <Sidebar />
-                  <InvokeSection userData={userData} />
-                </SecureRoute>
-              </Switch>
-              <SecureRoute exact path="/userinfo" component={Userinfo} />
-              <SecureRoute
-                exact
-                path="/state_assoc"
-                component={StateAssociations}
-              />
-              <SecureRoute
-                exact
-                path="/role_user_assoc"
-                component={UserRoleAssociations}
-              />
-              <SecureRoute
-                exact
-                path="/role_jobcode_assoc"
-                component={JobCodeRoleAssociations}
-              />
-            </div>
-          </div>
+          {/* These routes are available to everyone, so define them here */}
+          <SecureRoute exact path="/userinfo" component={Userinfo} />
+          <SecureRoute path="/profile" component={Profile} />
+          <SecureRoute path="/user/profile" component={UserProfile} />
         </Router>
         {VisibleFooter}
       </SecurityWrapper>


### PR DESCRIPTION
Another step towards completing #300.

- adds distinct landing pages for state users (same as current default landing page), admin users (screenshot below), and business/CO users (these two currently get the same page)
- tweaks routing so that only admin users get admin routes, state users get state routes, etc.

Some things we'll need before #300 can be closed:

- an API endpoint for business/CO users to fetch a list of all reports
- the `CMSHomepage` component is updated to show that list of reports
- `SecureInitialDataLoad` will need to be smarter to handle user types
- we'll want to delay loading whole reports until the bus/CO user clicks it, for performance reasons

@StephanieCoppel Should business/CO users only see certified reports, or should they see all reports along with their statuses? Same question for whether or not they can review all reports, or just certified ones.

---

Admin page:
![screenshot of admin landing page](https://user-images.githubusercontent.com/1775733/96490589-a73f9d80-1206-11eb-837e-d1eeb39eb592.png)
