### PR TITLE
Adjust stateuser state code to NOT use currentUser

### DIFF
--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -22,7 +22,7 @@ const Print = (props) => {
   useEffect(async () => {
     // Get user details
     const { stateUser } = props.state;
-    const stateCode = stateUser.currentUser.state.id;
+    const stateCode = stateUser.abbr;
 
     // Start Spinner
     dispatch({ type: "CONTENT_FETCHING_STARTED" });


### PR DESCRIPTION
CurrentUser data is empty and should probably be removed from state. In the interim, this should fix the print page and allow it to load with the current users data.