### PR TITLE
Add printable textarea functionality

### DIFF
--- a/frontend/react/package-lock.json
+++ b/frontend/react/package-lock.json
@@ -13206,6 +13206,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
     },
+    "react-html-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-html-parser/-/react-html-parser-2.0.2.tgz",
+      "integrity": "sha512-XeerLwCVjTs3njZcgCOeDUqLgNIt/t+6Jgi5/qPsO/krUWl76kWKXMeVs2LhY2gwM6X378DkhLjur0zUQdpz0g==",
+      "requires": {
+        "htmlparser2": "^3.9.0"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",

--- a/frontend/react/package.json
+++ b/frontend/react/package.json
@@ -28,6 +28,7 @@
     "react-data-table-component": "^6.11.6",
     "react-data-table-component-extensions": "^1.5.0",
     "react-dom": "^16.13.1",
+    "react-html-parser": "^2.0.2",
     "react-number-format": "^4.4.1",
     "react-papaparse": "^3.8.0",
     "react-redux": "^7.2.0",

--- a/frontend/react/src/components/fields/Text.js
+++ b/frontend/react/src/components/fields/Text.js
@@ -1,15 +1,28 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { TextField } from "@cmsgov/design-system-core";
 
-const Text = ({ question, ...props }) => (
-  <TextField
-    value={(question.answer && question.answer.entry) || ""}
-    type="text"
-    label=""
-    {...props}
-  />
-);
+const Text = ({ question, ...props }) => {
+  const [printValue, setPrintValue] = useState(
+    (question.answer && question.answer.entry) || ""
+  );
+
+  const updatePrintHelper = ({ target: { value } }) => {
+    setPrintValue(value);
+  };
+  return (
+    <>
+      <div className="print-helper">{printValue}</div>
+      <TextField
+        value={(question.answer && question.answer.entry) || ""}
+        type="text"
+        label=""
+        onBlur={updatePrintHelper}
+        {...props}
+      />
+    </>
+  );
+};
 Text.propTypes = {
   question: PropTypes.object.isRequired,
 };

--- a/frontend/react/src/components/fields/Text.js
+++ b/frontend/react/src/components/fields/Text.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { TextField } from "@cmsgov/design-system-core";
+import ReactHtmlParser from "react-html-parser";
 
 const Text = ({ question, ...props }) => {
   const [printValue, setPrintValue] = useState(
@@ -8,11 +9,12 @@ const Text = ({ question, ...props }) => {
   );
 
   const updatePrintHelper = ({ target: { value } }) => {
-    setPrintValue(value);
+    const val = value.replace(/\n/g, "<br/>");
+    setPrintValue(val);
   };
   return (
     <>
-      <div className="print-helper">{printValue}</div>
+      <div className="print-helper">{ReactHtmlParser(printValue)}</div>
       <TextField
         value={(question.answer && question.answer.entry) || ""}
         type="text"

--- a/frontend/react/src/scss/_globals.scss
+++ b/frontend/react/src/scss/_globals.scss
@@ -25,7 +25,8 @@ img {
   color: red;
 }
 
-.print-only {
+.print-only,
+.print-helper {
   display: none;
 }
 

--- a/frontend/react/src/scss/_print.scss
+++ b/frontend/react/src/scss/_print.scss
@@ -3,13 +3,22 @@
  */
 
 .print-all {
+  textarea {
+    display: none !important;
+  }
+
   .ds-c-alert,
   .form-footer,
   .page-info {
     display: none;
   }
-  .print-only {
+  .print-only,
+  .print-helper {
     display: block;
+  }
+
+  .print-helper {
+    margin: 1.2rem 0;
   }
 
   .screen-only {
@@ -36,6 +45,9 @@
 }
 
 @media print {
+  textarea {
+    display: none !important;
+  }
   .action-buttons,
   .ds-c-alert,
   .footer,
@@ -48,8 +60,13 @@
     display: none;
   }
 
-  .print-only {
+  .print-only,
+  .print-helper {
     display: block;
+  }
+
+  .print-helper {
+    margin: 1.2rem 0;
   }
 
   .screen-only {


### PR DESCRIPTION
Satisfies: [#3284](https://qmacbis.atlassian.net/browse/OY2-3284?atlOrigin=eyJpIjoiMGJjZmEwNTJmZGJkNGY1NThkN2E0OWE5YzkyMjAzMWUiLCJwIjoiaiJ9)

There is no reasonable CSS-only solution to print textareas. Instead, I created a new div the mimics the data in the textarea. In the print styleshet, the textarea is hidden the print-helper text is shown. This works for text_multiline and text_medium.