### PR TITLE
Set DJANGO_SETTINGS_MODULE for all api tasks

### DIFF
--- a/frontend/api_postgres/carts/wsgi.py
+++ b/frontend/api_postgres/carts/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'carts.settings_prod')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'carts.settings')
 
 application = get_wsgi_application()

--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -2,17 +2,6 @@ locals {
   endpoint_api_postgres = var.acm_certificate_domain_api_postgres == "" ? "http://${aws_alb.api_postgres.dns_name}:8000" : "https://${var.acm_certificate_domain_api_postgres}"
 }
 
-# Number of container instances to spawn per resource. Default is 1.
-locals {
-  dev_postgres     = substr(terraform.workspace, 0, 4) == "dev-" ? 1 : 0
-  master_postgres  = terraform.workspace == "master" ? 1 : 0
-  staging_postgres = terraform.workspace == "staging" ? 1 : 0
-  prod_postgres    = terraform.workspace == "prod" ? 1 : 0
-
-  count_postgres         = local.dev_postgres + local.master_postgres + local.staging_postgres + local.prod_postgres
-  desired_count_postgres = local.count_postgres > 0 ? local.count_postgres : 1
-}
-
 data "aws_ssm_parameter" "postgres_user" {
   name = "/${terraform.workspace}/postgres_user"
 }
@@ -106,7 +95,7 @@ resource "aws_ecs_service" "api_postgres" {
     capacity_provider = "FARGATE"
     weight            = "100"
   }
-  desired_count = local.desired_count_postgres
+  desired_count = 1
   network_configuration {
     subnets         = data.aws_subnet_ids.private.ids
     security_groups = [aws_security_group.api_postgres.id]

--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -1,5 +1,8 @@
 locals {
   endpoint_api_postgres = var.acm_certificate_domain_api_postgres == "" ? "http://${aws_alb.api_postgres.dns_name}:8000" : "https://${var.acm_certificate_domain_api_postgres}"
+  django_settings_module = {
+    "prod" : "carts.settings_prod"
+  }
 }
 
 data "aws_ssm_parameter" "postgres_user" {
@@ -44,6 +47,7 @@ resource "aws_ecs_task_definition" "api_postgres" {
     cloudwatch_stream_prefix = "api_postgres",
     postgres_api_url         = var.acm_certificate_domain_api_postgres == "" ? aws_alb.api_postgres.dns_name : var.acm_certificate_domain_api_postgres,
     openid_discovery_url     = var.openid_discovery_url
+    django_settings_module   = lookup(local.django_settings_module, terraform.workspace, "carts.settings")
   })
 }
 

--- a/frontend/aws/templates/ecs_task_def_api_postgres.json.tpl
+++ b/frontend/aws/templates/ecs_task_def_api_postgres.json.tpl
@@ -32,6 +32,10 @@
       {
         "name": "OPENID_DISCOVERY_URL",
         "value": "${openid_discovery_url}"
+      },
+      {
+        "name": "DJANGO_SETTINGS_MODULE",
+        "value": "${django_settings_module}"
       }
     ],
     "logConfiguration": {


### PR DESCRIPTION
Default is non-prod; behavior is overriden by adding to the local.django_settings_module lookup table