### PR TITLE
Fix ACS data if user is an admin

### DIFF
--- a/frontend/react/src/components/fields/SynthesizedTable.js
+++ b/frontend/react/src/components/fields/SynthesizedTable.js
@@ -10,8 +10,10 @@ const SynthesizedTable = ({ question, rows }) => {
         {question.fieldset_info.headers && (
           <thead>
             <tr>
-              {question.fieldset_info.headers.map((header) => (
-                <th scope="col">{header.contents}</th>
+              {question.fieldset_info.headers.map((header, index) => (
+                <th scope="col" key={index}>
+                  {header.contents}
+                </th>
               ))}
             </tr>
           </thead>
@@ -20,8 +22,8 @@ const SynthesizedTable = ({ question, rows }) => {
           {rows.map((row) => {
             return (
               <tr>
-                {row.map((cell) => (
-                  <td>{cell.contents}</td>
+                {row.map((cell, index) => (
+                  <td key={index}>{cell.contents}</td>
                 ))}
               </tr>
             );

--- a/frontend/react/src/components/fields/SynthesizedTable.js
+++ b/frontend/react/src/components/fields/SynthesizedTable.js
@@ -19,9 +19,9 @@ const SynthesizedTable = ({ question, rows }) => {
           </thead>
         )}
         <tbody>
-          {rows.map((row) => {
+          {rows.map((row, index) => {
             return (
-              <tr>
+              <tr key={index}>
                 {row.map((cell, index) => (
                   <td key={index}>{cell.contents}</td>
                 ))}

--- a/frontend/react/src/util/synthesize.js
+++ b/frontend/react/src/util/synthesize.js
@@ -194,8 +194,11 @@ const lookupAcs = (state, { ffy, acsProperty }) => {
   let returnValue = "";
   // if allStatesData and stateUser are available
   if (state.allStatesData && state.stateUser) {
-    // Get stateUser state
-    const stateAbbr = state.stateUser.abbr;
+    // if admin, grab the state from the URL
+    const stateFromURL = window.location.pathname.split("/")[3];
+
+    // Get stateUser state or fallback to the URL, if an admin
+    const stateAbbr = state.stateUser.abbr || stateFromURL;
 
     // Filter for only matching state
     const stateData = state.allStatesData.filter(


### PR DESCRIPTION
Satisfies: [#4836](https://qmacbis.atlassian.net/browse/OY2-4836?atlOrigin=eyJpIjoiMTcyZWQ3NDcwZTQyNDBiNjk2MDI4MTE3ZmQ4MDc0YWQiLCJwIjoiaiJ9)

If user is an admin, ACS data was not loading. To correct this, I've added a fallback to use the State from the URL. The first check is the user data, then state from the url.

Also added keys to the header and rows; this will remove two errors from the console log.