### PR TITLE
change label of Jenkinsfile.prod

### DIFF
--- a/.jenkins/Jenkinsfile.prod
+++ b/.jenkins/Jenkinsfile.prod
@@ -1,5 +1,5 @@
 pipeline {
-  agent { label "ec2-jnlp-slave" }
+  agent { label "ec2-slave" }
   options {
     disableConcurrentBuilds()
     quietPeriod(0)


### PR DESCRIPTION
This will fix jenkins builds for production level environments. The issue was that it was not using the correct label in the jenkinsfile.