### PR TITLE
[MDCT-51] Patch Django

### DIFF
--- a/frontend/api_postgres/requirements.txt
+++ b/frontend/api_postgres/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.2.13
+Django==2.2.27
 gunicorn==19.9.0
 psycopg2-binary==2.8.3
 djangorestframework


### PR DESCRIPTION
https://qmacbis.atlassian.net/browse/MDCT-51

Upgrades Django from 2.2.13 to the v2 LTS, 2.2.27. 

I verified Django upgraded to new version, no dependencies broke, and everything seemed normal on my limited (no reports) local setup.