### PR TITLE
Disable form fields for CMS users

### DIFF
--- a/frontend/react/src/components/sections/homepage/CMSHomepage.js
+++ b/frontend/react/src/components/sections/homepage/CMSHomepage.js
@@ -2,8 +2,8 @@ import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { getAllStateStatuses } from "../../../actions/initial";
-import states from "../../Utils/statesArray";
 import ReportItem from "./ReportItem";
+import { selectFormStatuses } from "../../../store/selectors";
 
 const CMSHomepage = ({ getStatuses, statuses }) => {
   useEffect(() => {
@@ -33,17 +33,15 @@ const CMSHomepage = ({ getStatuses, statuses }) => {
                 <div className="status ds-l-col--4">Status</div>
                 <div className="actions ds-l-col--6">Actions</div>
               </div>
-              {states.map(({ label, value }) =>
-                statuses[value] ? (
-                  <ReportItem
-                    key={value}
-                    link1URL={`/views/sections/${value}/2020/00/a`}
-                    name={`${label} 2020`}
-                    statusText={statuses[value] || "not started"}
-                    editor="x@y.z"
-                  />
-                ) : null
-              )}
+              {statuses.map(({ state, stateCode, status }) => (
+                <ReportItem
+                  key={stateCode}
+                  link1URL={`/views/sections/${stateCode}/2020/00/a`}
+                  name={`${state} 2020`}
+                  statusText={status}
+                  editor="x@y.z"
+                />
+              ))}
             </div>
           </div>
         </div>
@@ -57,7 +55,7 @@ CMSHomepage.propTypes = {
 };
 
 const mapState = (state) => ({
-  statuses: state.reportStatus,
+  statuses: selectFormStatuses(state),
 });
 
 const mapDispatch = {

--- a/frontend/react/src/store/selectors.js
+++ b/frontend/react/src/store/selectors.js
@@ -2,6 +2,7 @@ import jsonpath from "../util/jsonpath";
 
 import { selectFragment } from "./formData"; // eslint-disable-line import/no-cycle
 import { shouldDisplay } from "../util/shouldDisplay";
+import statesArray from "../components/Utils/statesArray";
 
 export const selectById = (state, id) => {
   const jspath = `$..formData[*].contents..*[?(@.id==='${id}')]`;
@@ -142,18 +143,21 @@ export const selectSectionsForNav = (state) => {
 
 export const selectIsFormEditable = (state) => {
   const { status } = state.reportStatus;
+  const { role } = state.stateUser.currentUser;
 
   switch (status) {
     case "not_started":
     case "in_progress":
     case "uncertified":
-      return true;
+      // Forms can only be edited if the current user is a state user AND the
+      // form is in one of the statuses above.
+      return role === "state_user";
     default:
       return false;
   }
 };
 
-export const selectFormStatus = (() => {
+export const { selectFormStatus, selectFormStatuses } = (() => {
   const STATUS_MAPPING = {
     not_started: "Not started",
     in_progress: "In progress",
@@ -164,11 +168,19 @@ export const selectFormStatus = (() => {
     published: "Published",
   };
 
-  return (state) => {
-    const { status } = state.reportStatus;
-    if (STATUS_MAPPING[status]) {
-      return STATUS_MAPPING[status];
-    }
-    return null;
+  return {
+    selectFormStatus: (state) => {
+      const { status } = state.reportStatus;
+      if (STATUS_MAPPING[status]) {
+        return STATUS_MAPPING[status];
+      }
+      return null;
+    },
+    selectFormStatuses: (state) =>
+      Object.entries(state.reportStatus).map(([stateCode, status]) => ({
+        state: statesArray.find(({ value }) => value === stateCode)?.label,
+        stateCode,
+        status: STATUS_MAPPING[status],
+      })),
   };
 })();


### PR DESCRIPTION
- makes form fields disabled for CMS users
- updates the CMS dashboard so that it shows friendly statuses instead of the all-lowercase, snake-cased internal names
- addresses #840 