### PR TITLE
Open yearly forms in current tab instead of a new tab

### DIFF
--- a/frontend/react/src/components/sections/homepage/ReportItem.js
+++ b/frontend/react/src/components/sections/homepage/ReportItem.js
@@ -14,7 +14,7 @@ const ReportItem = ({
   theUncertify: uncertifyAction,
   stateUser,
 }) => {
-  const anchorTarget = link1Text === "Edit" ? "_self" : "_blank";
+  const anchorTarget = "_self";
   const stateCode = link1URL.toString().split("/")[3];
   const uncertify = () => {
     if (window.confirm("Are you sure to uncertify this record?")) {


### PR DESCRIPTION
This addresses ticket [2451](https://qmacbis.atlassian.net/browse/OY2-2451). Now when the user clicks to view or edit a state form, it will open up in their current tab instead of a new tab.