### PR TITLE
Fix group permissions for co users

### DIFF
--- a/frontend/api_postgres/carts/management/commands/add_state_permissions.py
+++ b/frontend/api_postgres/carts/management/commands/add_state_permissions.py
@@ -118,6 +118,7 @@ def _create_permissions_for_co_users() -> None:
     for model in models:
         for verb in verbs:
             codename = f"{verb}_{model}"
+            group_permissions.append(Permission.objects.get(codename=codename))
 
     group.permissions.set(group_permissions)
     group.save()


### PR DESCRIPTION
Must add to the group
Otherwise nothing is set
So we see nothing.

We weren't actually adding the permissions for co_users to their group; this fixes that.