### PR TITLE
Quick fix

### DIFF
--- a/frontend/react/src/store/globalVariables.js
+++ b/frontend/react/src/store/globalVariables.js
@@ -2,7 +2,7 @@
 
 const initialState = {
   formName: "CARTS FY",
-  formYear: new Date().getFullYear().toString(),
+  formYear: "2020",
   largeTextBoxHeight: 6,
   isFetching: false,
 };


### PR DESCRIPTION
As a quick fix, hard code in the formYear global variable to 2020. We will need to change this to read off the User's current form going forward. I believe we will want this to happen in formData.js but not 100% sure and we cannot have "2021" forms being certified. Things will not show properly to users if that happens.