### PR TITLE
Temporary fix to skip the data deploy

### DIFF
--- a/.jenkins/Jenkinsfile.dev
+++ b/.jenkins/Jenkinsfile.dev
@@ -20,6 +20,7 @@ pipeline {
     OIDC_CLIENT_ID = "0oa4juv4poiQ6nDB6297"
     OIDC_ISSUER = "https://test.idp.idm.cms.gov/oauth2/aus4itu0feyg3RJTK297"
     TF_VAR_openid_discovery_url = "https://test.idp.idm.cms.gov/oauth2/aus4itu0feyg3RJTK297/.well-known/openid-configuration"
+    SKIP_DATA_LAYER = 'true'
   }
   stages {
     stage("Prep Agent") {
@@ -185,7 +186,7 @@ pipeline {
 
     stage("Deploy Data Layer") {
       when {
-        expression { env.DEPLOY == "true"}
+        expression { env.DEPLOY == "true" && env.SKIP_DATA_LAYER == "false"}
       }
       steps {
         script {

--- a/.jenkins/Jenkinsfile.master
+++ b/.jenkins/Jenkinsfile.master
@@ -7,6 +7,7 @@ pipeline {
   }
   environment {
     BUILD_TAG = resolveBuildTag()
+    SKIP_DATA_LAYER = 'true'
   }
   stages {
     stage("Prep Agent") {
@@ -81,7 +82,7 @@ pipeline {
 
     stage("Deploy Data Layer") {
       when {
-        expression { env.DEPLOY_DATA == "true" || env.FORCE_DEPLOY == "true" }
+        expression { (env.DEPLOY_DATA == "true" || env.FORCE_DEPLOY == "true") && env.SKIP_DATA_LAYER == "false" }
       }
       steps {
         script {

--- a/.jenkins/Jenkinsfile.prod
+++ b/.jenkins/Jenkinsfile.prod
@@ -5,6 +5,9 @@ pipeline {
     quietPeriod(0)
     ansiColor('xterm')
   }
+  environment {
+    SKIP_DATA_LAYER = 'true'
+  }
   parameters {
     string(
       name: 'VERSION',
@@ -69,7 +72,7 @@ pipeline {
 
     stage("Deploy Data Layer") {
       when {
-        expression { env.DEPLOY_DATA == "true" || env.FORCE_DEPLOY == "true" }
+        expression { (env.DEPLOY_DATA == "true" || env.FORCE_DEPLOY == "true") && env.SKIP_DATA_LAYER == "false"}
       }
       steps {
         script {


### PR DESCRIPTION
This will be a temporary fix while we look for the problem with options groups not being able to be deleted. For the time being I have added an environment variable (skip_data_deploy) which will skip the data deploy when set to true. It is currently being defaulted to true so unless you want to deploy the data layer no changes are required.