### PR TITLE
Require S3 buckets be encrypted at rest and in transit

### DIFF
--- a/serverless-uploads/services/uploads/serverless.yml
+++ b/serverless-uploads/services/uploads/serverless.yml
@@ -86,7 +86,27 @@ resources:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: !Sub ${self:service.name}-${self:custom.stage}-avscan-${AWS::AccountId}
-        AccessControl: Private
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
+    ClamDefsBucketPolicy:
+      Type: "AWS::S3::BucketPolicy"
+      Properties:
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Sid: "AllowSSLRequestsOnly"
+              Effect: Deny
+              Action: "s3:*"
+              Principal: "*"
+              Resource:
+                - !Sub arn:aws:s3:::${ClamDefsBucket}/*
+                - !Sub arn:aws:s3:::${ClamDefsBucket}
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
+        Bucket: !Ref ClamDefsBucket
     BucketAVScanRole:
       Type: "AWS::IAM::Role"
       Properties:


### PR DESCRIPTION
# Description

Some of the S3 buckets created by the infracode were causing security hub findings that we need to address.

Namely

[[S3.4] S3 buckets should have server-side encryption enabled](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-4)
[[S3.5] S3 buckets should require requests to use Secure Socket Layer](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-5)

Addresses [MDCT-82](https://qmacbis.atlassian.net/browse/MDCT-82) and closes out the S3.5 findings for CARTS v2.

## How to test

I deployed this a dev environment and verified.

1) The buckets created pass the security hub finds
![image](https://user-images.githubusercontent.com/121035/161854921-ba46b6f8-c939-4f8f-a21d-12829b9cf44f.png)

2) Connecting to the cloudfront domain works find and loads the assets from the the now encrypted website bucket.

3) Cloudfront logs are logging

**We will need to validate uploads work as expected after merging**

## Dependencies 

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist
- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)
- [x] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review 

## Assignee 
- [ ] I have closed the PR after the review and necessary changes (squashing preferred)