### PR TITLE
Money/Integer field validation checks copy/paste values 

### DIFF
--- a/frontend/react/src/components/fields/Integer.js
+++ b/frontend/react/src/components/fields/Integer.js
@@ -6,11 +6,11 @@ const Integer = ({ onChange, question, ...props }) => {
   const [error, setError] = useState(false);
 
   const change = ({ target: { name, value } }) => {
-    const stripped = value.replace(/,/g, "");
+    const stripped = value.replace(/[^0-9]+/g, "");
     const parsed = parseFloat(stripped);
 
     if (!Number.isNaN(parsed)) {
-      onChange({ target: { name, value: `${stripped}` } });
+      onChange({ target: { name, value: `${parsed}` } });
       setError(false);
     } else {
       setError("Please enter whole numbers only");

--- a/frontend/react/src/components/fields/Percentage.js
+++ b/frontend/react/src/components/fields/Percentage.js
@@ -10,18 +10,20 @@ const Percentage = ({ onChange, question, ...props }) => {
 
     let sign = "";
     if (/^(\+|-)/.test(value)) {
+      // starts with a + or - sign; temporarily remove
       [sign] = value;
 
       value = value.substr(1);
     }
 
     const numericString = `${value}`;
+    // This strips everything but numbers and decimals
     const stripped = numericString.replace(/[^0-9.]/g, "");
 
     // Parsed will remove trailing '.'s as users type, so it is used just to validate
     const parsed = parseFloat(stripped);
 
-    //This regex allows for numbers with a single decimal
+    //This regex allows for numbers with ONLY a single decimal
     const regexTest = /^\d*[0-9](|.\d*[0-9]|,\d*[0-9])?$/;
     const isNumberOrDecimal = regexTest.test(stripped);
 

--- a/frontend/react/src/components/fields/Percentage.js
+++ b/frontend/react/src/components/fields/Percentage.js
@@ -10,17 +10,32 @@ const Percentage = ({ onChange, question, ...props }) => {
 
     let sign = "";
     if (/^(\+|-)/.test(value)) {
-      // starts with a + or - sign; temporarily remove
       [sign] = value;
+
       value = value.substr(1);
     }
 
-    const numeric = +value;
+    const numericString = `${value}`;
+    const stripped = numericString.replace(/[^0-9.]/g, "");
 
-    if (!Number.isNaN(numeric)) {
-      onChange({ target: { name, value: `${sign}${value}` } });
-      setError(false);
+    // Parsed will remove trailing '.'s as users type, so it is used just to validate
+    const parsed = parseFloat(stripped);
+
+    //This regex allows for numbers with a single decimal
+    const regexTest = /^\d*[0-9](|.\d*[0-9]|,\d*[0-9])?$/;
+    const isNumberOrDecimal = regexTest.test(stripped);
+
+    if (!Number.isNaN(parsed)) {
+      onChange({ target: { name, value: `${sign}${stripped}` } });
+
+      // if a number has multiple decimals
+      if (!isNumberOrDecimal) {
+        setError("Please enter only numbers and decimals");
+      } else {
+        setError(false);
+      }
     } else {
+      // if the input cannot be parsed into a number
       setError("Please enter only numbers and decimals");
     }
   };


### PR DESCRIPTION
**Linked Issue:**
https://qmacbis.atlassian.net/browse/OY2-3845

**Overview:**
This fixes the bug that users were encountering when using copy/paste to populate money fields. The validation is triggered when they copy/paste. Specifically in section 5, calculated fields rely on the input from money fields so validation errors in the money fields triggered errors elsewhere in the section. 

**Files Changed (2):**
`frontend/react/src/components/fields/Integer.js`
The regex was changed to remove anything that isnt a number including commas, spaces, letters and any special characters. The parsed variable was previously only used to check if input was a number, but it is now also the value passed to redux. This will remove any trailing commas and periods. 

`frontend/react/src/components/fields/Percentage.js`
The percentage field validation was also failing. I added validation that strips  anything that isnt a number including commas, spaces, letters and any special characters. I test to see that it is a number. Then we check to see if it has multiple decimals. 