### PR TITLE
Section 2 tables add commas and percent sign

### DIFF
--- a/frontend/react/src/components/fields/NoninteractiveTable.js
+++ b/frontend/react/src/components/fields/NoninteractiveTable.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 
 const NoninteractiveTable = ({ question }) => {
   const columnWidth = 100 / question.fieldset_info.headers.length;
+  // eslint-disable-next-line
   let percentLocation = [];
   let count = -1;
   return (
@@ -10,10 +11,8 @@ const NoninteractiveTable = ({ question }) => {
       <thead>
         <tr>
           {question.fieldset_info.headers.map(function (header) {
-            {
-              count++;
-            }
-            //captures the location of a percent element
+            count += 1;
+            // captures the location of a percent element
             if (String(header).toLowerCase().includes("percent")) {
               percentLocation[count] = true;
             } else {
@@ -28,20 +27,17 @@ const NoninteractiveTable = ({ question }) => {
         </tr>
       </thead>
       {question.fieldset_info.rows.map((row) => {
-        {
-          count = -1;
-        }
+        count = -1;
         return (
           <tr>
             {row.map((value) => {
-              {
-                count++;
-              }
-              //adds % to any element that has percent in the header and adds commas via toLocaleString
+              count += 1;
+              // adds % to any element that has percent in the header and adds commas via toLocaleString
               if (percentLocation[count] === true) {
                 return (
                   <td width={`${columnWidth}%`}>{value.toLocaleString()}%</td>
                 );
+                // eslint-disable-next-line
               } else {
                 return (
                   <td width={`${columnWidth}%`}>{value.toLocaleString()}</td>

--- a/frontend/react/src/components/fields/NoninteractiveTable.js
+++ b/frontend/react/src/components/fields/NoninteractiveTable.js
@@ -3,11 +3,22 @@ import PropTypes from "prop-types";
 
 const NoninteractiveTable = ({ question }) => {
   const columnWidth = 100 / question.fieldset_info.headers.length;
+  let percentLocation = [];
+  let count = -1;
   return (
     <table className="ds-c-table" width="100%">
       <thead>
         <tr>
           {question.fieldset_info.headers.map(function (header) {
+            {
+              count++;
+            }
+            //captures the location of a percent element
+            if (String(header).toLowerCase().includes("percent")) {
+              percentLocation[count] = true;
+            } else {
+              percentLocation[count] = false;
+            }
             return (
               <th width={`${columnWidth}%`} name={`${header}`}>
                 {header}
@@ -17,10 +28,25 @@ const NoninteractiveTable = ({ question }) => {
         </tr>
       </thead>
       {question.fieldset_info.rows.map((row) => {
+        {
+          count = -1;
+        }
         return (
           <tr>
             {row.map((value) => {
-              return <td width={`${columnWidth}%`}>{value}</td>;
+              {
+                count++;
+              }
+              //adds % to any element that has percent in the header and adds commas via toLocaleString
+              if (percentLocation[count] === true) {
+                return (
+                  <td width={`${columnWidth}%`}>{value.toLocaleString()}%</td>
+                );
+              } else {
+                return (
+                  <td width={`${columnWidth}%`}>{value.toLocaleString()}</td>
+                );
+              }
             })}
           </tr>
         );

--- a/frontend/react/src/util/synthesize.js
+++ b/frontend/react/src/util/synthesize.js
@@ -202,6 +202,10 @@ const lookupAcs = (state, { ffy, acsProperty }) => {
     // If acs exists, return the value from the object
     if (acs) {
       returnValue = `${acs[acsProperty]}`;
+      if (acsProperty.includes("percent"))
+      {
+        returnValue = returnValue + "%"
+      }
     }
   }
   return returnValue;
@@ -246,7 +250,7 @@ const compareACS = (state, { ffy1, ffy2, acsProperty }) => {
       // Calculate the percent change
       returnValue = parseFloat(
         ((tempEnd - tempStart) / tempStart) * 100
-      ).toFixed(percentagePrecision);
+      ).toFixed(percentagePrecision) + "%";
     }
   }
   return returnValue;

--- a/frontend/react/src/util/synthesize.js
+++ b/frontend/react/src/util/synthesize.js
@@ -208,9 +208,8 @@ const lookupAcs = (state, { ffy, acsProperty }) => {
     // If acs exists, return the value from the object
     if (acs) {
       returnValue = Number(`${acs[acsProperty]}`).toLocaleString();
-      if (acsProperty.includes("percent"))
-      {
-        returnValue = returnValue + "%"
+      if (acsProperty.includes("percent")) {
+        returnValue += "%";
       }
     }
   }
@@ -254,9 +253,11 @@ const compareACS = (state, { ffy1, ffy2, acsProperty }) => {
       const tempEnd = parseFloat(endACS[acsProperty]);
 
       // Calculate the percent change
-      returnValue = parseFloat(
-        ((tempEnd - tempStart) / tempStart) * 100
-      ).toFixed(percentagePrecision).toLocaleString() + "%";
+
+      returnValue = // eslint-disable-next-line
+        parseFloat(((tempEnd - tempStart) / tempStart) * 100)
+          .toFixed(percentagePrecision)
+          .toLocaleString() + "%";
     }
   }
   return returnValue;

--- a/frontend/react/src/util/synthesize.js
+++ b/frontend/react/src/util/synthesize.js
@@ -207,7 +207,7 @@ const lookupAcs = (state, { ffy, acsProperty }) => {
 
     // If acs exists, return the value from the object
     if (acs) {
-      returnValue = `${acs[acsProperty]}`;
+      returnValue = Number(`${acs[acsProperty]}`).toLocaleString();
       if (acsProperty.includes("percent"))
       {
         returnValue = returnValue + "%"
@@ -256,7 +256,7 @@ const compareACS = (state, { ffy1, ffy2, acsProperty }) => {
       // Calculate the percent change
       returnValue = parseFloat(
         ((tempEnd - tempStart) / tempStart) * 100
-      ).toFixed(percentagePrecision) + "%";
+      ).toFixed(percentagePrecision).toLocaleString() + "%";
     }
   }
   return returnValue;


### PR DESCRIPTION
using toLocaleString() to add commas. It could also be entered as toLocaleString('en') but it seems to auto detect it for the US. This handles ticket [710](https://app.zenhub.com/workspaces/carts-prototype-zenhub-5f0643b2a50cb70019ecc5b0/issues/cmsgov/cms-carts-seds/710)