### PR TITLE
Allow fields to be shown/hidden by table data

### DIFF
--- a/frontend/api_postgres/utils/section-schemas/backend-json-section-2.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-section-2.json
@@ -30,18 +30,8 @@
                     "Percent change"
                   ],
                   "rows": [
-                    [
-                      "Medicaid Expansion CHIP",
-                      284143,
-                      300579,
-                      5.78
-                    ],
-                    [
-                      "Separate CHIP",
-                      478542,
-                      511473,
-                      6.88
-                    ]
+                    ["Medicaid Expansion CHIP", 284143, 300579, 5.78],
+                    ["Separate CHIP", 478542, 511473, 6.88]
                   ]
                 },
                 "questions": []
@@ -354,13 +344,8 @@
                         "hide_if": {
                           "target": "$..*[?(@.id=='2020-02-a-02-02')].answer.entry",
                           "values": {
-                            "interactive": [
-                              null,
-                              "no"
-                            ],
-                            "noninteractive": [
-                              "no"
-                            ]
+                            "interactive": [null, "no"],
+                            "noninteractive": ["no"]
                           }
                         }
                       }
@@ -402,10 +387,7 @@
                         "label": "Tell us the date range for your data",
                         "type": "daterange",
                         "answer": {
-                          "labels": [
-                            "Start",
-                            "End"
-                          ],
+                          "labels": ["Start", "End"],
                           "entry": null
                         }
                       },
@@ -465,13 +447,8 @@
                         "hide_if": {
                           "target": "$..*[?(@.id=='2020-02-a-02-03')].answer.entry",
                           "values": {
-                            "interactive": [
-                              null,
-                              "no"
-                            ],
-                            "noninteractive": [
-                              "no"
-                            ]
+                            "interactive": [null, "no"],
+                            "noninteractive": ["no"]
                           }
                         }
                       }

