### PR TITLE
Show edit link if status is undefined

### DIFF
--- a/frontend/react/src/store/selectors.js
+++ b/frontend/react/src/store/selectors.js
@@ -1,6 +1,6 @@
 import jsonpath from "../util/jsonpath";
 
-import { selectFragment } from "./formData"; // eslint-disable-line import/no-cycle
+import { selectFragment } from "./formData";
 import { shouldDisplay } from "../util/shouldDisplay";
 import statesArray from "../components/Utils/statesArray";
 
@@ -149,6 +149,7 @@ export const selectIsFormEditable = (state) => {
     case "not_started":
     case "in_progress":
     case "uncertified":
+    case undefined:
       // Forms can only be edited if the current user is a state user AND the
       // form is in one of the statuses above.
       return role === "state_user";


### PR DESCRIPTION
Satisfies: [#3331](https://qmacbis.atlassian.net/browse/OY2-3331?atlOrigin=eyJpIjoiZjVjZjc3ODMwMjVmNDA0YWJjMmI2YjFmOGJkZjllN2QiLCJwIjoiaiJ9)

On first load for a new state user, the reportStatus is undefined. For the first load of the homepage, users were not able to edit the form. This has been fixed to account for undefined as a status option. 