### PR TITLE
Print All functionality w/ adjustments to page footer

### DIFF
--- a/frontend/react/src/components/Utils/helperFunctions.js
+++ b/frontend/react/src/components/Utils/helperFunctions.js
@@ -2,9 +2,21 @@
 // from all objectives & goals, stopping at the underscore
 
 const sliceId = (id) => {
-  let idString = id.toString();
-  let num = idString.slice(idString.indexOf("_", idString.length - 1));
+  const idString = id.toString();
+  const num = idString.slice(idString.indexOf("_", idString.length - 1));
   return num;
 };
 
-export { sliceId };
+// Set pageDisable based on location
+// hide for print page
+const showQuestionByPath = (path) => {
+  let pageDisable = false;
+
+  if (path === "/print") {
+    pageDisable = true;
+  }
+
+  return pageDisable;
+};
+
+export { sliceId, showQuestionByPath };

--- a/frontend/react/src/components/fields/Question.js
+++ b/frontend/react/src/components/fields/Question.js
@@ -25,6 +25,7 @@ import { Text, TextMedium, TextMultiline, TextSmall } from "./Text";
 
 import { setAnswerEntry } from "../../actions/initial";
 import { selectIsFormEditable } from "../../store/selectors";
+import { showQuestionByPath } from "../Utils/helperFunctions";
 
 const questionTypes = new Map([
   ["checkbox", Checkbox],
@@ -86,6 +87,9 @@ const Question = ({ hideNumber, question, readonly, setAnswer, ...props }) => {
     }
   }
 
+  // Check if question should be shown based on pathname
+  const pageDisable = showQuestionByPath(window.location.pathname);
+
   return (
     <div className="question">
       <Container question={question}>
@@ -104,7 +108,10 @@ const Question = ({ hideNumber, question, readonly, setAnswer, ...props }) => {
           name={question.id}
           onChange={onChange}
           disabled={
-            readonly || (question.answer && question.answer.readonly) || false
+            pageDisable ||
+            readonly ||
+            (question.answer && question.answer.readonly) ||
+            false
           }
         />
 

--- a/frontend/react/src/components/fields/Question.js
+++ b/frontend/react/src/components/fields/Question.js
@@ -89,7 +89,7 @@ const Question = ({ hideNumber, question, readonly, setAnswer, ...props }) => {
 
   // Check if question should be shown based on pathname
   const pageDisable = showQuestionByPath(window.location.pathname);
-  
+
   // Disable the File Upload component for launch since it is not fully functional
   if (question.type === "file_upload") {
     question.answer.readonly = true;

--- a/frontend/react/src/components/layout/FormActions.js
+++ b/frontend/react/src/components/layout/FormActions.js
@@ -51,9 +51,9 @@ const FormActions = () => {
               <Button
                 className="ds-c-button--primary ds-c-button--small"
                 onClick={printWindow}
-                title="This Page"
+                title="This Section"
               >
-                <FontAwesomeIcon icon={faPrint} /> This Page
+                <FontAwesomeIcon icon={faPrint} /> This Section
               </Button>
             </div>
             <div className="print-form">

--- a/frontend/react/src/components/layout/FormActions.js
+++ b/frontend/react/src/components/layout/FormActions.js
@@ -1,9 +1,15 @@
-import React from "react";
+import React, { useState } from "react";
 import { Button } from "@cmsgov/design-system-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPrint } from "@fortawesome/free-solid-svg-icons";
 
 const FormActions = () => {
+  /**
+   * Print dialogue box
+   * Defaults to false
+   */
+  const [printShow, setPrintShow] = useState(false);
+
   /**
    * Opens print dialogue for current view
    *
@@ -14,17 +20,44 @@ const FormActions = () => {
     window.print();
   };
 
+  const togglePrintDiaglogue = () => {
+    setPrintShow(!printShow);
+  }
   return (
     <section className="action-buttons">
       <div className="print-button">
         <Button
           className="ds-c-button--primary ds-c-button--small"
-          onClick={printWindow}
+          onClick={togglePrintDiaglogue}
           title="Print"
         >
           <FontAwesomeIcon icon={faPrint} /> Print
         </Button>
       </div>
+      {printShow ? (
+      <div className="print-dialogue">
+        <h4>Print</h4>
+        <div className="print-options">
+          <div className="print-page">
+            <Button
+              className="ds-c-button--primary ds-c-button--small"
+              onClick={printWindow}
+              title="This Page"
+            >
+              <FontAwesomeIcon icon={faPrint} /> This Page
+            </Button>
+          </div>
+          <div className="print-form">
+            <Button
+              className="ds-c-button--primary ds-c-button--small"
+              href="/print?dev=dev-ak"
+              title="Entire Form"
+            >
+              <FontAwesomeIcon icon={faPrint} /> Entire Form
+            </Button>
+          </div>
+        </div>
+      </div>) : null }
     </section>
   );
 };

--- a/frontend/react/src/components/layout/FormActions.js
+++ b/frontend/react/src/components/layout/FormActions.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Button } from "@cmsgov/design-system-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPrint } from "@fortawesome/free-solid-svg-icons";
+import { faPrint, faWindowClose } from "@fortawesome/free-solid-svg-icons";
 
 const FormActions = () => {
   /**
@@ -22,7 +22,7 @@ const FormActions = () => {
 
   const togglePrintDiaglogue = () => {
     setPrintShow(!printShow);
-  }
+  };
   return (
     <section className="action-buttons">
       <div className="print-button">
@@ -35,29 +35,40 @@ const FormActions = () => {
         </Button>
       </div>
       {printShow ? (
-      <div className="print-dialogue">
-        <h4>Print</h4>
-        <div className="print-options">
-          <div className="print-page">
+        <div className="print-dialogue">
+          <div className="close">
             <Button
-              className="ds-c-button--primary ds-c-button--small"
-              onClick={printWindow}
-              title="This Page"
+              className="ds-c-button--transparent ds-c-button--small"
+              onClick={togglePrintDiaglogue}
+              title="close"
             >
-              <FontAwesomeIcon icon={faPrint} /> This Page
+              <FontAwesomeIcon icon={faWindowClose} />
             </Button>
           </div>
-          <div className="print-form">
-            <Button
-              className="ds-c-button--primary ds-c-button--small"
-              href="/print?dev=dev-ak"
-              title="Entire Form"
-            >
-              <FontAwesomeIcon icon={faPrint} /> Entire Form
-            </Button>
+          <h4>Print</h4>
+          <div className="print-options">
+            <div className="print-page">
+              <Button
+                className="ds-c-button--primary ds-c-button--small"
+                onClick={printWindow}
+                title="This Page"
+              >
+                <FontAwesomeIcon icon={faPrint} /> This Page
+              </Button>
+            </div>
+            <div className="print-form">
+              <Button
+                className="ds-c-button--primary ds-c-button--small"
+                href="/print?dev=dev-ak"
+                title="Entire Form"
+                target="_blank"
+              >
+                <FontAwesomeIcon icon={faPrint} /> Entire Form
+              </Button>
+            </div>
           </div>
         </div>
-      </div>) : null }
+      ) : null}
     </section>
   );
 };

--- a/frontend/react/src/components/layout/Section.js
+++ b/frontend/react/src/components/layout/Section.js
@@ -8,12 +8,18 @@ import FormNavigation from "./FormNavigation";
 import FormActions from "./FormActions";
 import Autosave from "../fields/Autosave";
 
-const Section = ({ subsectionId, title }) => {
+// Get section number only from sectionId
+const selectSectionNumber = (sectionId) => {
+  return Number(sectionId.split('-')[1]);
+}
+
+const Section = ({ subsectionId, title, sectionId }) => {
   return (
     <div className="section-basic-info ds-l-col--9 content">
       <div className="main">
         <PageInfo />
-        <h2>{title}</h2>
+        {sectionId !== 0 ? (<h2 className="print-only"><span className="section-pre-title">Section {sectionId}: {title}</span></h2>) : <h2>{title}</h2> }
+        {/*<h2 className="print-exclude">{title}</h2>*/}
         <Subsection key={subsectionId} subsectionId={subsectionId} />
       </div>
       <div className="form-footer">
@@ -33,6 +39,7 @@ const mapStateToProps = (state, { sectionId, subsectionId }) => {
   return {
     subsectionId,
     title: selectSectionTitle(state, sectionId),
+    sectionId: selectSectionNumber(sectionId)
   };
 };
 

--- a/frontend/react/src/components/layout/Section.js
+++ b/frontend/react/src/components/layout/Section.js
@@ -25,9 +25,9 @@ const Section = ({ subsectionId, title, sectionId }) => {
             </span>
           </h2>
         ) : (
-          <h2>{title}</h2>
+          <h2 className="print-only">{title}</h2>
         )}
-        <h2 className="print-exclude">{title}</h2>
+        <h2 className="screen-only">{title}</h2>
         <Subsection key={subsectionId} subsectionId={subsectionId} />
       </div>
       <div className="form-footer">

--- a/frontend/react/src/components/layout/Section.js
+++ b/frontend/react/src/components/layout/Section.js
@@ -10,16 +10,24 @@ import Autosave from "../fields/Autosave";
 
 // Get section number only from sectionId
 const selectSectionNumber = (sectionId) => {
-  return Number(sectionId.split('-')[1]);
-}
+  return Number(sectionId.split("-")[1]);
+};
 
 const Section = ({ subsectionId, title, sectionId }) => {
   return (
     <div className="section-basic-info ds-l-col--9 content">
       <div className="main">
         <PageInfo />
-        {sectionId !== 0 ? (<h2 className="print-only"><span className="section-pre-title">Section {sectionId}: {title}</span></h2>) : <h2>{title}</h2> }
-        {/*<h2 className="print-exclude">{title}</h2>*/}
+        {sectionId !== 0 ? (
+          <h2 className="print-only">
+            <span className="section-pre-title">
+              Section {sectionId}: {title}
+            </span>
+          </h2>
+        ) : (
+          <h2>{title}</h2>
+        )}
+        <h2 className="print-exclude">{title}</h2>
         <Subsection key={subsectionId} subsectionId={subsectionId} />
       </div>
       <div className="form-footer">
@@ -33,13 +41,14 @@ const Section = ({ subsectionId, title, sectionId }) => {
 Section.propTypes = {
   subsectionId: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
+  sectionId: PropTypes.string.isRequired,
 };
 
 const mapStateToProps = (state, { sectionId, subsectionId }) => {
   return {
     subsectionId,
     title: selectSectionTitle(state, sectionId),
-    sectionId: selectSectionNumber(sectionId)
+    sectionId: selectSectionNumber(sectionId),
   };
 };
 

--- a/frontend/react/src/components/layout/Subsection.js
+++ b/frontend/react/src/components/layout/Subsection.js
@@ -8,7 +8,7 @@ import Text from "./Text";
 const Subsection = ({ partIds, subsectionId, title, text }) => {
   return (
     <div id={subsectionId}>
-      <h2>{title}</h2>
+      <h2 className="screen-only">{title}</h2>
       {text ? (
         <div className="helper-text">
           <Text>{text}</Text>

--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -1,0 +1,62 @@
+import React, {useEffect} from "react";
+import {connect, useDispatch} from "react-redux";
+import {getAllStatesData, getStateStatus, loadSections} from "../../actions/initial";
+import Section from "../layout/Section";
+
+const Print = (props) => {
+  const dispatch = useDispatch();
+
+  useEffect(async () => {
+
+    // Get user details
+    const {stateUser} = props.state;
+    const stateCode = stateUser.currentUser.state.id;
+
+    // Start Spinner
+    // dispatch({ type: "CONTENT_FETCHING_STARTED" });
+
+    // Pull data based on user details
+    try {
+      await Promise.all([
+        dispatch(loadSections({userData: stateUser, stateCode})),
+        dispatch(getStateStatus({stateCode})),
+        dispatch(getAllStatesData()),
+      ])
+    } catch (err) {
+      console.log("err", err);
+    }
+  }, []);
+
+  // End isFetching for spinner
+  //dispatch({ type: "CONTENT_FETCHING_FINISHED" });
+
+  let sections = [];
+
+  // Check if formData has values
+  const formData = props.state.formData;
+  if (formData !== undefined && formData.length != 0) {
+
+    // Loop through each section to get sectionId
+    for(let i = 0; i < formData.length; i++) {
+      let sectionId = formData[i].contents.section.id;
+
+      // Loop through subsections to get subsectionId
+      for(let j = 0; j < formData[i].contents.section.subsections.length; j++) {
+        let subsectionId = formData[i].contents.section.subsections[j].id;
+
+        // Add section to sections array
+        sections.push(<Section sectionId={sectionId} subsectionId={subsectionId}/>)
+      }
+    }
+  }
+
+  // Use map to add wrapper div with class
+  return sections;
+};
+
+const mapStateToProps = (state) => ({
+  username: state.stateUser.currentUser.username,
+  state: state,
+});
+
+export default connect(mapStateToProps)(Print);

--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -2,6 +2,14 @@ import React, {useEffect} from "react";
 import {connect, useDispatch} from "react-redux";
 import {getAllStatesData, getStateStatus, loadSections} from "../../actions/initial";
 import Section from "../layout/Section";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faPrint} from "@fortawesome/free-solid-svg-icons";
+import {Button} from "@cmsgov/design-system-core";
+
+const printWindow = (event) => {
+  event.preventDefault();
+  window.print();
+};
 
 const Print = (props) => {
   const dispatch = useDispatch();
@@ -13,7 +21,7 @@ const Print = (props) => {
     const stateCode = stateUser.currentUser.state.id;
 
     // Start Spinner
-    // dispatch({ type: "CONTENT_FETCHING_STARTED" });
+    dispatch({type: "CONTENT_FETCHING_STARTED"});
 
     // Pull data based on user details
     try {
@@ -25,10 +33,10 @@ const Print = (props) => {
     } catch (err) {
       console.log("err", err);
     }
-  }, []);
 
-  // End isFetching for spinner
-  //dispatch({ type: "CONTENT_FETCHING_FINISHED" });
+    // End isFetching for spinner
+    dispatch({type: "CONTENT_FETCHING_FINISHED"});
+  }, []);
 
   let sections = [];
 
@@ -37,11 +45,11 @@ const Print = (props) => {
   if (formData !== undefined && formData.length != 0) {
 
     // Loop through each section to get sectionId
-    for(let i = 0; i < formData.length; i++) {
+    for (let i = 0; i < formData.length; i++) {
       let sectionId = formData[i].contents.section.id;
 
       // Loop through subsections to get subsectionId
-      for(let j = 0; j < formData[i].contents.section.subsections.length; j++) {
+      for (let j = 0; j < formData[i].contents.section.subsections.length; j++) {
         let subsectionId = formData[i].contents.section.subsections[j].id;
 
         // Add section to sections array
@@ -50,8 +58,18 @@ const Print = (props) => {
     }
   }
 
-  // Use map to add wrapper div with class
-  return sections;
+  // Return sections with wrapper div and print dialogue box
+  return (
+    <div className="print-all">
+      <Button
+        className="ds-c-button--primary ds-c-button--large print-all-btn"
+        onClick={printWindow}
+        title="Print"
+      >
+        <FontAwesomeIcon icon={faPrint}/> Print
+      </Button>
+      {sections}
+    </div>);
 };
 
 const mapStateToProps = (state) => ({

--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -82,6 +82,13 @@ const Print = (props) => {
         <FontAwesomeIcon icon={faPrint} /> Print
       </Button>
       {sections}
+      <Button
+        className="ds-c-button--primary ds-c-button--large print-all-btn"
+        onClick={printWindow}
+        title="Print"
+      >
+        <FontAwesomeIcon icon={faPrint} /> Print
+      </Button>
     </div>
   );
 };

--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -1,10 +1,15 @@
-import React, {useEffect} from "react";
-import {connect, useDispatch} from "react-redux";
-import {getAllStatesData, getStateStatus, loadSections} from "../../actions/initial";
+import React, { useEffect } from "react";
+import { connect, useDispatch } from "react-redux";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPrint } from "@fortawesome/free-solid-svg-icons";
+import { Button } from "@cmsgov/design-system-core";
+import PropTypes from "prop-types";
+import {
+  getAllStatesData,
+  getStateStatus,
+  loadSections,
+} from "../../actions/initial";
 import Section from "../layout/Section";
-import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faPrint} from "@fortawesome/free-solid-svg-icons";
-import {Button} from "@cmsgov/design-system-core";
 
 const printWindow = (event) => {
   event.preventDefault();
@@ -15,45 +20,53 @@ const Print = (props) => {
   const dispatch = useDispatch();
 
   useEffect(async () => {
-
     // Get user details
-    const {stateUser} = props.state;
+    const { stateUser } = props.state;
     const stateCode = stateUser.currentUser.state.id;
 
     // Start Spinner
-    dispatch({type: "CONTENT_FETCHING_STARTED"});
+    dispatch({ type: "CONTENT_FETCHING_STARTED" });
 
     // Pull data based on user details
-    try {
-      await Promise.all([
-        dispatch(loadSections({userData: stateUser, stateCode})),
-        dispatch(getStateStatus({stateCode})),
-        dispatch(getAllStatesData()),
-      ])
-    } catch (err) {
-      console.log("err", err);
-    }
+    await Promise.all([
+      dispatch(loadSections({ userData: stateUser, stateCode })),
+      dispatch(getStateStatus({ stateCode })),
+      dispatch(getAllStatesData()),
+    ]);
 
     // End isFetching for spinner
-    dispatch({type: "CONTENT_FETCHING_FINISHED"});
+    dispatch({ type: "CONTENT_FETCHING_FINISHED" });
   }, []);
 
-  let sections = [];
+  const sections = [];
 
   // Check if formData has values
-  const formData = props.state.formData;
-  if (formData !== undefined && formData.length != 0) {
+  const { state } = props;
+  const { formData } = state;
 
+  if (formData !== undefined && formData.length !== 0) {
     // Loop through each section to get sectionId
+    /* eslint-disable no-plusplus */
     for (let i = 0; i < formData.length; i++) {
-      let sectionId = formData[i].contents.section.id;
+      const sectionId = formData[i].contents.section.id;
 
       // Loop through subsections to get subsectionId
-      for (let j = 0; j < formData[i].contents.section.subsections.length; j++) {
-        let subsectionId = formData[i].contents.section.subsections[j].id;
+      /* eslint-disable no-plusplus */
+      for (
+        let j = 0;
+        j < formData[i].contents.section.subsections.length;
+        j++
+      ) {
+        const subsectionId = formData[i].contents.section.subsections[j].id;
 
         // Add section to sections array
-        sections.push(<Section sectionId={sectionId} subsectionId={subsectionId}/>)
+        sections.push(
+          <Section
+            sectionId={sectionId}
+            subsectionId={subsectionId}
+            readonly="false"
+          />
+        );
       }
     }
   }
@@ -66,15 +79,20 @@ const Print = (props) => {
         onClick={printWindow}
         title="Print"
       >
-        <FontAwesomeIcon icon={faPrint}/> Print
+        <FontAwesomeIcon icon={faPrint} /> Print
       </Button>
       {sections}
-    </div>);
+    </div>
+  );
+};
+
+Print.propTypes = {
+  state: PropTypes.object.isRequired,
 };
 
 const mapStateToProps = (state) => ({
   username: state.stateUser.currentUser.username,
-  state: state,
+  state,
 });
 
 export default connect(mapStateToProps)(Print);

--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -74,13 +74,17 @@ const Print = (props) => {
   // Return sections with wrapper div and print dialogue box
   return (
     <div className="print-all">
-      <Button
-        className="ds-c-button--primary ds-c-button--large print-all-btn"
-        onClick={printWindow}
-        title="Print"
-      >
-        <FontAwesomeIcon icon={faPrint} /> Print
-      </Button>
+      <div className="print-directions">
+        <p>Click below to print full CARTS report shown here</p>
+        <Button
+          className="ds-c-button--primary ds-c-button--large print-all-btn"
+          onClick={printWindow}
+          title="Print"
+        >
+          <FontAwesomeIcon icon={faPrint} /> Print
+        </Button>
+      </div>
+
       {sections}
       <Button
         className="ds-c-button--primary ds-c-button--large print-all-btn"

--- a/frontend/react/src/scss/_form.scss
+++ b/frontend/react/src/scss/_form.scss
@@ -233,22 +233,34 @@
     float: right;
     margin-top: 0;
     max-width: 360px;
-    padding: .6rem;
+    padding: 0.6rem;
+    position: relative;
 
     h4 {
       margin-top: 0;
       text-align: center;
     }
 
-    .print-options {
+    .close {
+      position: absolute;
+      top: 2px;
+      right: 0;
+      svg {
+        color: $color-gray-light;
+        &:hover {
+          color: $color-gray;
+        }
+      }
+    }
 
+    .print-options {
       & > div {
         display: inline-block;
         padding: 0 1.2rem;
         width: auto;
 
         &:first-of-type {
-          border-right: 1px solid $black;
+          border-right: 1px solid #bbb;
         }
       }
     }

--- a/frontend/react/src/scss/_form.scss
+++ b/frontend/react/src/scss/_form.scss
@@ -223,6 +223,35 @@
 
 .action-buttons {
   clear: both;
+
+  .print-dialogue {
+    border: 1px solid #aaa;
+    border-radius: $border-radius;
+    box-shadow: 2px 3px 4px #aaa;
+    clear: both;
+    display: block;
+    float: right;
+    max-width: 360px;
+    padding: .6rem;
+
+    h4 {
+      margin-top: 0;
+      text-align: center;
+    }
+
+    .print-options {
+
+      & > div {
+        display: inline-block;
+        padding: 0 1.2rem;
+        width: auto;
+
+        &:first-of-type {
+          border-right: 1px solid $black;
+        }
+      }
+    }
+  }
 }
 
 .autosave {

--- a/frontend/react/src/scss/_form.scss
+++ b/frontend/react/src/scss/_form.scss
@@ -231,6 +231,7 @@
     clear: both;
     display: block;
     float: right;
+    margin-top: 0;
     max-width: 360px;
     padding: .6rem;
 

--- a/frontend/react/src/scss/_main.scss
+++ b/frontend/react/src/scss/_main.scss
@@ -316,7 +316,7 @@ div[data-state="open"] .accordion-header .arrow:before {
     text-align: right;
   }
   & > div {
-    display: inline-block;
+    display: block;
     margin: ($margin * 2) $margin;
   }
   .share-container {

--- a/frontend/react/src/scss/_main.scss
+++ b/frontend/react/src/scss/_main.scss
@@ -319,6 +319,7 @@ div[data-state="open"] .accordion-header .arrow:before {
     display: block;
     margin: ($margin * 2) $margin;
   }
+
   .share-container {
     background: $white;
     box-shadow: 0px 0px 8px $color-gray;

--- a/frontend/react/src/scss/_print.scss
+++ b/frontend/react/src/scss/_print.scss
@@ -8,6 +8,13 @@
   .page-info {
     display: none;
   }
+  .print-only {
+    display: block;
+  }
+
+  .print-exclude {
+    display: none;
+  }
 
   .print-all-btn {
     margin: 2.2rem;
@@ -21,6 +28,7 @@
   .header,
   .nav-buttons,
   .print-all-btn,
+  .print-exclude,
   .sidebar {
     display: none;
   }

--- a/frontend/react/src/scss/_print.scss
+++ b/frontend/react/src/scss/_print.scss
@@ -12,7 +12,7 @@
     display: block;
   }
 
-  .print-exclude {
+  .screen-only {
     display: none;
   }
 
@@ -28,7 +28,7 @@
   .header,
   .nav-buttons,
   .print-all-btn,
-  .print-exclude,
+  .screen-only,
   .sidebar {
     display: none;
   }

--- a/frontend/react/src/scss/_print.scss
+++ b/frontend/react/src/scss/_print.scss
@@ -19,6 +19,20 @@
   .print-all-btn {
     margin: 2.2rem;
   }
+
+  .print-directions {
+    border: 1px solid #aaa;
+    border-radius: $border-radius;
+    box-shadow: 2px 3px 4px #aaa;
+    margin: 2.2rem;
+    max-width: 420px;
+    text-align: center;
+    width: auto;
+
+    .print-all-btn {
+      margin: 0 2.2rem 1.2rem 2.2rem;
+    }
+  }
 }
 
 @media print {
@@ -28,6 +42,7 @@
   .header,
   .nav-buttons,
   .print-all-btn,
+  .print-directions,
   .screen-only,
   .sidebar {
     display: none;

--- a/frontend/react/src/scss/_print.scss
+++ b/frontend/react/src/scss/_print.scss
@@ -1,8 +1,26 @@
+/**
+  * Contains Print media query AND print page
+ */
+
+.print-all {
+  .ds-c-alert,
+  .form-footer,
+  .page-info {
+    display: none;
+  }
+
+  .print-all-btn {
+    margin: 2.2rem;
+  }
+}
+
 @media print {
   .action-buttons,
+  .ds-c-alert,
   .footer,
   .header,
   .nav-buttons,
+  .print-all-btn,
   .sidebar {
     display: none;
   }
@@ -57,5 +75,8 @@
 
   .ly_header {
     margin-bottom: ($margin * 8);
+  }
+  .question {
+    break-inside: avoid;
   }
 }

--- a/frontend/react/src/scss/_print.scss
+++ b/frontend/react/src/scss/_print.scss
@@ -24,8 +24,8 @@
     border: 1px solid #aaa;
     border-radius: $border-radius;
     box-shadow: 2px 3px 4px #aaa;
-    margin: 2.2rem;
-    max-width: 420px;
+    margin: 2.2rem auto;
+    max-width: 90%;
     text-align: center;
     width: auto;
 

--- a/frontend/react/src/wrapSecurity.js
+++ b/frontend/react/src/wrapSecurity.js
@@ -13,10 +13,13 @@ import Home from "./components/layout/Home";
 import Footer from "./components/layout/Footer";
 import Userinfo from "./components/sections/Userinfo";
 import UserProfile from "./components/sections/UserProfile";
+import Print from "./components/sections/Print";
 import SecureInitialDataLoad from "./components/Utils/SecureInitialDataLoad";
 import Profile from "./Profile";
 import config from "./auth-config";
 import Spinner from "./components/Utils/Spinner";
+import Sidebar from "./components/layout/Sidebar";
+import InvokeSection from "./components/Utils/InvokeSection";
 
 const WrappedSecurity = () => {
   const VisibleHeader =
@@ -69,6 +72,7 @@ const WrappedSecurity = () => {
           <SecureRoute exact path="/userinfo" component={Userinfo} />
           <SecureRoute path="/profile" component={Profile} />
           <SecureRoute path="/user/profile" component={UserProfile} />
+          <SecureRoute path="/print" component={Print} />
         </Router>
         {VisibleFooter}
       </SecurityWrapper>

--- a/frontend/react/src/wrapSecurity.js
+++ b/frontend/react/src/wrapSecurity.js
@@ -18,8 +18,6 @@ import SecureInitialDataLoad from "./components/Utils/SecureInitialDataLoad";
 import Profile from "./Profile";
 import config from "./auth-config";
 import Spinner from "./components/Utils/Spinner";
-import Sidebar from "./components/layout/Sidebar";
-import InvokeSection from "./components/Utils/InvokeSection";
 
 const WrappedSecurity = () => {
   const VisibleHeader =


### PR DESCRIPTION
Adds ability to print entire form; includes functionality at the bottom of form pages to print single page or entire form.

Created new route for `Print All` functionality via Print.js. Print.js displays the entire form with print buttons at the top and bottom. The logic mimicks that of initial.js for loading the form data. 

To set the fields as disabled, a helper function was created (helperFunction.js) and added to the Question.js logic. A new modal was created for print options and added to FormActions.js

Added additional styles and modified some existing.