### PR TITLE
survey array switched out for single link

### DIFF
--- a/frontend/react/src/components/layout/CertifyAndSubmit.js
+++ b/frontend/react/src/components/layout/CertifyAndSubmit.js
@@ -33,12 +33,8 @@ Submit.propTypes = { certify: PropTypes.func.isRequired };
 const Thanks = ({ done: doneDispatch, lastSave, user }) => {
   const [showAlert, setShowAlert] = useState(true);
 
-  const surveyOptions = [
-    "https://docs.google.com/forms/d/1HTOqQ4-gVw8OSRg7Whyjn-FQUoFYKWUogWeG69lR7cQ/edit?ts=5fb6f4d6&gxids=7628",
-    "https://docs.google.com/forms/d/1c8DN_GDuD4vfYBcAAGFa-JEK4b3KqcC8oYvjUjzVaZM/edit?ts=5fb6f4ed&gxids=7628",
-  ];
-  // This will randomly be assigned to the number 1 or 2
-  const oddOrEven = Math.floor(Math.random() * 10) % 2;
+  const survey =
+    "https://docs.google.com/forms/d/1HTOqQ4-gVw8OSRg7Whyjn-FQUoFYKWUogWeG69lR7cQ/edit?ts=5fb6f4d6&gxids=7628";
 
   return (
     <>
@@ -62,7 +58,7 @@ const Thanks = ({ done: doneDispatch, lastSave, user }) => {
             <p className="ds-c-alert__text">
               We would appreciate your feedback on the CARTS 2020 Redesign.
               Follow this link to participate in a brief survey
-              <a href={surveyOptions[oddOrEven]}> Google Forms</a>
+              <a href={survey}> Google Forms</a>
             </p>
             <Button
               className="hide-alert-button"


### PR DESCRIPTION
**Linked Issue:**
https://qmacbis.atlassian.net/browse/OY2-5235

**Overview:**
Instead of two survey options, users will now only have access to one. 

**Files changed (1):**
`frontend/react/src/components/layout/CertifyAndSubmit.js`
The survey linked used to be a random element in an array with two links. There is now just one survey link


