### PR TITLE
Print Functionality for Logged in Users

### DIFF
--- a/frontend/react/src/components/layout/FormActions.js
+++ b/frontend/react/src/components/layout/FormActions.js
@@ -98,7 +98,7 @@ const FormActions = () => {
             <div className="print-form">
               <Button
                 className="ds-c-button--primary ds-c-button--small"
-                href="/print?dev=dev-ak"
+                href="/print"
                 title="Entire Form"
                 target="_blank"
                 onClick={togglePrintDiaglogue}

--- a/frontend/react/src/components/layout/FormActions.js
+++ b/frontend/react/src/components/layout/FormActions.js
@@ -1,14 +1,53 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Button } from "@cmsgov/design-system-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPrint, faWindowClose } from "@fortawesome/free-solid-svg-icons";
 
+/**
+ * Display available options for form (print)
+ *
+ * @returns {JSX.Element}
+ * @constructor
+ */
 const FormActions = () => {
+  // Initialise printDialogeRef
+  const printDialogeRef = useRef(null);
+
   /**
-   * Print dialogue box
+   * Print dialogue box state
    * Defaults to false
    */
   const [printShow, setPrintShow] = useState(false);
+
+  /**
+   * If click occurs outside component, setPrintShow to false
+   */
+  const useOutsideAlerter = (ref) => {
+    useEffect(() => {
+      // if clicked on outside of element
+      function handleClickOutside(event) {
+        if (ref.current && !ref.current.contains(event.target)) {
+          setPrintShow(false);
+        }
+      }
+
+      // Bind the event listener
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => {
+        // Unbind the event listener on clean up
+        document.removeEventListener("mousedown", handleClickOutside);
+      };
+    }, [ref]);
+  };
+
+  useOutsideAlerter(printDialogeRef);
+
+  /**
+   * Toggles printDialogue component display
+   */
+  const togglePrintDiaglogue = () => {
+    setPrintShow(!printShow);
+  };
 
   /**
    * Opens print dialogue for current view
@@ -17,12 +56,12 @@ const FormActions = () => {
    */
   const printWindow = (event) => {
     event.preventDefault();
+
+    // Close dialogue box
+    togglePrintDiaglogue();
     window.print();
   };
 
-  const togglePrintDiaglogue = () => {
-    setPrintShow(!printShow);
-  };
   return (
     <section className="action-buttons">
       <div className="print-button">
@@ -35,7 +74,7 @@ const FormActions = () => {
         </Button>
       </div>
       {printShow ? (
-        <div className="print-dialogue">
+        <div className="print-dialogue" ref={printDialogeRef}>
           <div className="close">
             <Button
               className="ds-c-button--transparent ds-c-button--small"
@@ -62,6 +101,7 @@ const FormActions = () => {
                 href="/print?dev=dev-ak"
                 title="Entire Form"
                 target="_blank"
+                onClick={togglePrintDiaglogue}
               >
                 <FontAwesomeIcon icon={faPrint} /> Entire Form
               </Button>

--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -1,57 +1,57 @@
-import React, {useEffect, useState} from "react";
+import React, { useEffect } from "react";
 import { connect, useDispatch } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPrint } from "@fortawesome/free-solid-svg-icons";
 import { Button } from "@cmsgov/design-system-core";
 import PropTypes from "prop-types";
-import {
-  getAllStatesData,
-  getStateStatus,
-  loadSections,
-} from "../../actions/initial";
+import { loadSections } from "../../actions/initial";
 import Section from "../layout/Section";
-import {useOktaAuth} from "@okta/okta-react";
 
+// Print page
 const printWindow = (event) => {
   event.preventDefault();
   window.print();
 };
 
-
-
-const Print = ({currentUser, myState}) => {
+/**
+ * Generate data and load entire form based on user information
+ *
+ * @param currentUser
+ * @param state
+ * @returns {JSX.Element}
+ * @constructor
+ */
+const Print = ({ currentUser, state }) => {
   const dispatch = useDispatch();
-let n =0;
-  useEffect( () => {
 
-    const retrieveUserData = async (myState, currentUser, dispatch) => {
+  // Load formData via side effect
+  useEffect(() => {
+    // Create function to call data to prevent return data from useEffect
+    const retrieveUserData = async () => {
       // Get user details
-      const { stateUser } = myState;
+      const { stateUser } = state;
       const stateCode = stateUser.abbr;
-      let a = 0;
+
       // Start Spinner
       dispatch({ type: "CONTENT_FETCHING_STARTED" });
-      let b = 0;
+
       // Pull data based on user details
       await Promise.all([
         dispatch(loadSections({ userData: currentUser, stateCode })),
-        // dispatch(getStateStatus({ stateCode })),
-        // dispatch(getAllStatesData()),
       ]);
 
       // End isFetching for spinner
       dispatch({ type: "CONTENT_FETCHING_FINISHED" });
-    }
+    };
 
-    retrieveUserData(myState, currentUser, dispatch)
+    // Call async function to load data
+    retrieveUserData();
   }, [currentUser]);
 
   const sections = [];
 
   // Check if formData has values
-  const { state } = myState;
-  const { formData } = myState;
-let a =0;
+  const { formData } = state;
   if (formData !== undefined && formData.length !== 0) {
     // Loop through each section to get sectionId
     /* eslint-disable no-plusplus */
@@ -107,12 +107,12 @@ let a =0;
 
 Print.propTypes = {
   state: PropTypes.object.isRequired,
-  currentUser: PropTypes.object.isRequired
+  currentUser: PropTypes.object.isRequired,
 };
 
 const mapStateToProps = (state) => ({
   currentUser: state.stateUser,
-  myState: state,
+  state,
 });
 
 export default connect(mapStateToProps)(Print);

--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -17,26 +17,33 @@ const printWindow = (event) => {
   window.print();
 };
 
+
+
 const Print = ({currentUser, myState}) => {
   const dispatch = useDispatch();
 let n =0;
-  useEffect(() => {
-    // Get user details
-    const { stateUser } = myState;
-    const stateCode = stateUser.abbr;
-let a = 0;
-    // Start Spinner
-    dispatch({ type: "CONTENT_FETCHING_STARTED" });
+  useEffect( () => {
 
-    // Pull data based on user details
-    Promise.all([
-      dispatch(loadSections({ userData: currentUser, stateCode })),
-      // dispatch(getStateStatus({ stateCode })),
-      // dispatch(getAllStatesData()),
-    ]);
+    const retrieveUserData = async (myState, currentUser, dispatch) => {
+      // Get user details
+      const { stateUser } = myState;
+      const stateCode = stateUser.abbr;
+      let a = 0;
+      // Start Spinner
+      dispatch({ type: "CONTENT_FETCHING_STARTED" });
+      let b = 0;
+      // Pull data based on user details
+      await Promise.all([
+        dispatch(loadSections({ userData: currentUser, stateCode })),
+        // dispatch(getStateStatus({ stateCode })),
+        // dispatch(getAllStatesData()),
+      ]);
 
-    // End isFetching for spinner
-    dispatch({ type: "CONTENT_FETCHING_FINISHED" });
+      // End isFetching for spinner
+      dispatch({ type: "CONTENT_FETCHING_FINISHED" });
+    }
+
+    retrieveUserData(myState, currentUser, dispatch)
   }, [currentUser]);
 
   const sections = [];

--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, {useEffect, useState} from "react";
 import { connect, useDispatch } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPrint } from "@fortawesome/free-solid-svg-icons";
@@ -10,40 +10,41 @@ import {
   loadSections,
 } from "../../actions/initial";
 import Section from "../layout/Section";
+import {useOktaAuth} from "@okta/okta-react";
 
 const printWindow = (event) => {
   event.preventDefault();
   window.print();
 };
 
-const Print = (props) => {
+const Print = ({currentUser, myState}) => {
   const dispatch = useDispatch();
-
-  useEffect(async () => {
+let n =0;
+  useEffect(() => {
     // Get user details
-    const { stateUser } = props.state;
+    const { stateUser } = myState;
     const stateCode = stateUser.abbr;
-
+let a = 0;
     // Start Spinner
     dispatch({ type: "CONTENT_FETCHING_STARTED" });
 
     // Pull data based on user details
-    await Promise.all([
-      dispatch(loadSections({ userData: stateUser, stateCode })),
-      dispatch(getStateStatus({ stateCode })),
-      dispatch(getAllStatesData()),
+    Promise.all([
+      dispatch(loadSections({ userData: currentUser, stateCode })),
+      // dispatch(getStateStatus({ stateCode })),
+      // dispatch(getAllStatesData()),
     ]);
 
     // End isFetching for spinner
     dispatch({ type: "CONTENT_FETCHING_FINISHED" });
-  }, []);
+  }, [currentUser]);
 
   const sections = [];
 
   // Check if formData has values
-  const { state } = props;
-  const { formData } = state;
-
+  const { state } = myState;
+  const { formData } = myState;
+let a =0;
   if (formData !== undefined && formData.length !== 0) {
     // Loop through each section to get sectionId
     /* eslint-disable no-plusplus */
@@ -99,11 +100,12 @@ const Print = (props) => {
 
 Print.propTypes = {
   state: PropTypes.object.isRequired,
+  currentUser: PropTypes.object.isRequired
 };
 
 const mapStateToProps = (state) => ({
-  username: state.stateUser.currentUser.username,
-  state,
+  currentUser: state.stateUser,
+  myState: state,
 });
 
 export default connect(mapStateToProps)(Print);


### PR DESCRIPTION
Updated code to accurately pull logged-in user data. Previously print was pulling initialState user information and not updating with currentUser data.

An odd change: useEffect was throwing errors with dispatch returning a promise. The solution was to move the data loading functionality into a function that is async and have use effect call it.

Close print dialogue box when:

- Print `This Section` is selected
- Print `Entire Form` is selected
- User clicks anywhere else on the page (that's not the print dialogue box)