--- a/frontend/api_postgres/utils/section-schemas/backend-json-section-2.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-section-2.json
@@ -22,7 +22,7 @@
               {
                 "type": "fieldset",
                 "fieldset_type": "noninteractive_table",
-                "fieldset_id": "noninteractive-table-1",
+                "fieldset_id": "noninteractive-table-2-1",
                 "fieldset_info": {
                   "headers": [
                     "Program",
@@ -61,7 +61,8 @@
                   "conditional_display": {
                     "type": "conditional_display",
                     "hide_if_table_value": {
-                      "target": "$..*[?(@.fieldset_id=='noninteractive-table-1')].fieldset_info.rows",
+                      "target": "$..*[?(@.fieldset_id=='noninteractive-table-2-1')].fieldset_info.rows",
+                      "computed": false,
                       "variation_operator": "or",
                       "variations": [
                         {
@@ -94,6 +95,7 @@
                 "label": "",
                 "hint": "",
                 "fieldset_type": "synthesized_table",
+                "fieldset_id": "synthesized-table-2-1",
                 "fieldset_info": {
                   "headers": [
                     {
@@ -265,6 +267,7 @@
               {
                 "type": "fieldset",
                 "fieldset_type": "synthesized_table",
+                "fieldset_id": "synthesized-table-2-2",
                 "fieldset_info": {
                   "headers": [
                     {
@@ -291,6 +294,33 @@
                 "type": "text_multiline",
                 "answer": {
                   "entry": null
+                },
+                "context_data": {
+                  "interactive_conditional": "Hide if percent change values in parent's table are all under 3.",
+                  "noninteractive_conditional": "Hide if percent change values in parent's table are all under 3.",
+                  "skip_text": "Since your percent change didn’t exceed 3%, you can skip to Part 2.",
+                  "conditional_display": {
+                    "type": "conditional_display",
+                    "hide_if_table_value": {
+                      "target": "$..*[?(@.fieldset_id=='synthesized-table-2-2')].fieldset_info.rows",
+                      "computed": true,
+                      "variation_operator": "or",
+                      "variations": [
+                        {
+                          "threshold": "3",
+                          "operator": ">",
+                          "row": "*",
+                          "row_key": "0"
+                        },
+                        {
+                          "threshold": "-3",
+                          "operator": "<",
+                          "row": "*",
+                          "row_key": "0"
+                        }
+                      ]
+                    }
+                  }
                 }
               },
               {

--- a/frontend/api_postgres/utils/section-schemas/backend-json-section-2.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-section-2.json
@@ -22,6 +22,7 @@
               {
                 "type": "fieldset",
                 "fieldset_type": "noninteractive_table",
+                "fieldset_id": "noninteractive-table-1",
                 "fieldset_info": {
                   "headers": [
                     "Program",
@@ -30,8 +31,18 @@
                     "Percent change"
                   ],
                   "rows": [
-                    ["Medicaid Expansion CHIP", 284143, 300579, 5.78],
-                    ["Separate CHIP", 478542, 511473, 6.88]
+                    [
+                      "Medicaid Expansion CHIP",
+                      284143,
+                      300579,
+                      5.78
+                    ],
+                    [
+                      "Separate CHIP",
+                      478542,
+                      511473,
+                      6.88
+                    ]
                   ]
                 },
                 "questions": []
@@ -46,7 +57,28 @@
                 "context_data": {
                   "interactive_conditional": "Hide if percent change values in parent's table are all under 3.",
                   "noninteractive_conditional": "Hide if percent change values in parent's table are all under 3.",
-                  "skip_text": "Since your percent change didn’t exceed 3%, you can skip to Part 2."
+                  "skip_text": "Since your percent change didn’t exceed 3%, you can skip to Part 2.",
+                  "conditional_display": {
+                    "type": "conditional_display",
+                    "hide_if_table_value": {
+                      "target": "$..*[?(@.fieldset_id=='noninteractive-table-1')].fieldset_info.rows",
+                      "variation_operator": "or",
+                      "variations": [
+                        {
+                          "threshold": "3",
+                          "operator": ">",
+                          "row": "*",
+                          "row_key": "3"
+                        },
+                        {
+                          "threshold": "-3",
+                          "operator": "<",
+                          "row": "*",
+                          "row_key": "3"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             ]
@@ -293,8 +325,13 @@
                         "hide_if": {
                           "target": "$..*[?(@.id=='2020-02-a-02-02')].answer.entry",
                           "values": {
-                            "interactive": [null, "no"],
-                            "noninteractive": ["no"]
+                            "interactive": [
+                              null,
+                              "no"
+                            ],
+                            "noninteractive": [
+                              "no"
+                            ]
                           }
                         }
                       }
@@ -336,7 +373,10 @@
                         "label": "Tell us the date range for your data",
                         "type": "daterange",
                         "answer": {
-                          "labels": ["Start", "End"],
+                          "labels": [
+                            "Start",
+                            "End"
+                          ],
                           "entry": null
                         }
                       },
@@ -396,8 +436,13 @@
                         "hide_if": {
                           "target": "$..*[?(@.id=='2020-02-a-02-03')].answer.entry",
                           "values": {
-                            "interactive": [null, "no"],
-                            "noninteractive": ["no"]
+                            "interactive": [
+                              null,
+                              "no"
+                            ],
+                            "noninteractive": [
+                              "no"
+                            ]
                           }
                         }
                       }

--- a/frontend/api_postgres/utils/section-schemas/backend-json-structure-documentation.rst
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-structure-documentation.rst
@@ -415,6 +415,112 @@ To express the logic described above, the sub-question has this ``conditional_di
 
 .. _JSON Path: https://goessner.net/articles/JsonPath/
 
+``hide_if_table_value``
+    This construct describes the conditions under which the question should be hidden from view. It has several properties, ``target``, ``computed``, ``variation_operator``, and ``variations``. ``Variations`` is an object with the following properties ``threshold``, ``operator``, ``row``, and ``row_key``. The frontend will evaluate the current value of the JSON elements specified by ``target`` and hide it from view if the values fall within the threshold provided.
+
+    This is valuable for determining if a value falls above or below a specified threshold. This can be compared against an array of items, a compareACS (computed) value and a seds (computed) field.
+
+    ``target``
+        String.
+
+        This is an string of `JSON Path`_ expression that points to the locations in the JSON to find the values to be evaluated against. Normally this will be the values of an ``entry`` property. The vast majority of these will refer to ``id`` values. For example, to find the value of ``entry`` for a question with the ``id`` of ``2020-01-a-01-01``, the expression would be ``$..*[?(@.id=='2020-01-a-01-01')].answer.entry``. The assumption is that changing these values will almost always be a question of simply changing the ``id`` and leaving the rest of the expression unchanged.
+    ``computed``
+        Bool.
+
+        This determines if the target is a synthesized table (true) or a non-interactive table (false).
+
+    ``variation_operator``
+        String.
+
+        Options: `or` or `and`. Select `or` for items that should resolve true if ANY of the variations are true. Use `and` when all variations must resolve true.
+
+    ``variations``
+        Array[Objects]
+
+        Variations house the data to determine if a comparison resolves as true or false.
+
+        ``threshold``
+            String.
+
+            Enter the number that is being compared against. (E.g. if checking that a value is greater than 3, set threshold to 3)
+
+        ``operator``
+            String.
+
+            Options: `>`, `<`, `=`, `!=`. Set which operator for the comparison
+
+        ``row``
+            String.
+
+            Options: *(all), number. This corresponds with the row number from the `target` table. This field starts at 0. For the second row, select 1.
+
+        ``row_key``
+            Number.
+
+            This is the column, or row index. If attempted to read the 3rd value in a row, select 2.
+
+
+Section 2 has question 1. “What are some reasons why the number and/or percent of uninsured children has changed?”, This question is shown only if the value from the preceding table is less than -3 OR greater than +3.
+
+The ``fieldset_id`` for the target table is ``noninteractive-table-2-1``, and will show if the value is either less than -3 or greater than +3.
+
+Example of non-interactive table (note the fieldset_id)
+.. code:: json
+    {
+        "type": "fieldset",
+        "fieldset_type": "noninteractive_table",
+        "fieldset_id": "noninteractive-table-2-1",
+        "fieldset_info": {
+          "headers": [
+            "Program",
+            "Number of children enrolled in FFY 2019",
+            "Number of children enrolled in FFY 2020",
+            "Percent change"
+          ],
+          "rows": [
+            [
+              "Medicaid Expansion CHIP",
+              284143,
+              300579,
+              5.78
+            ],
+            [
+              "Separate CHIP",
+              478542,
+              511473,
+              6.88
+            ]
+          ]
+        },
+        "questions": []
+    },
+
+Below is an example of the conditional display for the above example.
+..  code:: json
+
+        "conditional_display": {
+            "type": "conditional_display",
+            "hide_if_table_value": {
+              "target": "$..*[?(@.fieldset_id=='noninteractive-table-2-1')].fieldset_info.rows",
+              "computed": false,
+              "variation_operator": "or",
+              "variations": [
+                {
+                  "threshold": "3",
+                  "operator": ">",
+                  "row": "*",
+                  "row_key": "3"
+                },
+                {
+                  "threshold": "-3",
+                  "operator": "<",
+                  "row": "*",
+                  "row_key": "3"
+                }
+              ]
+            }
+          }
+
 Question types
 --------------
 This section describes the characteristics and properties (in addition to those described in the Answer section) of answer constructs of a given question type that are specific to that type of question.

--- a/frontend/api_postgres/utils/section-schemas/backend-section.schema.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-section.schema.json
@@ -614,6 +614,9 @@
             "comment": {
               "type": "string"
             },
+            "computed": {
+              "type": "boolean"
+            },
             "variation_operator": {
               "type": "string"
             },
@@ -636,7 +639,7 @@
                   }
                 }
               },
-              "required": ["threshold", "operator", "row", "row_key"]
+              "required": ["threshold", "operator", "computed", "row", "row_key"]
             }
           },
           "required": ["target", "variation_operator", "variations"]

--- a/frontend/api_postgres/utils/section-schemas/backend-section.schema.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-section.schema.json
@@ -639,7 +639,13 @@
                   }
                 }
               },
-              "required": ["threshold", "operator", "computed", "row", "row_key"]
+              "required": [
+                "threshold",
+                "operator",
+                "computed",
+                "row",
+                "row_key"
+              ]
             }
           },
           "required": ["target", "variation_operator", "variations"]

--- a/frontend/api_postgres/utils/section-schemas/backend-section.schema.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-section.schema.json
@@ -399,6 +399,9 @@
         "fieldset_info": {
           "type": "object"
         },
+        "fieldset_id": {
+          "type": "string"
+        },
         "context_data": {
           "$ref": "#/definitions/context_data"
         },
@@ -601,6 +604,42 @@
             }
           },
           "required": ["target", "values"]
+        },
+        "hide_if_table_value": {
+          "type": "object",
+          "properties": {
+            "target": {
+              "type": "string"
+            },
+            "comment": {
+              "type": "string"
+            },
+            "variation_operator": {
+              "type": "string"
+            },
+            "variations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "threshold": {
+                    "type": "string"
+                  },
+                  "operator": {
+                    "type": "string"
+                  },
+                  "row": {
+                    "type": "string"
+                  },
+                  "row_key": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": ["threshold", "operator", "row", "row_key"]
+            }
+          },
+          "required": ["target", "variation_operator", "variations"]
         }
       },
       "additionalProperties": false,
