### PR TITLE
Match postgres minor version to prod: 12.8

### DIFF
--- a/data/aws/postgres.tf
+++ b/data/aws/postgres.tf
@@ -25,7 +25,7 @@ module "db" {
   version                 = "~> 2.0"
   identifier              = "postgres-rf-${terraform.workspace}"
   engine                  = "postgres"
-  engine_version          = "12.7"
+  engine_version          = "12.8"
   allow_major_version_upgrade = true
   instance_class          = "db.t3.small"
   parameter_group_name    = aws_db_parameter_group.db_param_group_12.id

--- a/data/docker-compose.yml
+++ b/data/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ./postgres
       dockerfile: Dockerfile
       target: postgres
-    image: postgres:12.7
+    image: postgres:12.8
     ports:
       - "5432:5432"
     networks:

--- a/data/postgres/Dockerfile
+++ b/data/postgres/Dockerfile
@@ -1,5 +1,5 @@
 # ==============================================================================
 # => psql database container
-FROM postgres:12.7 as postgres
+FROM postgres:12.8 as postgres
 
 RUN mkdir -p /app/pgdata && chown -R postgres:postgres /app

--- a/data/postgres_bootstrapper/Dockerfile
+++ b/data/postgres_bootstrapper/Dockerfile
@@ -1,6 +1,6 @@
 # ==============================================================================
 # => psql deployment container
-FROM postgres:12.7 as bootstrapper
+FROM postgres:12.8 as bootstrapper
 
 WORKDIR /app
 

--- a/data/postgres_deployer/Dockerfile
+++ b/data/postgres_deployer/Dockerfile
@@ -1,6 +1,6 @@
 # ==============================================================================
 # => psql deployment container
-FROM postgres:12.7 as deployer
+FROM postgres:12.8 as deployer
 
 WORKDIR /app
 

--- a/frontend/docker-compose.dev.yml
+++ b/frontend/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: "3.4"
 services:
   postgres:
-    image: postgres:12.7
+    image: postgres:12.8
     ports:
       - "5432:5432"
     networks:

--- a/frontend/docker-compose.local.yml
+++ b/frontend/docker-compose.local.yml
@@ -1,7 +1,7 @@
 version: "3.4"
 services:
   postgres:
-    image: postgres:12.7
+    image: postgres:12.8
     ports:
       - "5432:5432"
     networks:


### PR DESCRIPTION
# Description

Currently, staging and prod are both on version 12.8 for postgres. This alters the infracode to reflect that reality.

## How to test

<img width="681" alt="image" src="https://user-images.githubusercontent.com/121035/163053452-1951d037-2aa2-4b9d-8d80-e3b1bcb216b6.png">


## Dependencies 

Updated the related docker files to also be at the right version.

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist
- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review 

## Assignee 
- [x] I have closed the PR after the review and necessary changes (squashing preferred)