### PR TITLE
Force destroy nonprod cloudfront logs bucket

### DIFF
--- a/frontend/aws/s3_cloudfront_ui.tf
+++ b/frontend/aws/s3_cloudfront_ui.tf
@@ -62,6 +62,8 @@ resource "aws_cloudfront_function" "hsts_cloudfront_function" {
 resource "aws_s3_bucket" "cloudfront_logs" {
   bucket = "cartscloudfrontlogs-${terraform.workspace}"
 
+  force_destroy = terraform.workspace == "prod" ? false : true
+
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {


### PR DESCRIPTION
# Description

Ensures that we can clean up the cloudfront logs bucket when tearing down development environments. Allows for forceful deletion when not in prod. Otherwise tearing down dev environments will fail without manually clearing the cloudfront logs bucket.

## How to test

None

## Dependencies 

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist
- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review 

## Assignee 
- [ ] I have closed the PR after the review and necessary changes (squashing preferred)