### PR TITLE
Fix Django deployment issue regarding timeout

### DIFF
--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -178,6 +178,7 @@ resource "aws_alb_target_group" "api_postgres" {
   health_check {
     matcher             = "200,403"
     unhealthy_threshold = 10
+    interval            = 60
   }
   depends_on = [aws_alb.api_postgres]
 }

--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -176,7 +176,8 @@ resource "aws_alb_target_group" "api_postgres" {
   deregistration_delay = "1"
   vpc_id               = data.aws_vpc.app.id
   health_check {
-    matcher = "200,403"
+    matcher             = "200,403"
+    unhealthy_threshold = 15
   }
   depends_on = [aws_alb.api_postgres]
 }

--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -177,7 +177,7 @@ resource "aws_alb_target_group" "api_postgres" {
   vpc_id               = data.aws_vpc.app.id
   health_check {
     matcher             = "200,403"
-    unhealthy_threshold = 15
+    unhealthy_threshold = 10
   }
   depends_on = [aws_alb.api_postgres]
 }


### PR DESCRIPTION
The Django container is being utilized to do database migration/deployment.
The migration/deployment is part of the container's startup process.
In amazon, load balancers send traffic to a target group.
This target group performs health checks on its targets.
So the django container reports as a possible target to the target group, and the healthcheckin begins.
Django is taking longer than the default allowable start time, so the target group is marking the target as unhealthy and deregistering it.
Then the process repeats itself.

This bumps the allowable start time way up.  The interval and unhealthy_threshhold are both increased.