### PR TITLE
Disable emailing in PROD

### DIFF
--- a/frontend/api_postgres/carts/carts_api/views.py
+++ b/frontend/api_postgres/carts/carts_api/views.py
@@ -1039,7 +1039,7 @@ def SendEmailStatusChange(request):
     # Disallow if not in Dev or Prod environments
     if (
         os.environ.get("ENVIRONMENT") != "dev"
-    #1/4/2021: commenting out PROD for the moment since SES service has not been fully configured so emails cannot be sent
+    # 1/4/2021: commenting out PROD for the moment since SES service has not been fully configured so emails cannot be sent
     #    and os.environ.get("ENVIRONMENT") != "prod"
     ):
         return JsonResponse(

--- a/frontend/api_postgres/carts/carts_api/views.py
+++ b/frontend/api_postgres/carts/carts_api/views.py
@@ -1039,7 +1039,8 @@ def SendEmailStatusChange(request):
     # Disallow if not in Dev or Prod environments
     if (
         os.environ.get("ENVIRONMENT") != "dev"
-        and os.environ.get("ENVIRONMENT") != "prod"
+    #1/4/2021: commenting out PROD for the moment since SES service has not been fully configured so emails cannot be sent
+    #    and os.environ.get("ENVIRONMENT") != "prod"
     ):
         return JsonResponse(
             {

--- a/frontend/api_postgres/carts/carts_api/views.py
+++ b/frontend/api_postgres/carts/carts_api/views.py
@@ -1039,8 +1039,8 @@ def SendEmailStatusChange(request):
     # Disallow if not in Dev or Prod environments
     if (
         os.environ.get("ENVIRONMENT") != "dev"
-    # 1/4/2021: commenting out PROD for the moment since SES service has not been fully configured so emails cannot be sent
-    #    and os.environ.get("ENVIRONMENT") != "prod"
+        # 1/4/2021: commenting out PROD for the moment since SES service has not been fully configured so emails cannot be sent
+        # and os.environ.get("ENVIRONMENT") != "prod"
     ):
         return JsonResponse(
             {

--- a/frontend/api_postgres/carts/carts_api/views.py
+++ b/frontend/api_postgres/carts/carts_api/views.py
@@ -1038,7 +1038,8 @@ def SendEmail(request):
 def SendEmailStatusChange(request):
     # Disallow if not in Dev or Prod environments
     if (
-        os.environ.get("ENVIRONMENT") != "dev"
+        os.environ.get("ENVIRONMENT")
+        != "dev"
         # 1/4/2021: commenting out PROD for the moment since SES service has not been fully configured so emails cannot be sent
         # and os.environ.get("ENVIRONMENT") != "prod"
     ):


### PR DESCRIPTION
At this time, SES is not set up fully, we are waiting on additional work from DevOps. As a result, we do not want PROD to send emails at this time.