### PR TITLE
OY2-10889: Enable HSTS for CARTS in containers

### DIFF
--- a/.jenkins/Jenkinsfile.dev
+++ b/.jenkins/Jenkinsfile.dev
@@ -27,7 +27,7 @@ pipeline {
           def jenkinsUtils = load ".jenkins/groovy/JenkinsUtils.groovy"
           jenkinsUtils.installAwsCli()
           jenkinsUtils.installEcsCli()
-          jenkinsUtils.installTerraform("0.12.28")
+          jenkinsUtils.installTerraform("0.13.7")
 
           if( env.BUILD_NUMBER == "1" ) {
             env.DEPLOY = true

--- a/.jenkins/Jenkinsfile.master
+++ b/.jenkins/Jenkinsfile.master
@@ -18,7 +18,7 @@ pipeline {
 
           jenkinsUtils.installAwsCli()
           jenkinsUtils.installEcsCli()
-          jenkinsUtils.installTerraform("0.12.28")
+          jenkinsUtils.installTerraform("0.13.7")
 
           env.DEPLOY_DATA = jenkinsUtils.pathHasChanges("data") || jenkinsUtils.pathHasChanges(".jenkins")
           env.DEPLOY_FRONTEND = jenkinsUtils.pathHasChanges("frontend") || env.DEPLOY_DATA

--- a/.jenkins/Jenkinsfile.prod
+++ b/.jenkins/Jenkinsfile.prod
@@ -23,7 +23,7 @@ pipeline {
 
           jenkinsUtils.installAwsCli()
           jenkinsUtils.installEcsCli()
-          jenkinsUtils.installTerraform("0.12.28")
+          jenkinsUtils.installTerraform("0.13.7")
 
           env.DEPLOY_DATA = jenkinsUtils.pathHasChanges("data") || jenkinsUtils.pathHasChanges(".jenkins")
           env.DEPLOY_FRONTEND = jenkinsUtils.pathHasChanges("frontend") || env.DEPLOY_DATA

--- a/.jenkins/Jenkinsfile.saf
+++ b/.jenkins/Jenkinsfile.saf
@@ -18,7 +18,7 @@ pipeline {
 
           jenkinsUtils.installAwsCli()
           jenkinsUtils.installEcsCli()
-          jenkinsUtils.installTerraform("0.12.28")
+          jenkinsUtils.installTerraform("0.13.7")
         }
       }
     }

--- a/frontend/aws/hsts.js
+++ b/frontend/aws/hsts.js
@@ -1,0 +1,7 @@
+function handler(event) {
+    var response = event.response;
+    var headers = response.headers;
+    headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload' };
+    return response;
+  }
+  

--- a/frontend/aws/hsts.js
+++ b/frontend/aws/hsts.js
@@ -1,7 +1,6 @@
 function handler(event) {
-    var response = event.response;
-    var headers = response.headers;
-    headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload' };
-    return response;
-  }
-  
+  var response = event.response;
+  var headers = response.headers;
+  headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload' };
+  return response;
+}

--- a/frontend/aws/hsts.js
+++ b/frontend/aws/hsts.js
@@ -1,6 +1,8 @@
 function handler(event) {
   var response = event.response;
   var headers = response.headers;
-  headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload' };
+  headers["strict-transport-security"] = {
+    value: "max-age=63072000; includeSubdomains; preload",
+  };
   return response;
 }

--- a/frontend/aws/main.tf
+++ b/frontend/aws/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
     version = "3.58.0"
-    region  = "us-east-1"
+    source  = "hashicorp/aws"
     }
 
   }
@@ -12,7 +12,9 @@ terraform {
     encrypt = true
   }
 }
-
+provider "aws" {
+  region  = "us-east-1"
+}
 provider "null" {
   version = "2.1.0"
 }

--- a/frontend/aws/main.tf
+++ b/frontend/aws/main.tf
@@ -1,9 +1,11 @@
-provider "aws" {
-  version = "3.7.0"
-  region  = "us-east-1"
-}
-
 terraform {
+  required_providers {
+    aws = {
+    version = "3.58.0"
+    region  = "us-east-1"
+    }
+
+  }
   backend "s3" {
     key     = "tf_state/application/pipeline"
     region  = "us-east-1"

--- a/frontend/aws/s3_cloudfront_ui.tf
+++ b/frontend/aws/s3_cloudfront_ui.tf
@@ -43,6 +43,13 @@ resource "aws_cloudfront_origin_access_identity" "s3_origin_access_identity" {
   comment = "carts s3 OAI"
 }
 
+resource "aws_cloudfront_function" "hsts_cloudfront_function" {
+  name    = "hsts-${terraform.workspace}"
+  runtime = "cloudfront-js-1.0"
+  comment = "This function adds headers to implement HSTS"
+  publish = true
+  code    = file("${path.module}/hsts.js")
+}
 
 resource "aws_cloudfront_distribution" "www_distribution" {
   origin {
@@ -88,6 +95,10 @@ resource "aws_cloudfront_distribution" "www_distribution" {
       cookies {
         forward = "none"
       }
+    }
+    function_association {
+      event_type   = "viewer-response"
+      function_arn = aws_cloudfront_function.hsts_cloudfront_function.arn
     }
   }
   restrictions {
@@ -233,3 +244,4 @@ resource "aws_wafv2_web_acl" "uiwaf" {
     }
   }
 }
+


### PR DESCRIPTION
Purpose:Enabled HTTP Strict Transport Security (HSTS) Policy in CARTs so that CARTS is compliant. 

Had to upgrade terraform along with the AWS provider

The AWS provider upgrade was needed to support the aws_cloudfront_function resource as well as the function_association in the default cache behavior.

The terraform upgrade was needed to support the newer AWS provider version