### PR TITLE
Fix smart quotes and apostrophes for prince api

### DIFF
--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -44,19 +44,11 @@ const Print = ({ currentUser, state }) => {
       .innerHTML.replaceAll(
         '<link href="',
         `<link href="https://${window.location.host}`
-      ).replaceAll(
-        `’`,
-        `'`
-      ).replaceAll(
-        `‘`,
-        `'`
-      ).replaceAll(
-        `”`,
-        `"`
-      ).replaceAll(
-        `“`,
-        `"`
-    );
+      )
+      .replaceAll(`’`, `'`)
+      .replaceAll(`‘`, `'`)
+      .replaceAll(`”`, `"`)
+      .replaceAll(`“`, `"`);
     const base64String = btoa(unescape(encodeURIComponent(htmlString)));
     // const res = await axios.post(window.env.PRINCE_API_ENDPOINT, base64String);
     const res = await axios.post("prince", {

--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -44,6 +44,18 @@ const Print = ({ currentUser, state }) => {
       .innerHTML.replaceAll(
         '<link href="',
         `<link href="https://${window.location.host}`
+      ).replaceAll(
+        `’`,
+        `'`
+      ).replaceAll(
+        `‘`,
+        `'`
+      ).replaceAll(
+        `”`,
+        `"`
+      ).replaceAll(
+        `“`,
+        `"`
       );
     const base64String = btoa(unescape(encodeURIComponent(htmlString)));
     // const res = await axios.post(window.env.PRINCE_API_ENDPOINT, base64String);

--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -56,7 +56,7 @@ const Print = ({ currentUser, state }) => {
       ).replaceAll(
         `“`,
         `"`
-      );
+    );
     const base64String = btoa(unescape(encodeURIComponent(htmlString)));
     // const res = await axios.post(window.env.PRINCE_API_ENDPOINT, base64String);
     const res = await axios.post("prince", {


### PR DESCRIPTION
# Description

Smart quotes and apostrophes (“”‘’) couldn't be parsed properly by the prince 508 compliance api. This PR replaces smart quotes and apostrophes on the string that gets encoded and sent to prince. This way we can print properly while also allowing the frontend to display quotes and apostrophes however it wants, no need to look out for them in the future.

## How to test

Create a pdf in any CARTS env and notice the improper characters "b⯑" (can also reference the [ticket](https://qmacbis.atlassian.net/browse/MDCT-103?atlOrigin=eyJpIjoiNmUwZjgyMWU1OWZjNDE0Nzg1YmM0NzI0NmM2ZDRhYWQiLCJwIjoiaiJ9))

To run locally and get a fixed pdf: 
Change into the react directory under _frontend/react_
Run the following command to create a local environment that points to the deployed dev api `API_POSTGRES_URL=https://api.mdctcartsdev.cms.gov/ ./env.sh && cp env-config.js public/`
Start react locally with `npm run start`

Then you can login and do everything from localhost:3000 (note: need to use firefox or incognito browser to get the pdf to generate properly)

Select admin and view a state's report. At the bottom select print -> entire form. On the next page click print. The popup may be blocked, click on the icon in the url bar to open it. This pdf should have fixed quotes. A few passages you can search for (see screenshots in tickets for more clear examples)

"Indicate any"
"lawfully residing"

The "b⯑" still shows up with em-dashes and hyphens. This can be added to a separate ticket.

You may notice a ["B" symbol that appears on the radio buttons](https://coforma.slack.com/archives/C03311VTN9G/p1648843658008289). This is likely unrelated and a result of running locally, not the replaces.

## Dependencies 

N/A

# Get it done

Test and let me know

## Code authors checklist
- [x] I have performed a self-review of my code
- [ ] ~I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)~
- [x] Necessary analytics were added, or no new analytics were required
- [ ] ~I have made corresponding changes to the documentation~
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)
- [x] I have done the deep review and verified the items in the above checklist are g2g
- [x] I have done the lgtm review 

## Assignee 
- [ ] I have closed the PR after the review and necessary changes (squashing preferred)