### PR TITLE
Disable questions in the form if it isn't in an editable status

### DIFF
--- a/frontend/react/src/actions/initial.js
+++ b/frontend/react/src/actions/initial.js
@@ -117,9 +117,14 @@ export const loadUser = (userToken) => async (dispatch) => {
   const { data } = userToken
     ? await axios.get(`/api/v1/appusers/${userToken}`)
     : await axios.post(`/api/v1/appusers/auth`);
-  dispatch(getUserData(data.currentUser));
-  dispatch(getStateData(data));
-  dispatch(getProgramData(data));
+
+  await Promise.all([
+    dispatch(getUserData(data.currentUser)),
+    dispatch(getStateData(data)),
+    dispatch(getProgramData(data)),
+    dispatch(getStateStatus({ stateCode: data.abbr })),
+    dispatch(getAllStatesData()),
+  ]);
 };
 
 export const loadForm = (state) => async (dispatch, getState) => {
@@ -130,11 +135,7 @@ export const loadForm = (state) => async (dispatch, getState) => {
   dispatch({ type: "CONTENT_FETCHING_STARTED" });
 
   try {
-    await Promise.all([
-      dispatch(loadSections({ userData: stateUser, stateCode })),
-      dispatch(getStateStatus({ stateCode })),
-      dispatch(getAllStatesData()),
-    ]);
+    await dispatch(loadSections({ userData: stateUser, stateCode }));
   } finally {
     // End isFetching for spinner
     dispatch({ type: "CONTENT_FETCHING_FINISHED" });

--- a/frontend/react/src/components/fields/Objectives.js
+++ b/frontend/react/src/components/fields/Objectives.js
@@ -11,7 +11,12 @@ import {
   removeRepeatable,
 } from "../../actions/repeatables";
 
-const Objectives = ({ addObjectiveTo, question, removeObjectiveFrom }) => {
+const Objectives = ({
+  addObjectiveTo,
+  disabled,
+  question,
+  removeObjectiveFrom,
+}) => {
   const ref = useRef();
 
   const add = () => {
@@ -46,6 +51,7 @@ const Objectives = ({ addObjectiveTo, question, removeObjectiveFrom }) => {
 
         {question.questions.length > 1 && (
           <button
+            disabled={disabled}
             onClick={remove}
             type="button"
             className="add-objective ds-c-button ds-c-button--danger"
@@ -62,6 +68,7 @@ const Objectives = ({ addObjectiveTo, question, removeObjectiveFrom }) => {
 
         <div className="ds-c-field__hint">Optional</div>
         <button
+          disabled={disabled}
           onClick={add}
           type="button"
           className="add-objective ds-c-button ds-c-button--primary"
@@ -75,6 +82,7 @@ const Objectives = ({ addObjectiveTo, question, removeObjectiveFrom }) => {
 };
 Objectives.propTypes = {
   addObjectiveTo: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired,
   question: PropTypes.object.isRequired,
   removeObjectiveFrom: PropTypes.func.isRequired,
 };

--- a/frontend/react/src/components/fields/Question.js
+++ b/frontend/react/src/components/fields/Question.js
@@ -24,6 +24,7 @@ import { Text, TextMedium, TextMultiline, TextSmall } from "./Text";
 /* eslint-enable */
 
 import { setAnswerEntry } from "../../actions/initial";
+import { selectIsFormEditable } from "../../store/selectors";
 
 const questionTypes = new Map([
   ["checkbox", Checkbox],
@@ -59,7 +60,7 @@ Container.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const Question = ({ hideNumber, question, setAnswer, ...props }) => {
+const Question = ({ hideNumber, question, readonly, setAnswer, ...props }) => {
   let Component = Text;
   if (questionTypes.has(question.type)) {
     Component = questionTypes.get(question.type);
@@ -102,7 +103,9 @@ const Question = ({ hideNumber, question, setAnswer, ...props }) => {
           question={question}
           name={question.id}
           onChange={onChange}
-          disabled={(question.answer && question.answer.readonly) || false}
+          disabled={
+            readonly || (question.answer && question.answer.readonly) || false
+          }
         />
 
         {/* If there are subquestions, wrap them so they are indented with the
@@ -123,14 +126,19 @@ const Question = ({ hideNumber, question, setAnswer, ...props }) => {
 Question.propTypes = {
   hideNumber: PropTypes.bool,
   question: PropTypes.object.isRequired,
+  readonly: PropTypes.bool.isRequired,
   setAnswer: PropTypes.func.isRequired,
 };
 Question.defaultProps = {
   hideNumber: false,
 };
 
+const mapState = (state) => ({
+  readonly: !selectIsFormEditable(state),
+});
+
 const mapDispatchToProps = {
   setAnswer: setAnswerEntry,
 };
 
-export default connect(null, mapDispatchToProps)(Question);
+export default connect(mapState, mapDispatchToProps)(Question);

--- a/frontend/react/src/components/fields/Repeatables.js
+++ b/frontend/react/src/components/fields/Repeatables.js
@@ -13,6 +13,7 @@ import {
 
 const Repeatables = ({
   addRepeatableTo,
+  disabled,
   question,
   removeRepeatableFrom,
   type,
@@ -56,6 +57,7 @@ const Repeatables = ({
 
         {question.questions.length > 1 && (
           <button
+            disabled={disabled}
             onClick={remove}
             type="button"
             className="add-objective ds-c-button ds-c-button--danger"
@@ -72,6 +74,7 @@ const Repeatables = ({
 
         <div className="ds-c-field__hint">Optional</div>
         <button
+          disabled={disabled}
           onClick={add}
           type="button"
           className="add-objective ds-c-button ds-c-button--primary"
@@ -85,6 +88,7 @@ const Repeatables = ({
 };
 Repeatables.propTypes = {
   addRepeatableTo: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired,
   question: PropTypes.object.isRequired,
   removeRepeatableFrom: PropTypes.func.isRequired,
   type: PropTypes.oneOf([PropTypes.string, null]),

--- a/frontend/react/src/components/layout/CertifyAndSubmit.js
+++ b/frontend/react/src/components/layout/CertifyAndSubmit.js
@@ -7,6 +7,7 @@ import { useHistory } from "react-router-dom";
 import { certifyAndSubmit } from "../../actions/certify";
 
 import PageInfo from "./PageInfo";
+import { selectIsFormEditable } from "../../store/selectors";
 
 const Submit = ({ certify }) => (
   <>
@@ -84,7 +85,7 @@ CertifyAndSubmit.defaultProps = {
 };
 
 const mapState = (state) => ({
-  isCertified: state.reportStatus.status === "certified",
+  isCertified: !selectIsFormEditable(state),
   lastSave: moment(state.save.lastSave),
   user: state.reportStatus.userName,
 });

--- a/frontend/react/src/components/sections/homepage/Homepage.js
+++ b/frontend/react/src/components/sections/homepage/Homepage.js
@@ -1,8 +1,14 @@
 import React from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
 import ReportItem from "./ReportItem";
 import { DownloadDrawer } from "./DownloadDrawer";
+import {
+  selectFormStatus,
+  selectIsFormEditable,
+} from "../../../store/selectors";
 
-const Homepage = () => (
+const Homepage = ({ editable, status }) => (
   <div className="homepage">
     <div className="ds-l-container">
       <div className="ds-l-row ds-u-padding-left--2">
@@ -28,10 +34,10 @@ const Homepage = () => (
               lastEditedTime="1:32pm"
               lastEditedDate="9/21/20"
               link1URL="/sections/2020/00"
-              link1Text="Edit"
+              link1Text={editable ? "Edit" : "View"}
               link2URL="#"
               link2Text={null}
-              statusText="In Progress"
+              statusText={status}
               editor="karen.dalton@state.gov"
             />
           </div>
@@ -51,5 +57,14 @@ const Homepage = () => (
     </div>
   </div>
 );
+Homepage.propTypes = {
+  editable: PropTypes.bool.isRequired,
+  status: PropTypes.string.isRequired,
+};
 
-export default Homepage;
+const mapState = (state) => ({
+  editable: selectIsFormEditable(state),
+  status: selectFormStatus(state),
+});
+
+export default connect(mapState)(Homepage);

--- a/frontend/react/src/store/selectors.js
+++ b/frontend/react/src/store/selectors.js
@@ -139,3 +139,36 @@ export const selectSectionsForNav = (state) => {
   }
   return [];
 };
+
+export const selectIsFormEditable = (state) => {
+  const { status } = state.reportStatus;
+
+  switch (status) {
+    case "not_started":
+    case "in_progress":
+    case "uncertified":
+      return true;
+    default:
+      return false;
+  }
+};
+
+export const selectFormStatus = (() => {
+  const STATUS_MAPPING = {
+    not_started: "Not started",
+    in_progress: "In progress",
+    certified: "Certified",
+    uncertified: "Uncertified",
+    approved: "Approved",
+    submitted: "Submitted",
+    published: "Published",
+  };
+
+  return (state) => {
+    const { status } = state.reportStatus;
+    if (STATUS_MAPPING[status]) {
+      return STATUS_MAPPING[status];
+    }
+    return null;
+  };
+})();


### PR DESCRIPTION
- make questions `disabled` if the form is not editable
- disable repeatables add/remove buttons if the containing question is disabled
- update the landing page so that it shows the actual form status and either an "Edit" or "View" link, depending on the status
- addresses #841 