### PR TITLE
Default users with no role to state_user, show error if incomplete

### DIFF
--- a/frontend/api_postgres/carts/auth.py
+++ b/frontend/api_postgres/carts/auth.py
@@ -106,6 +106,8 @@ def _get_or_create_user(user_info):
     print(f"\n\n    $$$$$username_map is: ", username_map)
 
     if not username_map:
+        # If nothing is returned from RoleFromUsername
+        # table, default to state user
         role = "state_user"
     else:
         role = role_from_raw_ldap_job_codes(

--- a/frontend/api_postgres/carts/auth.py
+++ b/frontend/api_postgres/carts/auth.py
@@ -105,9 +105,12 @@ def _get_or_create_user(user_info):
 
     print(f"\n\n    $$$$$username_map is: ", username_map)
 
-    role = role_from_raw_ldap_job_codes(
-        role_map, username_map, user_info["job_codes"]
-    )
+    if not username_map:
+        role = "state_user"
+    else:
+        role = role_from_raw_ldap_job_codes(
+            role_map, username_map, user_info["job_codes"]
+        )
 
     print(f"\n\n!!!$$$$$role is: ", role)
 

--- a/frontend/react/src/components/layout/Home.js
+++ b/frontend/react/src/components/layout/Home.js
@@ -6,9 +6,11 @@ import AdminHome from "./HomeAdmin";
 import CMSHome from "./HomeCMS";
 import StateHome from "./HomeState";
 import Unauthorized from "./Unauthorized";
+import IncompleteUser from "./IncompleteUser";
 
-const Home = ({ role, SecureRouteComponent }) => {
+const Home = ({ role, SecureRouteComponent, stateId }) => {
   let content = null;
+  console.log("zzzzzzzzz", stateId);
   switch (role) {
     case "admin_user":
       content = <AdminHome SecureRouteComponent={SecureRouteComponent} />;
@@ -18,7 +20,13 @@ const Home = ({ role, SecureRouteComponent }) => {
       content = <CMSHome SecureRouteComponent={SecureRouteComponent} />;
       break;
     case "state_user":
-      content = <StateHome SecureRouteComponent={SecureRouteComponent} />;
+      if (stateId) {
+        content = <StateHome SecureRouteComponent={SecureRouteComponent} />;
+      } else {
+        content = (
+          <IncompleteUser SecureRouteComponent={SecureRouteComponent} />
+        );
+      }
       break;
     default:
       content = <Unauthorized />;
@@ -32,11 +40,13 @@ const Home = ({ role, SecureRouteComponent }) => {
 };
 Home.propTypes = {
   role: PropTypes.oneOf([PropTypes.bool, PropTypes.string]).isRequired,
+  stateId: PropTypes.element.isRequired,
   SecureRouteComponent: PropTypes.element.isRequired,
 };
 
 const mapState = (state) => ({
   role: state.stateUser?.currentUser?.role,
+  stateId: state.stateUser?.currentUser?.state.id,
 });
 
 export default connect(mapState)(Home);

--- a/frontend/react/src/components/layout/Home.js
+++ b/frontend/react/src/components/layout/Home.js
@@ -10,7 +10,7 @@ import IncompleteUser from "./IncompleteUser";
 
 const Home = ({ role, SecureRouteComponent, stateId }) => {
   let content = null;
-  console.log("zzzzzzzzz", stateId);
+
   switch (role) {
     case "admin_user":
       content = <AdminHome SecureRouteComponent={SecureRouteComponent} />;
@@ -20,9 +20,11 @@ const Home = ({ role, SecureRouteComponent, stateId }) => {
       content = <CMSHome SecureRouteComponent={SecureRouteComponent} />;
       break;
     case "state_user":
+      // If there is a state associated to the user, send them to home page
       if (stateId) {
         content = <StateHome SecureRouteComponent={SecureRouteComponent} />;
       } else {
+        // If no state, alert the user that their setup is incomplete
         content = (
           <IncompleteUser SecureRouteComponent={SecureRouteComponent} />
         );

--- a/frontend/react/src/components/layout/IncompleteUser.js
+++ b/frontend/react/src/components/layout/IncompleteUser.js
@@ -4,9 +4,10 @@ const incompleteUser = () => (
   <div>
     <h1>User Account Error</h1>
     <p>
-      Your account has not been fully set up. Please contact{" "}
+      Additional information is required to provide access to your CARTS
+      account, please contact the Help Desk at{" "}
       <a href="mailto:cartshelp@cms.hhs.gov">cartshelp@cms.hhs.gov</a> for
-      assistance.
+      further assistance.
     </p>
   </div>
 );

--- a/frontend/react/src/components/layout/IncompleteUser.js
+++ b/frontend/react/src/components/layout/IncompleteUser.js
@@ -1,0 +1,14 @@
+import React from "react";
+
+const incompleteUser = () => (
+  <div>
+    <h1>User Account Error</h1>
+    <p>
+      Your account has not been fully set up. Please contact{" "}
+      <a href="mailto:cartshelp@cms.hhs.gov">cartshelp@cms.hhs.gov</a> for
+      assistance.
+    </p>
+  </div>
+);
+
+export default incompleteUser;


### PR DESCRIPTION
Satisfies: [#3384](https://qmacbis.atlassian.net/secure/RapidBoard.jspa?rapidView=184&projectKey=OY2&modal=detail&selectedIssue=OY2-3384&search=3384)

Users without an entry in the `carts_api_rolefromusername` table will now default to "state_user" in app (no db change occurs). This provides the lowest amount of privileges possible.

When the user attempts to access the site without an assigned state in the `carts_api_statesfromusername` table they are now greeted with an error message containing instructions to contact the helpdesk. 