### PR TITLE
Block S3 Public Access

### DIFF
--- a/frontend/aws/s3_cloudfront_ui.tf
+++ b/frontend/aws/s3_cloudfront_ui.tf
@@ -33,6 +33,15 @@ data "aws_iam_policy_document" "s3_policy" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "uploads" {
+  bucket = aws.aws_s3_bucket.www.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_policy" "www_bucket_policy" {
   bucket = aws_s3_bucket.www.id
   policy = data.aws_iam_policy_document.s3_policy.json

--- a/frontend/aws/s3_cloudfront_ui.tf
+++ b/frontend/aws/s3_cloudfront_ui.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "s3_policy" {
 }
 
 resource "aws_s3_bucket_public_access_block" "www" {
-  bucket = aws.aws_s3_bucket.www.id
+  bucket = aws_s3_bucket.www.id
 
   block_public_acls       = true
   block_public_policy     = true

--- a/frontend/aws/s3_cloudfront_ui.tf
+++ b/frontend/aws/s3_cloudfront_ui.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "s3_policy" {
   }
 }
 
-resource "aws_s3_bucket_public_access_block" "uploads" {
+resource "aws_s3_bucket_public_access_block" "www" {
   bucket = aws.aws_s3_bucket.www.id
 
   block_public_acls       = true

--- a/frontend/aws/s3_uploads.tf
+++ b/frontend/aws/s3_uploads.tf
@@ -17,6 +17,15 @@ resource "aws_lambda_permission" "allow_bucket" {
   source_account = "730373213083"
 }
 
+resource "aws_s3_bucket_public_access_block" "uploads" {
+  bucket = aws.aws_s3_bucket.uploads.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_notification" "avscan" {
   bucket = aws_s3_bucket.uploads.id
 

--- a/frontend/aws/s3_uploads.tf
+++ b/frontend/aws/s3_uploads.tf
@@ -18,7 +18,7 @@ resource "aws_lambda_permission" "allow_bucket" {
 }
 
 resource "aws_s3_bucket_public_access_block" "uploads" {
-  bucket = aws.aws_s3_bucket.uploads.id
+  bucket = aws_s3_bucket.uploads.id
 
   block_public_acls       = true
   block_public_policy     = true


### PR DESCRIPTION
# Description

There were just a few buckets left in the old infracode for CARTS that were not setting the block against public access. The actually buckets for master, val, and prod already had been set to block public access outside the infracode, but dev branches created from the code were not setting the block for S3 public access on the uploads and www buckets. This updates the terraform to ensure that the block is set.

Addresses MDCT-81 for Carts V2.

## How to test

This was deployed to a dev environment and I confirmed in S3 that the buckets had the public access block set.

## Dependencies 

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist
- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)
- [x] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review 

## Assignee 
- [x] I have closed the PR after the review and necessary changes (squashing preferred)