### PR TITLE
Enable django logging

### DIFF
--- a/frontend/api_postgres/carts/settings.py
+++ b/frontend/api_postgres/carts/settings.py
@@ -176,3 +176,24 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = "/static/"
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'WARNING',
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+            'propagate': False,
+        },
+    },
+}


### PR DESCRIPTION
# Description

Currently server errors provide no information in our logs because server logging to the console is not enabled by default when DEBUG is turned off for django. This replaces the default logger with the same configuration, but allows for output exception messages to the logs to the console. Taken from the second example at https://docs.djangoproject.com/en/4.0/topics/logging/#examples as being the default logger but on without regard to debug.

## How to test

Started up API locally and tested hitting a few endpoints to ensure that logs were still being printed.

## Dependencies 

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist
- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)
- [x] I have done the deep review and verified the items in the above checklist are g2g
- [x] I have done the lgtm review 

## Assignee 
- [x] I have closed the PR after the review and necessary changes (squashing preferred)