### PR TITLE
New Way to Pass Custom Username and Password (Works for Both Terraform and Serverless)

### DIFF
--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -1,6 +1,6 @@
 locals {
-  postgres_password = var.postgres_custom_password == "" ? "/${terraform.workspace}/postgres_password" : var.postgres_custom_password
-  postgres_user = var.postgres_custom_user == "" ? "/${terraform.workspace}/postgres_user" : var.postgres_custom_user
+  postgres_password = var.use_custom_db_password_info ? "/${terraform.workspace}/custom_postgres_password" : "/${terraform.workspace}/postgres_password"
+  postgres_user = var.use_custom_db_user_info ? "/${terraform.workspace}/custom_postgres_username" : "/${terraform.workspace}/postgres_user"
   endpoint_api_postgres = var.acm_certificate_domain_api_postgres == "" ? "http://${aws_alb.api_postgres.dns_name}:8000" : "https://${var.acm_certificate_domain_api_postgres}"
   django_settings_module = {
     "prod" : "carts.settings"

--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -1,6 +1,6 @@
 locals {
-  postgres_password = var.use_custom_db_password_info ? "/${terraform.workspace}/custom_postgres_password" : "/${terraform.workspace}/postgres_password"
-  postgres_user = var.use_custom_db_user_info ? "/${terraform.workspace}/custom_postgres_username" : "/${terraform.workspace}/postgres_user"
+  postgres_password = var.use_custom_db_password_info ? "/${terraform.workspace}/custom/postgres_custom_password" : "/${terraform.workspace}/postgres_password"
+  postgres_user = var.use_custom_db_user_info ? "/${terraform.workspace}/custom/postgres_custom_user" : "/${terraform.workspace}/postgres_user"
   endpoint_api_postgres = var.acm_certificate_domain_api_postgres == "" ? "http://${aws_alb.api_postgres.dns_name}:8000" : "https://${var.acm_certificate_domain_api_postgres}"
   django_settings_module = {
     "prod" : "carts.settings"

--- a/frontend/aws/s3_uploads.tf
+++ b/frontend/aws/s3_uploads.tf
@@ -13,7 +13,7 @@ resource "aws_lambda_permission" "allow_bucket" {
   action        = "lambda:InvokeFunction"
   function_name = data.aws_cloudformation_stack.uploads.outputs["AvScanArn"]
   principal     = "s3.amazonaws.com"
-  source_arn    = "arn:aws:s3::${local.account_id}:${aws_s3_bucket.uploads.bucket}"
+  source_arn    = aws_s3_bucket.uploads.arn
 }
 
 resource "aws_s3_bucket_notification" "avscan" {

--- a/frontend/aws/variables.tf
+++ b/frontend/aws/variables.tf
@@ -24,9 +24,11 @@ variable "enable_log_waf_acl" {
   description = "Should logging be enabled on WAF ACL or not? Default is FALSE to not create"
   default = true
 }
-variable "postgres_custom_password" {
-  default = ""
+
+variable "use_custom_db_user_info" {
+  default = false
 }
-variable "postgres_custom_user" {
-  default = ""
+
+variable "use_custom_db_password_info" {
+  default = false
 }

--- a/serverless/services/carts-bigmac-streams/serverless.yml
+++ b/serverless/services/carts-bigmac-streams/serverless.yml
@@ -29,8 +29,8 @@ custom:
     - ${ssm:/configuration/${self:custom.stage}/vpc/subnets/private/c/id~true, ssm:/configuration/default/vpc/subnets/private/c/id~true}
   postgresHost: ${ssm:/${self:custom.stage}/postgres_host~true}
   postgresDb: ${ssm:/${self:custom.stage}/postgres_db~true}
-  postgresUser: ${ssm:/${self:custom.stage}/custom_postgres_username~true, ssm:/${self:custom.stage}/postgres_user~true}
-  postgresPassword: ${ssm:/${self:custom.stage}/custom_postgres_password~true, ssm:/${self:custom.stage}/postgres_password~true}
+  postgresUser: ${ssm:/${self:custom.stage}/custom/postgres_custom_user~true, ssm:/${self:custom.stage}/postgres_user~true}
+  postgresPassword: ${ssm:/${self:custom.stage}/custom/postgres_custom_password~true, ssm:/${self:custom.stage}/postgres_password~true}
   postgresSecurityGroupId: ${ssm:/${self:custom.stage}/postgres_security_group~true}
   scripts:
     hooks:

--- a/serverless/services/carts-bigmac-streams/serverless.yml
+++ b/serverless/services/carts-bigmac-streams/serverless.yml
@@ -29,8 +29,8 @@ custom:
     - ${ssm:/configuration/${self:custom.stage}/vpc/subnets/private/c/id~true, ssm:/configuration/default/vpc/subnets/private/c/id~true}
   postgresHost: ${ssm:/${self:custom.stage}/postgres_host~true}
   postgresDb: ${ssm:/${self:custom.stage}/postgres_db~true}
-  postgresUser: ${ssm:/${self:custom.stage}/postgres_user~true}
-  postgresPassword: ${ssm:/${self:custom.stage}/postgres_password~true}
+  postgresUser: ${ssm:/${self:custom.stage}/custom_postgres_username~true, ssm:/${self:custom.stage}/postgres_user~true}
+  postgresPassword: ${ssm:/${self:custom.stage}/custom_postgres_password~true, ssm:/${self:custom.stage}/postgres_password~true}
   postgresSecurityGroupId: ${ssm:/${self:custom.stage}/postgres_security_group~true}
   scripts:
     hooks:


### PR DESCRIPTION
The purpose of this PR is to allow for custom database login information to be passed into each environment. This was previously implemented, but there was an oversight. That being, custom credentials were not passed to serverless. This PR will fix that issue with minor changes to the way that we will be passing custom credentials. This page in the WIKI will be updated to reflect the new way of handling it.

https://github.com/CMSgov/cms-carts-seds/wiki/Password-Changes-for-the-Postgres-Database