### PR TITLE
Address logout issue: missing client_id

### DIFF
--- a/frontend/react/.env
+++ b/frontend/react/.env
@@ -3,3 +3,4 @@ API_POSTGRES_URL=https//default.dev.api_postgres.com
 API_SQLSERVER_URL=https//default.dev.api_sqlserver.com
 OIDC_CLIENT_ID=0oa4juv4poiQ6nDB6297
 OIDC_ISSUER=https://test.idp.idm.cms.gov/oauth2/aus4itu0feyg3RJTK297
+OIDC_ISSUER_URL=https://test.idp.idm.cms.gov

--- a/frontend/react/src/components/layout/Logout.js
+++ b/frontend/react/src/components/layout/Logout.js
@@ -20,7 +20,12 @@ const Logout = () => {
       await authService.logout("/");
 
       // Clear remote session
-      window.location.href = `${config.oidc.issuer}/v1/logout?id_token_hint=${idToken}&post_logout_redirect_uri=${redirectUri}`;
+      if (idToken) {
+        window.location.href = `${config.oidc.issuer}/v1/logout?id_token_hint=${idToken}&post_logout_redirect_uri=${redirectUri}`;
+      } else {
+        /* eslint-disable no-undef */
+        window.location.href = `${window.env.OIDC_ISSUER_URL}/login/signout?fromURI=${redirectUri}`;
+      }
     };
 
     return (


### PR DESCRIPTION
Satisfies: [#3673](https://qmacbis.atlassian.net/browse/OY2-3673?atlOrigin=eyJpIjoiNzU4MWM4ZDAxYTQyNGNlZWJiOTQxNDViYTQ2ZTNjNTEiLCJwIjoiaiJ9)

Occasionally, users experience a logout error concerning a missing client_id. This addresses that issue with a workaround for when the client_id or idToken are missing.