### PR TITLE
Change status to in_progress if form is being saved

### DIFF
--- a/frontend/api_postgres/carts/carts_api/views.py
+++ b/frontend/api_postgres/carts/carts_api/views.py
@@ -365,6 +365,8 @@ class SectionViewSet(viewsets.ModelViewSet):
                 .last()
             )
             status.last_changed = datetime.now(tz=timezone.utc)
+            # if the form is being changed, it must be in progress:
+            status.status = "in_progress"
             status.save()
             return HttpResponse(status=204)
 


### PR DESCRIPTION
Define “in progress”—
Editing must mean progress,
Make status say that.

We already prevent saving in cases where the user isn't allowed to save or the form is in a state that doesn't allow editing. However, if in any of the other statuses, a save means that the status has switched to `in_progress`. Specifically this addresses no status, `not_started`, and `uncertified`, although the code flow means that only the last one is directly involved here.
With this change, any save means the status gets set to `in_progress`.
Related to the last item in #450