### PR TITLE
Add table header/body to non-interactive table and style

### DIFF
--- a/frontend/react/src/components/fields/NoninteractiveTable.js
+++ b/frontend/react/src/components/fields/NoninteractiveTable.js
@@ -7,47 +7,55 @@ const NoninteractiveTable = ({ question }) => {
   let percentLocation = [];
   let count = -1;
   return (
-    <table className="ds-c-table" width="100%">
-      <thead>
-        <tr>
-          {question.fieldset_info.headers.map(function (header) {
-            count += 1;
-            // captures the location of a percent element
-            if (String(header).toLowerCase().includes("percent")) {
-              percentLocation[count] = true;
-            } else {
-              percentLocation[count] = false;
-            }
-            return (
-              <th width={`${columnWidth}%`} name={`${header}`}>
-                {header}
-              </th>
-            );
-          })}
-        </tr>
-      </thead>
-      {question.fieldset_info.rows.map((row) => {
-        count = -1;
-        return (
+    <div className="non-interactive-table ds-u-margin-top--2">
+      <table className="ds-c-table" width="100%">
+        <thead>
           <tr>
-            {row.map((value) => {
+            {question.fieldset_info.headers.map((header) => {
               count += 1;
-              // adds % to any element that has percent in the header and adds commas via toLocaleString
-              if (percentLocation[count] === true) {
-                return (
-                  <td width={`${columnWidth}%`}>{value.toLocaleString()}%</td>
-                );
-                // eslint-disable-next-line
+              // captures the location of a percent element
+              if (String(header).toLowerCase().includes("percent")) {
+                percentLocation[count] = true;
               } else {
-                return (
-                  <td width={`${columnWidth}%`}>{value.toLocaleString()}</td>
-                );
+                percentLocation[count] = false;
               }
+              return (
+                <th width={`${columnWidth}%`} name={`${header}`}>
+                  {header}
+                </th>
+              );
             })}
           </tr>
-        );
-      })}
-    </table>
+        </thead>
+        <tbody>
+          {question.fieldset_info.rows.map((row) => {
+            count = -1;
+            return (
+              <tr>
+                {row.map((value) => {
+                  count += 1;
+                  // adds % to any element that has percent in the header and adds commas via toLocaleString
+                  if (percentLocation[count] === true) {
+                    return (
+                      <td width={`${columnWidth}%`}>
+                        {value.toLocaleString()}%
+                      </td>
+                    );
+                    // eslint-disable-next-line
+                  } else {
+                    return (
+                      <td width={`${columnWidth}%`}>
+                        {value.toLocaleString()}
+                      </td>
+                    );
+                  }
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
   );
 };
 NoninteractiveTable.propTypes = {

--- a/frontend/react/src/scss/_form.scss
+++ b/frontend/react/src/scss/_form.scss
@@ -18,6 +18,22 @@
   margin: 1.2rem 0;
 }
 
+.synthesized-table,
+.non-interactive-table {
+  table {
+    thead {
+      th {
+        background: #ddd;
+      }
+    }
+    tbody {
+      td {
+        background: #efefef;
+      }
+    }
+  }
+}
+
 .form-options {
   margin: ($padding * 3) 0;
 


### PR DESCRIPTION
Satisfies: #700 

Add table header and table body to non-interactive tables.

Style non-interactive and synthesized tables to more clearly indicate that no user input is needed.