### PR TITLE
Update linter to use eslint:recommended

### DIFF
--- a/frontend/react/.eslintrc.json
+++ b/frontend/react/.eslintrc.json
@@ -1,6 +1,11 @@
 {
   "parser": "babel-eslint",
-  "extends": ["eslint:recommended", "plugin:react/recommended", "prettier", "prettier/react"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "prettier",
+    "prettier/react"
+  ],
   "rules": {
     "no-param-reassign": [2, { "props": false }],
     "react/jsx-filename-extension": 0,

--- a/frontend/react/.eslintrc.json
+++ b/frontend/react/.eslintrc.json
@@ -1,30 +1,10 @@
 {
   "parser": "babel-eslint",
-  "extends": ["airbnb", "prettier", "prettier/react"],
+  "extends": ["eslint:recommended", "plugin:react/recommended", "prettier", "prettier/react"],
   "rules": {
-    "jsx-a11y/anchor-is-valid": [
-      2,
-      {
-        "components": ["Link"],
-        "specialLink": ["to"]
-      }
-    ],
-    "jsx-a11y/label-has-for": [
-      2,
-      {
-        "required": {
-          "some": ["nesting", "id"]
-        }
-      }
-    ],
-    "jsx-a11y/label-has-associated-control": ["error", { "assert": "either" }],
-
     "no-param-reassign": [2, { "props": false }],
-
-    "react/forbid-prop-types": ["error", { "forbid": ["any"] }],
     "react/jsx-filename-extension": 0,
-    "react/jsx-props-no-spreading": 0,
-    "react/no-array-index-key": "warn"
+    "react/jsx-props-no-spreading": 0
   },
   "env": {
     "browser": true

--- a/frontend/react/package-lock.json
+++ b/frontend/react/package-lock.json
@@ -6365,28 +6365,6 @@
         }
       }
     },
-    "eslint-config-airbnb": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.0.tgz",
-      "integrity": "sha512-Fz4JIUKkrhO0du2cg5opdyPKQXOI2MvF8KUvN2710nJMT6jaRUpRE2swrJftAjVGL7T1otLM5ieo5RqS1v9Udg==",
-      "dev": true,
-      "requires": {
-        "eslint-config-airbnb-base": "^14.2.0",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2"
-      }
-    },
-    "eslint-config-airbnb-base": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.0.tgz",
-      "integrity": "sha512-Snswd5oC6nJaevs3nZoLSTvGJBvzTfnBqOIArkf3cbyTyq9UD79wOk8s+RiL6bhca0p/eRO6veczhf6A/7Jy8Q==",
-      "dev": true,
-      "requires": {
-        "confusing-browser-globals": "^1.0.9",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2"
-      }
-    },
     "eslint-config-prettier": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",

--- a/frontend/react/package.json
+++ b/frontend/react/package.json
@@ -68,7 +68,6 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "eslint": "^7.9.0",
-    "eslint-config-airbnb": "^18.2.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",


### PR DESCRIPTION
Remove the opinionated airbnb linter in favor of a more applicable standard for this project. 

Also remove custom rules that no longer apply to the linter source.