### PR TITLE
changing postgres terraform module a bit

### DIFF
--- a/data/aws/postgres.tf
+++ b/data/aws/postgres.tf
@@ -46,7 +46,7 @@ module "db" {
   }
   subnet_ids                      = data.aws_subnet_ids.private.ids
   family                          = "postgres12"
-  major_engine_version            = "12.7"
+  major_engine_version            = "12"
   final_snapshot_identifier       = "postgres-${terraform.workspace}"
   deletion_protection             = false
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]


### PR DESCRIPTION
this code was thoroughly tested in dev branches but there appears to possibly be a problem with the major_engine_version line in the RDS module in terraform.  I've removed the minor version and deployed cleanly to a new branch to verify this works on a clean deploy. The confusing thing is major_engine_version = 12.7 also works on a clean branch and upgrading from a 9.6 branch. Why we're seeing this in master an nowhere else is perplexing. This is an attempt to remedy that. 