### PR TITLE
Fix logic for (non)display of §3(i) alert message

### DIFF
--- a/frontend/api_postgres/utils/section-schemas/backend-json-section-3.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-section-3.json
@@ -6612,12 +6612,12 @@
                           "conditional_display": {
                             "skip_text": "Since you're no longer operating this HSI program, please remove any references to it from your CHIP State Plan.",
                             "type": "conditional_display",
-                            "comment": "Interactive: Hide if 2020-03-i-02-01-01-02 is null or yes; noninteractive: hide if that's null or yes.",
+                            "comment": "Interactive: Hide if 2020-03-i-02-01-01-02 is no; noninteractive: hide if that's no.",
                             "hide_if": {
                               "target": "$..*[?(@.id=='2020-03-i-02-01-01-02')].answer.entry",
                               "values": {
-                                "interactive": [null, "yes"],
-                                "noninteractive": [null, "yes"]
+                                "interactive": ["no"],
+                                "noninteractive": ["no"]
                               }
                             }
                           }


### PR DESCRIPTION
This PR just makes a small change to the show/hide logic in §3(i) to correctly hide the HSI questions when user indicated they don't have a HSI program.

Addresses #764