### PR TITLE
updating jenkins file to run dev jobs on new ec2-slave 

### DIFF
--- a/.jenkins/Jenkinsfile.dev
+++ b/.jenkins/Jenkinsfile.dev
@@ -1,5 +1,5 @@
 pipeline {
-  agent { label "ec2-jnlp-slave" }
+  agent { label "ec2-slave" }
   options {
     disableConcurrentBuilds()
     quietPeriod(0)


### PR DESCRIPTION
The new ec2 slave with label ec2-slave is currently running on master jobs. This PR is to update the dev branch jenkins file with the new ec2-slave label.