### PR TITLE
Change the label for combo Program Type

### DIFF
--- a/docs/Queries/qry_ChangeProgramTypeOptions_11192020.sql
+++ b/docs/Queries/qry_ChangeProgramTypeOptions_11192020.sql
@@ -1,0 +1,5 @@
+UPDATE	carts_api_section
+SET    	contents = jsonb_set(contents, 
+				 '{section, subsections, 0, parts, 0, questions, 1, answer, options, 0}', '{"label": "Both Medicaid Expansion CHIP and Separate CHIP", "value": "combo"}')
+--FROM 	carts_api_section
+WHERE 	contents->'section'->>'id' = '2020-00' 

--- a/frontend/api_postgres/utils/section-schemas/backend-json-section-0.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-json-section-0.json
@@ -39,7 +39,7 @@
                   "options": [
                     {
                       "value": "combo",
-                      "label": "Combination"
+                      "label": "Both Medicaid Expansion CHIP and Separate CHIP"
                     },
                     {
                       "value": "medicaid_exp_chip",


### PR DESCRIPTION
Use "Both Medicaid Expansion CHIP and Separate CHIP" instead of "Combination" in the Basic Info Section.

- sql query to update the database
- json update so the fixtures remain in sync with the database

The sql query will need to be run manually in each environment. It has already been run manually in DEV. I can run it in VAL after this PR is approved and passed Manager Review. DevSecOps will need to run it in PROD when we are satisfied with it. JIRA Ticket for this action will be needed.