### PR TITLE
Add a page for CMS CO and business owner users

### DIFF
--- a/frontend/react/src/actions/initial.js
+++ b/frontend/react/src/actions/initial.js
@@ -4,6 +4,7 @@ import { getProgramData, getStateData, getUserData } from "../store/stateUser";
 export const LOAD_SECTIONS = "LOAD SECTIONS";
 export const GET_ALL_STATES_DATA = "GET_ALL_STATES_DATA";
 export const SET_STATE_STATUS = "SET_STATE_STATUS";
+export const SET_STATE_STATUSES = "SET_STATE_STATUSES";
 export const QUESTION_ANSWERED = "QUESTION ANSWERED";
 
 /* eslint-disable no-underscore-dangle, no-console */
@@ -18,6 +19,40 @@ export const getAllStatesData = () => {
       console.dir(err);
     }
   };
+};
+
+export const getAllStateStatuses = () => async (dispatch, getState) => {
+  const { data } = await axios.get(`/state_status/`);
+  const year = +getState().global.formYear;
+
+  const payload = data
+    .filter((status) => status.year === year)
+    .sort((a, b) => {
+      const dateA = new Date(a.last_changed);
+      const dateB = new Date(b.last_changed);
+
+      if (dateA > dateB) {
+        return 1;
+      }
+      if (dateA < dateB) {
+        return -1;
+      }
+      return 0;
+    })
+    .filter(
+      (status, index, original) =>
+        original.slice(index + 1).findIndex((el) => el.state === status.state) <
+        0
+    )
+    .reduce(
+      (out, status) => ({
+        ...out,
+        [status.state.replace(/.*\/([A-Z]{2})\//, "$1")]: status.status,
+      }),
+      {}
+    );
+
+  dispatch({ type: SET_STATE_STATUSES, payload });
 };
 
 export const getStateStatus = ({ stateCode }) => async (dispatch, getState) => {
@@ -81,34 +116,22 @@ export const loadSections = ({ userData, stateCode }) => {
   };
 };
 
-export const loadUserThenSections = (userToken) => {
-  const getUser = async () =>
-    userToken
-      ? axios.get(`/api/v1/appusers/${userToken}`)
-      : axios.post(`/api/v1/appusers/auth`);
+export const loadUser = (userToken) => async (dispatch) => {
+  const { data } = userToken
+    ? await axios.get(`/api/v1/appusers/${userToken}`)
+    : await axios.post(`/api/v1/appusers/auth`);
+  dispatch(getUserData(data.currentUser));
+  dispatch(getStateData(data));
+  dispatch(getProgramData(data));
+};
 
-  return async (dispatch) => {
-    await getUser()
-      .then(({ data }) => {
-        const stateCode = data.currentUser.state.id;
-        dispatch(loadSections({ userData: data, stateCode }));
-        dispatch(getProgramData(data));
-        dispatch(getStateData(data));
-        dispatch(getStateStatus({ stateCode }));
-        dispatch(getUserData(data.currentUser));
-        dispatch(getAllStatesData());
-      })
-      .catch((err) => {
-        /*
-         * Error-handling would go here, but for now, since the anticipated
-         * error is trying to run on cartsdemo, we just use the fake data.
-         * This fake user data has AK/AZ/MA, just like the fake data on the
-         * server. Log the error and proceed.
-         */
-        console.log("--- ERROR LOADING USER FROM API ---");
-        console.log(err);
-      });
-  };
+export const loadForm = (state) => async (dispatch, getState) => {
+  const { stateUser } = getState();
+  const stateCode = state ?? stateUser.currentUser.state.id;
+
+  dispatch(loadSections({ userData: stateUser, stateCode }));
+  dispatch(getStateStatus({ stateCode }));
+  dispatch(getAllStatesData());
 };
 
 // Move this to where actions should go when we know where that is.

--- a/frontend/react/src/components/Utils/InvokeSection.js
+++ b/frontend/react/src/components/Utils/InvokeSection.js
@@ -1,14 +1,20 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { connect, useDispatch } from "react-redux";
 import { useParams } from "react-router-dom";
+import { loadForm } from "../../actions/initial";
 import { constructIdFromYearSectionAndSubsection } from "../../store/formData";
 import Section from "../layout/Section";
-import SecureInitialDataLoad from "./SecureInitialDataLoad";
 
-const InvokeSection = () => {
+const InvokeSection = (username) => {
   const { state, year, sectionOrdinal, subsectionMarker } = useParams();
-  if (state) {
-    SecureInitialDataLoad({ stateCode: state });
-  }
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (username) {
+      dispatch(loadForm(state));
+    }
+  }, [username]);
+
   const filteredMarker = subsectionMarker
     ? subsectionMarker.toLowerCase()
     : "a";
@@ -24,4 +30,8 @@ const InvokeSection = () => {
   return <Section sectionId={sectionId} subsectionId={subsectionId} />;
 };
 
-export default InvokeSection;
+const mapState = (state) => ({
+  username: state.stateUser.currentUser.username,
+});
+
+export default connect(mapState)(InvokeSection);

--- a/frontend/react/src/components/Utils/SecureInitialDataLoad.js
+++ b/frontend/react/src/components/Utils/SecureInitialDataLoad.js
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { useOktaAuth } from "@okta/okta-react";
-import { loadUserThenSections } from "../../actions/initial";
+import { loadUser } from "../../actions/initial";
 import { setToken } from "../../authenticatedAxios";
 
 const SecureInitialDataLoad = ({ userData }) => {
@@ -14,7 +14,7 @@ const SecureInitialDataLoad = ({ userData }) => {
   useEffect(() => {
     if (userData !== false) {
       setToken();
-      dispatch(loadUserThenSections(userData.userToken));
+      dispatch(loadUser(userData.userToken));
     }
   }, []);
 
@@ -26,10 +26,14 @@ const SecureInitialDataLoad = ({ userData }) => {
     // brackets.
     if (authState && authService) {
       if (!authState.isAuthenticated) {
-        // show logged-out page here?
+        if (!authState.isPending) {
+          authService.login();
+        } else {
+          // show logged-out page here?
+        }
       } else {
         setToken(authState.accessToken);
-        dispatch(loadUserThenSections());
+        dispatch(loadUser());
       }
     }
   }, [authState, authService]);

--- a/frontend/react/src/components/layout/HomeCMS.js
+++ b/frontend/react/src/components/layout/HomeCMS.js
@@ -3,16 +3,28 @@ import PropTypes from "prop-types";
 import { Switch } from "react-router";
 
 import CMSHomepage from "../sections/homepage/CMSHomepage";
+import InvokeSection from "../Utils/InvokeSection";
 import SaveError from "./SaveError";
 import ScrollToTop from "../Utils/ScrollToTop";
+import Sidebar from "./Sidebar";
 
 const CMSHome = ({ SecureRouteComponent: SecureRoute }) => (
   <>
-    <SecureRoute path="/" />
     <SaveError />
     <ScrollToTop />
     <Switch>
       <SecureRoute exact path="/" component={CMSHomepage} />
+      <SecureRoute
+        exact
+        path="/views/sections/:state/:year/:sectionOrdinal/:subsectionMarker"
+      >
+        <Sidebar />
+        <InvokeSection />
+      </SecureRoute>
+      <SecureRoute path="/views/sections/:state/:year/:sectionOrdinal">
+        <Sidebar />
+        <InvokeSection />
+      </SecureRoute>
     </Switch>
   </>
 );

--- a/frontend/react/src/components/layout/HomeState.js
+++ b/frontend/react/src/components/layout/HomeState.js
@@ -17,18 +17,6 @@ const StateHome = ({ SecureRouteComponent: SecureRoute }) => (
     <Switch>
       <SecureRoute exact path="/" component={Homepage} />
 
-      <SecureRoute
-        exact
-        path="/views/sections/:state/:year/:sectionOrdinal/:subsectionMarker"
-      >
-        <Sidebar />
-        <InvokeSection />
-      </SecureRoute>
-      <SecureRoute path="/views/sections/:state/:year/:sectionOrdinal">
-        <Sidebar />
-        <InvokeSection />
-      </SecureRoute>
-
       <SecureRoute path="/sections/:year/certify-and-submit" exact>
         <Sidebar />
         <CertifyAndSubmit />

--- a/frontend/react/src/components/sections/homepage/CMSHomepage.js
+++ b/frontend/react/src/components/sections/homepage/CMSHomepage.js
@@ -1,34 +1,67 @@
-import React from "react";
+import React, { useEffect } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import { getAllStateStatuses } from "../../../actions/initial";
+import states from "../../Utils/statesArray";
+import ReportItem from "./ReportItem";
 
-const CMSHomepage = () => (
-  <div className="homepage">
-    <div className="ds-l-container">
-      <div className="ds-l-row ds-u-padding-left--2">
-        <h1 className="page-title ds-u-margin-bottom--0">
-          CHIP Annual Report Template System (CARTS)
-        </h1>
-      </div>
-      <div className="page-info ds-u-padding-left--2">
-        <div className="edit-info">CMS user</div>
-      </div>
+const CMSHomepage = ({ getStatuses, statuses }) => {
+  useEffect(() => {
+    getStatuses();
+  }, []);
 
-      <div className="ds-l-row">
-        <div className="reports ds-l-col--12">
-          <div className="carts-report preview__grid">
-            <div className="ds-l-row">
-              <legend className="ds-u-padding--2 ds-h3">All Reports</legend>
+  return (
+    <div className="homepage">
+      <div className="ds-l-container">
+        <div className="ds-l-row ds-u-padding-left--2">
+          <h1 className="page-title ds-u-margin-bottom--0">
+            CHIP Annual Report Template System (CARTS)
+          </h1>
+        </div>
+        <div className="page-info ds-u-padding-left--2">
+          <div className="edit-info">CMS user</div>
+        </div>
+
+        <div className="ds-l-row">
+          <div className="reports ds-l-col--12">
+            <div className="carts-report preview__grid">
+              <div className="ds-l-row">
+                <legend className="ds-u-padding--2 ds-h3">All Reports</legend>
+              </div>
+              <div className="report-header ds-l-row">
+                <div className="name ds-l-col--2">Report</div>
+                <div className="status ds-l-col--4">Status</div>
+                <div className="actions ds-l-col--6">Actions</div>
+              </div>
+              {states.map(({ label, value }) =>
+                statuses[value] ? (
+                  <ReportItem
+                    key={value}
+                    link1URL={`/views/sections/${value}/2020/00/a`}
+                    name={`${label} 2020`}
+                    statusText={statuses[value] || "not started"}
+                    editor="x@y.z"
+                  />
+                ) : null
+              )}
             </div>
-            <div className="report-header ds-l-row">
-              <div className="name ds-l-col--1">Year</div>
-              <div className="status ds-l-col--2">Status</div>
-              <div className="actions ds-l-col--3">Actions</div>
-            </div>
-            ... here is where we’ll list all the reports...
           </div>
         </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
+CMSHomepage.propTypes = {
+  getStatuses: PropTypes.func.isRequired,
+  statuses: PropTypes.object.isRequired,
+};
 
-export default CMSHomepage;
+const mapState = (state) => ({
+  statuses: state.reportStatus,
+});
+
+const mapDispatch = {
+  getStatuses: getAllStateStatuses ?? {},
+};
+
+export default connect(mapState, mapDispatch)(CMSHomepage);

--- a/frontend/react/src/components/sections/homepage/Homepage.js
+++ b/frontend/react/src/components/sections/homepage/Homepage.js
@@ -18,9 +18,9 @@ const Homepage = () => (
               <legend className="ds-u-padding--2 ds-h3">All Reports</legend>
             </div>
             <div className="report-header ds-l-row">
-              <div className="name ds-l-col--1">Year</div>
-              <div className="status ds-l-col--2">Status</div>
-              <div className="actions ds-l-col--3">Actions</div>
+              <div className="name ds-l-col--2">Year</div>
+              <div className="status ds-l-col--4">Status</div>
+              <div className="actions ds-l-col--6">Actions</div>
             </div>
 
             <ReportItem

--- a/frontend/react/src/components/sections/homepage/ReportItem.js
+++ b/frontend/react/src/components/sections/homepage/ReportItem.js
@@ -1,41 +1,38 @@
-import React, { Component } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 
-class ReportItem extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
-  render() {
-    let link1Text = this.props.link1Text ? this.props.link1Text : "View only";
-    let link1URL = this.props.link1URL ? this.props.link1URL : "#";
-    let statusText = this.props.statusText
-      ? this.props.statusText
-      : "Submitted";
+const ReportItem = ({ link1Text, link1URL, name, statusText, statusURL }) => {
+  const anchorTarget = link1Text === "Edit" ? "_self" : "_blank";
 
-    let statusURL = this.props.statusURL ? (
-      <a href={this.props.statusURL}> {statusText} </a>
-    ) : (
-        statusText
-      );
-
-    let anchorTarget = this.props.link1Text === "Edit" ? "_self" : "_blank";
-    const shortenEmail = email => {
-      return email.substring(0, email.indexOf('@'))
-    }
-
-    const editorURL = (< a href={`${this.props.editor}`} > {shortenEmail(this.props.editor)} </a>)
-    return (
-      <div className="report-item ds-l-row" >
-        <div className="name ds-l-col--1">{this.props.name}</div>
-        <div className={`status ds-l-col--2 ${statusText === 'Overdue' && `alert`}`}>{statusURL}</div>
-        <div className="actions ds-l-col--3">
-          <a href={link1URL} target={anchorTarget}>
-            {link1Text}
-          </a>
-        </div>
+  return (
+    <div className="report-item ds-l-row">
+      <div className="name ds-l-col--2">{name}</div>
+      <div
+        className={`status ds-l-col--4 ${statusText === "Overdue" && `alert`}`}
+      >
+        {statusURL ? <a href={statusURL}> {statusText} </a> : statusText}
       </div>
-    );
-  }
-}
+      <div className="actions ds-l-col--6">
+        <a href={link1URL} target={anchorTarget}>
+          {link1Text}
+        </a>
+      </div>
+    </div>
+  );
+};
+
+ReportItem.propTypes = {
+  link1Text: PropTypes.string,
+  link1URL: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  statusText: PropTypes.string,
+  statusURL: PropTypes.string,
+};
+ReportItem.defaultProps = {
+  link1Text: "View only",
+  link1URL: "#",
+  statusText: "Submitted",
+  statusURL: "",
+};
 
 export default ReportItem;

--- a/frontend/react/src/store/reportStatus.js
+++ b/frontend/react/src/store/reportStatus.js
@@ -1,4 +1,4 @@
-import { SET_STATE_STATUS } from "../actions/initial";
+import { SET_STATE_STATUS, SET_STATE_STATUSES } from "../actions/initial";
 import { CERTIFY_AND_SUBMIT_SUCCESS } from "../actions/certify";
 
 const initialState = {
@@ -15,6 +15,8 @@ export default (state = initialState, action) => {
         status: action.payload.status,
         userName: action.payload.user_name,
       };
+    case SET_STATE_STATUSES:
+      return action.payload;
     case CERTIFY_AND_SUBMIT_SUCCESS:
       return {
         ...state,


### PR DESCRIPTION
All CMS users get the same page for now: a listing of states that have a form with a status, and links to review them.

![screenshot of CMS user page](https://user-images.githubusercontent.com/1775733/96517393-707d7d80-122e-11eb-89a1-a1ad444b5273.png)

Also:
- rejiggers the initial data loading so that users and sections can be loaded completely separately
   - user info is required in order to load the higher-order routing components that then load sections, which guarantees the right order of operations
- updates the `<SecureInitialDataLoad>` so that it calls Okta login itself if the user is not logged in and auth is not pending. Unclear why this situation ever happens, but when it does, it becomes impossible to get an automatic login to "just work." So instead of relying on it "just working", "just manually do it."
- widen the form table so that state names will fit in the first column for CMS users