### PR TITLE
Set primary language on Prince-generated PDFs

### DIFF
--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -41,7 +41,7 @@ const Print = ({ currentUser, state }) => {
     });
     const htmlString = document
       .querySelector("html")
-      .innerHTML.replaceAll(
+      .outerHTML.replaceAll(
         '<link href="',
         `<link href="https://${window.location.host}`
       )


### PR DESCRIPTION
# Description

Closes [MDCT-152](https://qmacbis.atlassian.net/browse/MDCT-152) by grabbing the primary language of an HTML document before sending it over to the Prince API for PDF generation.

## How to test

```
cd frontend/react
nvm use 14.4.0
API_POSTGRES_URL=https://api.mdctcartsdev.cms.gov/ ./env.sh && cp env-config.js public/
npm run start
```

- `localhost:3000` in an Incognito Window
- Log into CARTS using Okta (EUA credentials)
- View a State Form
- Click **Print**
- Download as PDF
- Open file in Acrobat Reader
- "File -> Properties -> Advanced"

Should be able to see primary language is English :)

## Dependencies 

Make sure you're running `nvm v14.4.0` 

# Get it done

Prince PDFs are now more accessible!

## Code authors checklist
- [x] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)
- [x] I have done the deep review and verified the items in the above checklist are g2g
- [x] I have done the lgtm review 

## Assignee 
- [ ] I have closed the PR after the review and necessary changes (squashing preferred)