### PR TITLE
Update auth_user on login

### DIFF
--- a/frontend/api_postgres/carts/auth.py
+++ b/frontend/api_postgres/carts/auth.py
@@ -17,6 +17,7 @@ from carts.carts_api.models import (
 )
 from carts.carts_api.model_utils import role_from_raw_ldap_job_codes
 from rest_framework.permissions import AllowAny
+from datetime import datetime
 
 
 class JwtAuthentication(authentication.BaseAuthentication):
@@ -74,6 +75,8 @@ def _get_or_create_user(user_info):
     user.first_name = user_info["given_name"]
     user.last_name = user_info["family_name"]
     user.email = user_info["email"]
+    user.last_login = datetime.now()
+    user.is_active = True
 
     print(f"$$$$\n\nobtained user", user.email, "\n\n\n")
 


### PR DESCRIPTION
[2647 Last Login Date is not being recorded](https://qmacbis.atlassian.net/browse/OY2-2647)

Modified the Django auth.py's _get_or_create_user function to update the following in the public database:
- Update last_login to the current date/time on successful login
- Update is_active to true on successful login