### PR TITLE
Disable fileupload component for launch

### DIFF
--- a/frontend/react/src/components/fields/Question.js
+++ b/frontend/react/src/components/fields/Question.js
@@ -86,6 +86,12 @@ const Question = ({ hideNumber, question, readonly, setAnswer, ...props }) => {
     }
   }
 
+  // Disable the File Upload component for launch since it is not fully functional
+  if (question.type === "file_upload") {
+    question.answer.readonly = true
+    question.hint = "Currently unavailable"
+  }
+
   return (
     <div className="question">
       <Container question={question}>

--- a/frontend/react/src/components/fields/Question.js
+++ b/frontend/react/src/components/fields/Question.js
@@ -88,8 +88,8 @@ const Question = ({ hideNumber, question, readonly, setAnswer, ...props }) => {
 
   // Disable the File Upload component for launch since it is not fully functional
   if (question.type === "file_upload") {
-    question.answer.readonly = true
-    question.hint = "Currently unavailable"
+    question.answer.readonly = true;
+    question.hint = "Currently unavailable";
   }
 
   return (


### PR DESCRIPTION
Related to #887 
-Force the readonly property to true
-Add a hint property so it's clear the component is currently unavailable