### PR TITLE
Generate new form cronjob

### DIFF
--- a/frontend/api_postgres/carts/auth.py
+++ b/frontend/api_postgres/carts/auth.py
@@ -24,7 +24,7 @@ from datetime import datetime
 class JwtAuthentication(authentication.BaseAuthentication):
     def authenticate(self, request):
         raw_token = self._extract_token(request)
-        print("+++++++++raw token: " + raw_token)
+        print("+++++++++raw token:  " + raw_token)
         try:
             return self._do_authenticate(raw_token)
         except Exception as e:

--- a/frontend/api_postgres/carts/auth.py
+++ b/frontend/api_postgres/carts/auth.py
@@ -24,7 +24,7 @@ from datetime import datetime
 class JwtAuthentication(authentication.BaseAuthentication):
     def authenticate(self, request):
         raw_token = self._extract_token(request)
-        print("+++++++++raw token:  " + raw_token)
+        print("+++++++++raw token: " + raw_token)
         try:
             return self._do_authenticate(raw_token)
         except Exception as e:

--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -98,7 +98,7 @@ resource "aws_security_group_rule" "api_postgres_egress_ecr_pull" {
 #########################################
 
 resource "aws_iam_role" "scheduled_task_cloudwatch" {
-  name = "generate_form-aws-${terraform.workspace}"
+  name = "generate_form-role-${terraform.workspace}"
 
   assume_role_policy = <<DOC
   {
@@ -118,14 +118,14 @@ resource "aws_iam_role" "scheduled_task_cloudwatch" {
 }
 
 resource "aws_cloudwatch_event_rule" "generate_form_rule" {
-  name                = "scheduled-ecs-event-rule"
-  description         = "Schedule trigger for run every day at midnight"
+  name                = "generate_form-event-rule-${terraform.workspace}"
+  description         = "Schedule trigger for Sept 15th every year"
   schedule_expression = "cron(0 0 15 9 ? *)"
   is_enabled          = true
 }
 
 resource "aws_cloudwatch_event_target" "generate_form_target" {
-  target_id = "$scheduled-ecs-target"
+  target_id = "generate_form-ecs-target-${terraform.workspace}"
   rule      = aws_cloudwatch_event_rule.scheduled_task.name
   arn       = aws_ecs_cluster.frontend.id
   role_arn  = aws_iam_role.scheduled_task_cloudwatch.arn

--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -97,7 +97,7 @@ resource "aws_security_group_rule" "api_postgres_egress_ecr_pull" {
 # CloudWatch Event Cron
 #########################################
 
-resource "aws_iam_role" "scheduled_task_cloudwatch" {
+resource "aws_iam_role" "generate_form_scheduled_task_role" {
   name = "generate_form-role-${terraform.workspace}"
 
   assume_role_policy = <<DOC


### PR DESCRIPTION
The purpose of this Pr is to create the infracture for the cron job that will be hooked up to the generate forms functionality when it is completed, This cron will have to be set to run on sept 15th of every year.

closes: https://qmacbis.atlassian.net/browse/OY2-11033

Approach:
My approach was to create a cloudwatch event for since we have carts on ecs fargate, i am able to create a ecs target which targets the postgres backend running in the same container.