### PR TITLE
Bugfix: Export couldn't export null values

### DIFF
--- a/frontend/react/src/components/layout/HomeAdmin.js
+++ b/frontend/react/src/components/layout/HomeAdmin.js
@@ -39,7 +39,7 @@ const AdminHome = ({ SecureRouteComponent: SecureRoute }) => (
                 </Link>
               </li>
               <li>
-                <Link to="/users">List and edit all users</Link>
+                <a href="/users">List and edit all users</a>
               </li>
               <li>
                 <Link to="/add_state_user">Add state user</Link>

--- a/frontend/react/src/components/layout/users/Users.js
+++ b/frontend/react/src/components/layout/users/Users.js
@@ -56,7 +56,7 @@ const Users = () => {
     }
   };
 
-  let tableData;
+  let tableData = false;
 
   if (users) {
     // Build column structure for react-data-tables
@@ -92,13 +92,24 @@ const Users = () => {
         name: "Role",
         selector: "user_role",
         sortable: true,
+        cell: function Role(r) {
+          if (r) {
+            return r.user_role;
+          } else {
+            return "";
+          }
+        },
       },
       {
         name: "Joined",
         selector: "date_joined",
         sortable: true,
         cell: function modifyDateJoined(d) {
-          return <span>{moment(d.date_joined).format("MM/DD/YYYY")}</span>;
+          if (d.date_joined) {
+            return <span>{moment(d.date_joined).format("MM/DD/YYYY")}</span>;
+          } else {
+            return "";
+          }
         },
       },
       {
@@ -106,7 +117,11 @@ const Users = () => {
         selector: "last_login",
         sortable: true,
         cell: function modifyLastLogin(l) {
-          return <span>{moment(l.last_login).format("MM/DD/YYYY")}</span>;
+          if (l.last_login) {
+            return <span>{moment(l.last_login).format("MM/DD/YYYY")}</span>;
+          } else {
+            return "";
+          }
         },
       },
       {
@@ -136,14 +151,14 @@ const Users = () => {
             <span>
               {s.is_active ? (
                 <button
-                  className="btn btn-primary"
+                  className="btn btn-primary status"
                   onClick={() => deactivateUser(s.username)}
                 >
                   Deactivate
                 </button>
               ) : (
                 <button
-                  className="btn btn-primary"
+                  className="btn btn-primary status"
                   onClick={() => activateUser(s.username)}
                 >
                   Activate

--- a/frontend/react/src/scss/_layout.scss
+++ b/frontend/react/src/scss/_layout.scss
@@ -49,6 +49,21 @@ div[hidden] {
 .user-profiles {
   overflow-y: hidden;
   margin: 2.2rem 0;
+
+  .MuiPaper-root {
+    border: 1px solid #aaa;
+  }
+
+  .status {
+    min-width: 80px;
+  }
+}
+
+.App.users {
+  .ds-l-container {
+    max-width: 1080px;
+    padding: 0;
+  }
 }
 
 .data-table-extensions {

--- a/frontend/react/src/scss/_layout.scss
+++ b/frontend/react/src/scss/_layout.scss
@@ -61,7 +61,7 @@ div[hidden] {
 
 .App.users {
   .ds-l-container {
-    max-width: 1080px;
+    max-width: 1120px;
     padding: 0;
   }
 }

--- a/frontend/react/src/wrapSecurity.js
+++ b/frontend/react/src/wrapSecurity.js
@@ -55,9 +55,9 @@ const WrappedSecurity = () => {
 
   /* eslint-disable-line */
   console.log("!***** initial data load [userData] ===>", userData);
-
+  let pageName = window.location.pathname.split("/")[1];
   return (
-    <div className="App" data-test="component-app">
+    <div className={`${pageName + " App"}`} data-test="component-app">
       <SecurityWrapper
         {...config.oidc}
         tokenManager={{ secure: true, storage: "cookie" }}

--- a/frontend/react/src/wrapSecurity.js
+++ b/frontend/react/src/wrapSecurity.js
@@ -55,9 +55,12 @@ const WrappedSecurity = () => {
 
   /* eslint-disable-line */
   console.log("!***** initial data load [userData] ===>", userData);
-  let pageName = window.location.pathname.split("/")[1];
+
   return (
-    <div className={`${pageName + " App"}`} data-test="component-app">
+    <div
+      className={"App " + window.location.pathname.split("/")[1]}
+      data-test="component-app"
+    >
       <SecurityWrapper
         {...config.oidc}
         tokenManager={{ secure: true, storage: "cookie" }}


### PR DESCRIPTION
Export of table failed due to null/undefined values. Instead of displaying a null value, switched to empty string.

Added page specific class name to wrapSecurity.

Adjusted styling on `/users/`: Removed padding and increased max-width