### PR TITLE
change container count to 1 for prod

### DIFF
--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -7,7 +7,7 @@ locals {
   dev_postgres     = substr(terraform.workspace, 0, 4) == "dev-" ? 1 : 0
   master_postgres  = terraform.workspace == "master" ? 1 : 0
   staging_postgres = terraform.workspace == "staging" ? 1 : 0
-  prod_postgres    = terraform.workspace == "prod" ? 3 : 0
+  prod_postgres    = terraform.workspace == "prod" ? 1 : 0
 
   count_postgres         = local.dev_postgres + local.master_postgres + local.staging_postgres + local.prod_postgres
   desired_count_postgres = local.count_postgres > 0 ? local.count_postgres : 1


### PR DESCRIPTION
change container count to 1 for prod

since the api container does data migrations, only 1 should be allowed to exist