### PR TITLE
Fix broken json schema for backend sections

### DIFF
--- a/frontend/api_postgres/utils/section-schemas/backend-section.schema.json
+++ b/frontend/api_postgres/utils/section-schemas/backend-section.schema.json
@@ -185,14 +185,16 @@
         },
         "questions": {
           "type": "array",
-          "items": [
-            {
-              "$ref": "#/definitions/question"
-            },
-            {
-              "$ref": "#/definitions/repeatables"
-            }
-          ],
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/question"
+              },
+              {
+                "$ref": "#/definitions/repeatables"
+              }
+            ]
+          },
           "additionalItems": {
             "$ref": "#/definitions/repeatables"
           }


### PR DESCRIPTION
The generate fixtures command was not executing locally due to an syntax error in the backend-section.schema.json. This fixes that error, allowing for fixtures to be generated again.

Test Plan
========

Ran the docker-compose dev stack, and checked the output of the api_postgres service to ensure there were no more errors related to the schema validation. Additionally checked that the fixtures folder now contains the various state level fixtures.

```
cd frontend
docker-compose -f docker-compose.dev.yml up --force-recreate --build -d
docker-compose -f docker-compose.dev.yml logs api_postgres --follow
ls api_postgres/fixtures | head
```

