### PR TITLE
Don't wrap legend text inside columnar fieldsets

### DIFF
--- a/frontend/react/src/scss/_form.scss
+++ b/frontend/react/src/scss/_form.scss
@@ -10,6 +10,10 @@
   max-width: 100%;
 }
 
+.ds-l-col fieldset .ds-c-label {
+  white-space: nowrap;
+}
+
 .ds-c-table {
   margin: 1.2rem 0;
 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/6290/97024555-f0ecf880-1524-11eb-924b-8fdca3a5079a.png)

After:
![image](https://user-images.githubusercontent.com/6290/97024464-d61a8400-1524-11eb-8f95-9f3fc37000ce.png)

Addresses #694