@@ -614,6 +653,9 @@
         },
         {
           "required": ["hide_if_not"]
+        },
+        {
+          "required": ["hide_if_table_value"]
         }
       ]
     },

--- a/frontend/react/src/util/shouldDisplay.js
+++ b/frontend/react/src/util/shouldDisplay.js
@@ -65,8 +65,14 @@ const hideIfTableValue = (state, hideIfTableValueInfo) => {
     for(let j = 0; j < targetValues.length; j++) {
 
       // Check if current variation corresponds with targetValue row
+      let rowValue;
+      if(variations[i].row === "*") {
+        rowValue = "*"
+      } else {
+        rowValue = parseInt(variations[i].row, 10)
+      }
       /* eslint-disable no-plusplus */
-      if(variations[i].row === "*" || variations[i].row === j) {
+      if( rowValue === "*" || rowValue === j) {
 
         // get row key
         const rowKey = parseInt(variations[i].row_key, 10);
@@ -78,35 +84,46 @@ const hideIfTableValue = (state, hideIfTableValueInfo) => {
           case "<":
             if(comparisonValue < threshold) {
               resultsArray.push(true)
+            } else {
+              resultsArray.push(false)
             }
             break;
           case ">":
             if(comparisonValue > threshold) {
               resultsArray.push(true)
+            }else {
+              resultsArray.push(false)
             }
             break;
           case "=":
             if(comparisonValue === variations[i].threshold) {
               resultsArray.push(true)
+            }else {
+              resultsArray.push(false)
             }
             break;
           case "!=":
             if(comparisonValue !== variations[i].threshold) {
               resultsArray.push(true)
+            }else {
+              resultsArray.push(false)
             }
             break;
           default:
-            resultsArray.push("not caught")
+            resultsArray.push(false)
         }
 
         // Determine is variation_operator is true
 
         if(variationOperator === "or") {
+          result = false;
+
           if(resultsArray.includes(true)) {
             result = true;
           }
 
         } else if(variationOperator === "and") {
+          result = true;
           if(resultsArray.includes(false)) {
             result = false;
           }

--- a/frontend/react/src/util/shouldDisplay.js
+++ b/frontend/react/src/util/shouldDisplay.js
@@ -50,49 +50,48 @@ const hideIfNot = (state, hideIfNotInfo) => {
 const hideIfTableValue = (state, hideIfTableValueInfo) => {
   // Get table values
   const targetValues = jsonpath.query(state, hideIfTableValueInfo.target)[0];
-  const variations = hideIfTableValueInfo.variations;
-  const variation_operator = hideIfTableValueInfo.variation_operator;
+  const {variations} = hideIfTableValueInfo;
+  const variationOperator = hideIfTableValueInfo.variation_operator;
 
-  let resultsArray = [];
+  const resultsArray = [];
   let result;
 
   // Loop through variations and check is threshold is met
+  /* eslint-disable no-plusplus */
   for(let i = 0; i < variations.length; i++ ) {
 
     // Loop through table rows for matches
+    /* eslint-disable no-plusplus */
     for(let j = 0; j < targetValues.length; j++) {
 
       // Check if current variation corresponds with targetValue row
+      /* eslint-disable no-plusplus */
       if(variations[i].row === "*" || variations[i].row === j) {
 
         // get row key
-        const row_key = parseInt(variations[i]['row_key'], 10);
-        let threshold = parseInt(variations[i].threshold, 10);
-        let comparison_value = parseInt(targetValues[j][row_key], 10);
+        const rowKey = parseInt(variations[i].row_key, 10);
+        const threshold = parseInt(variations[i].threshold, 10);
+        const comparisonValue = parseInt(targetValues[j][rowKey], 10);
 
-        let b = typeof comparison_value;
-        let a =0;
         // Check if threshold is met
         switch(variations[i].operator) {
           case "<":
-            if(comparison_value < threshold) {
+            if(comparisonValue < threshold) {
               resultsArray.push(true)
-              let a = 0;
             }
             break;
           case ">":
-            if(comparison_value > threshold) {
+            if(comparisonValue > threshold) {
               resultsArray.push(true)
-              let a = 0;
             }
             break;
           case "=":
-            if(targetValues[j][row_key] === variations[i].threshold) {
+            if(comparisonValue === variations[i].threshold) {
               resultsArray.push(true)
             }
             break;
           case "!=":
-            if(targetValues[j][row_key] !== variations[i].threshold) {
+            if(comparisonValue !== variations[i].threshold) {
               resultsArray.push(true)
             }
             break;
@@ -102,12 +101,12 @@ const hideIfTableValue = (state, hideIfTableValueInfo) => {
 
         // Determine is variation_operator is true
 
-        if(variation_operator === "or") {
+        if(variationOperator === "or") {
           if(resultsArray.includes(true)) {
             result = true;
           }
 
-        } else if(variation_operator === "and") {
+        } else if(variationOperator === "and") {
           if(resultsArray.includes(false)) {
             result = false;
           }
@@ -117,7 +116,6 @@ const hideIfTableValue = (state, hideIfTableValueInfo) => {
 
 
   }
-  let a =0;
   return result;
 }
 

--- a/frontend/react/src/util/shouldDisplay.js
+++ b/frontend/react/src/util/shouldDisplay.js
@@ -1,4 +1,5 @@
 import jsonpath from "./jsonpath";
+import {compareACS} from "../../src/util/synthesize"
 
 /**
  * This function determines whether a radio's conditional subquestion should hide
@@ -49,7 +50,25 @@ const hideIfNot = (state, hideIfNotInfo) => {
 
 const hideIfTableValue = (state, hideIfTableValueInfo) => {
   // Get table values
-  const targetValues = jsonpath.query(state, hideIfTableValueInfo.target)[0];
+  let targetValues = jsonpath.query(state, hideIfTableValueInfo.target)[0];
+  let computedValue = new Array();
+
+  // If target needs to be calculated
+  if(hideIfTableValueInfo.computed) {
+    const type = targetValues[0][0];
+
+    if(type['compareACS']) {
+      // get computed value via compareACS and push into a multidimensional array
+      computedValue.push([compareACS(state, type['compareACS'])]);
+    }
+
+    if(type['lookupAcs']) {
+
+    }
+  } else {
+    computedValue = targetValues;
+  }
+
   const {variations} = hideIfTableValueInfo;
   const variationOperator = hideIfTableValueInfo.variation_operator;
 
@@ -62,7 +81,7 @@ const hideIfTableValue = (state, hideIfTableValueInfo) => {
 
     // Loop through table rows for matches
     /* eslint-disable no-plusplus */
-    for(let j = 0; j < targetValues.length; j++) {
+    for(let j = 0; j < computedValue.length; j++) {
 
       // Check if current variation corresponds with targetValue row
       let rowValue;
@@ -77,8 +96,8 @@ const hideIfTableValue = (state, hideIfTableValueInfo) => {
         // get row key
         const rowKey = parseInt(variations[i].row_key, 10);
         const threshold = parseInt(variations[i].threshold, 10);
-        const comparisonValue = parseInt(targetValues[j][rowKey], 10);
-
+        const comparisonValue = parseInt(computedValue[j][rowKey], 10);
+let a =0;
         // Check if threshold is met
         switch(variations[i].operator) {
           case "<":
@@ -121,6 +140,7 @@ const hideIfTableValue = (state, hideIfTableValueInfo) => {
           if(resultsArray.includes(true)) {
             result = true;
           }
+          let a =0;
 
         } else if(variationOperator === "and") {
           result = true;
@@ -133,6 +153,7 @@ const hideIfTableValue = (state, hideIfTableValueInfo) => {
 
 
   }
+  let a =0;
   return result;
 }
 

--- a/frontend/react/src/util/shouldDisplay.js
+++ b/frontend/react/src/util/shouldDisplay.js
@@ -85,16 +85,16 @@ const hideIfTableValue = (state, hideIfTableValueInfo) => {
       if(variations[i].row === "*") {
         rowValue = "*"
       } else {
-        rowValue = parseInt(variations[i].row, 10)
+        rowValue = parseFloat(variations[i].row, 10)
       }
       /* eslint-disable no-plusplus */
       if( rowValue === "*" || rowValue === j) {
 
         // get row key
-        const rowKey = parseInt(variations[i].row_key, 10);
-        const threshold = parseInt(variations[i].threshold, 10);
-        const comparisonValue = parseInt(computedValue[j][rowKey], 10);
-let a =0;
+        const rowKey = parseFloat(variations[i].row_key, 10);
+        const threshold = parseFloat(variations[i].threshold, 10);
+        const comparisonValue = parseFloat(computedValue[j][rowKey], 10);
+
         // Check if threshold is met
         switch(variations[i].operator) {
           case "<":

--- a/frontend/react/src/util/shouldDisplay.js
+++ b/frontend/react/src/util/shouldDisplay.js
@@ -1,5 +1,5 @@
 import jsonpath from "./jsonpath";
-import {compareACS} from "../../src/util/synthesize"
+import { compareACS } from "./synthesize";
 
 /**
  * This function determines whether a radio's conditional subquestion should hide
@@ -47,26 +47,24 @@ const hideIfNot = (state, hideIfNotInfo) => {
   return includedBoolean;
 };
 
-
 const hideIfTableValue = (state, hideIfTableValueInfo) => {
   // Get table values
-  let targetValues = jsonpath.query(state, hideIfTableValueInfo.target)[0];
-  let computedValue = new Array();
+  const targetValues = jsonpath.query(state, hideIfTableValueInfo.target)[0];
+  let computedValue = [];
 
   // If target needs to be calculated
-  if(hideIfTableValueInfo.computed) {
+  if (hideIfTableValueInfo.computed) {
     const type = targetValues[0][0];
 
-    if(type['compareACS']) {
+    if (type.compareACS) {
       // get computed value via compareACS and push into a multidimensional array
-      computedValue.push([compareACS(state, type['compareACS'])]);
+      computedValue.push([compareACS(state, type.compareACS)]);
     }
-
   } else {
     computedValue = targetValues;
   }
 
-  const {variations} = hideIfTableValueInfo;
+  const { variations } = hideIfTableValueInfo;
   const variationOperator = hideIfTableValueInfo.variation_operator;
 
   const resultsArray = [];
@@ -74,86 +72,77 @@ const hideIfTableValue = (state, hideIfTableValueInfo) => {
 
   // Loop through variations and check is threshold is met
   /* eslint-disable no-plusplus */
-  for(let i = 0; i < variations.length; i++ ) {
-
+  for (let i = 0; i < variations.length; i++) {
     // Loop through table rows for matches
     /* eslint-disable no-plusplus */
-    for(let j = 0; j < computedValue.length; j++) {
-
+    for (let j = 0; j < computedValue.length; j++) {
       // Check if current variation corresponds with targetValue row
       let rowValue;
-      if(variations[i].row === "*") {
-        rowValue = "*"
+      if (variations[i].row === "*") {
+        rowValue = "*";
       } else {
-        rowValue = parseFloat(variations[i].row, 10)
+        rowValue = parseFloat(variations[i].row, 10);
       }
       /* eslint-disable no-plusplus */
-      if( rowValue === "*" || rowValue === j) {
-
+      if (rowValue === "*" || rowValue === j) {
         // get row key
         const rowKey = parseFloat(variations[i].row_key, 10);
         const threshold = parseFloat(variations[i].threshold, 10);
         const comparisonValue = parseFloat(computedValue[j][rowKey], 10);
 
         // Check if threshold is met
-        switch(variations[i].operator) {
+        switch (variations[i].operator) {
           case "<":
-            if(comparisonValue < threshold) {
-              resultsArray.push(true)
+            if (comparisonValue < threshold) {
+              resultsArray.push(true);
             } else {
-              resultsArray.push(false)
+              resultsArray.push(false);
             }
             break;
           case ">":
-            if(comparisonValue > threshold) {
-              resultsArray.push(true)
-            }else {
-              resultsArray.push(false)
+            if (comparisonValue > threshold) {
+              resultsArray.push(true);
+            } else {
+              resultsArray.push(false);
             }
             break;
           case "=":
-            if(comparisonValue === variations[i].threshold) {
-              resultsArray.push(true)
-            }else {
-              resultsArray.push(false)
+            if (comparisonValue === variations[i].threshold) {
+              resultsArray.push(true);
+            } else {
+              resultsArray.push(false);
             }
             break;
           case "!=":
-            if(comparisonValue !== variations[i].threshold) {
-              resultsArray.push(true)
-            }else {
-              resultsArray.push(false)
+            if (comparisonValue !== variations[i].threshold) {
+              resultsArray.push(true);
+            } else {
+              resultsArray.push(false);
             }
             break;
           default:
-            resultsArray.push(false)
+            resultsArray.push(false);
         }
 
         // Determine is variation_operator is true
 
-        if(variationOperator === "or") {
+        if (variationOperator === "or") {
           result = false;
 
-          if(resultsArray.includes(true)) {
+          if (resultsArray.includes(true)) {
             result = true;
           }
-          let a =0;
-
-        } else if(variationOperator === "and") {
+        } else if (variationOperator === "and") {
           result = true;
-          if(resultsArray.includes(false)) {
+          if (resultsArray.includes(false)) {
             result = false;
           }
         }
       }
     }
-
-
   }
-  let a =0;
   return result;
-}
-
+};
 
 /**
  * This function checks to see if a question should display based on an answer from a different question
@@ -198,7 +187,10 @@ const shouldDisplay = (state, context) => {
   // hide_if_table_value, there is one target table that may have multiple variations
   // displaying relies on variations supplied to return a bool is ANY are tru
   if (context.conditional_display.hide_if_table_value) {
-    return hideIfTableValue(state, context.conditional_display.hide_if_table_value);
+    return hideIfTableValue(
+      state,
+      context.conditional_display.hide_if_table_value
+    );
   }
 
   // If we don't know what the heck is going on, just return true. Better to

--- a/frontend/react/src/util/shouldDisplay.js
+++ b/frontend/react/src/util/shouldDisplay.js
@@ -62,9 +62,6 @@ const hideIfTableValue = (state, hideIfTableValueInfo) => {
       computedValue.push([compareACS(state, type['compareACS'])]);
     }
 
-    if(type['lookupAcs']) {
-
-    }
   } else {
     computedValue = targetValues;
   }

--- a/frontend/react/src/util/synthesize.js
+++ b/frontend/react/src/util/synthesize.js
@@ -216,7 +216,7 @@ const lookupAcs = (state, { ffy, acsProperty }) => {
  * @param {string} acsProperty
  * @returns {(string|float)}
  */
-const compareACS = (state, { ffy1, ffy2, acsProperty }) => {
+export const compareACS = (state, { ffy1, ffy2, acsProperty }) => {
   const percentagePrecision = 2;
   let returnValue = "Not Available";
   // if allStatesData and stateUser are available


### PR DESCRIPTION
Covers Tickets: #641 and #877 

shouldDisplay.js: Allow for conditional logic to be applied from data in non-interactive and synthesized tables. This allows shouldDisplay to read from alternative sources when determining if questions should be shown/hidden

backend-json-section-2.json: Updates to fields to allow for conditional logic from non-interactive and synthesized tables

backend-json-structure-documentation.rst: Updated documentation

backend-section.schema.json: Update schema to allow for new JSON parameters

synthesize.js: Export compareACS for use in shouldDisplay.js


