### PR TITLE
MDCT-232: Author and Subject Fields for Prince-Generated PDF (main)

### DIFF
--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -30,6 +30,7 @@
     "react-data-table-component": "^6.11.6",
     "react-data-table-component-extensions": "^1.5.0",
     "react-dom": "^16.13.1",
+    "react-helmet": "^6.1.0",
     "react-html-parser": "^2.0.2",
     "react-json-editor-ajrm": "^2.5.13",
     "react-json-editor-viewer": "^1.0.7",

--- a/services/ui-src/src/components/sections/Print.js
+++ b/services/ui-src/src/components/sections/Print.js
@@ -7,6 +7,7 @@ import PropTypes from "prop-types";
 import { loadSections } from "../../actions/initial";
 import Section from "../layout/Section";
 import axios from "../../authenticatedAxios";
+import { Helmet } from "react-helmet";
 
 // Print page
 const printWindow = (event) => {
@@ -138,7 +139,10 @@ const Print = ({ currentUser, state }) => {
           <FontAwesomeIcon icon={faPrint} /> Print
         </Button>
       </div>
-
+      <Helmet>
+        <meta name="author" content="CMS" />
+        <meta name="subject" content="Annual CARTS Report" />
+      </Helmet>
       {sections}
       <Button
         className="ds-c-button--primary ds-c-button--large print-all-btn"

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -14711,6 +14711,21 @@ react-error-overlay@6.0.9, react-error-overlay@^6.0.7:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
+react-fast-compare@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
+
 react-html-parser@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/react-html-parser/-/react-html-parser-2.0.2.tgz#6dbe1ddd2cebc1b34ca15215158021db5fc5685e"
@@ -14905,6 +14920,11 @@ react-shallow-renderer@^16.13.1:
   dependencies:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
+
+react-side-effect@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
+  integrity sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==
 
 react-test-renderer@^16.0.0-0:
   version "16.14.0"


### PR DESCRIPTION
# Description

Closes [MDCT-232](https://qmacbis.atlassian.net/browse/MDCT-232). Add Author and Subject fields to Prince-generated PDFs, same as in `master` branch. 

## How to test

Right now, we're not generating Prince PDFs in `main` but this will ensure that once we do, these fields are populating correctly. 

## Dependencies 

N/A

# Get it done

N/A

## Code authors checklist
- [x] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review 

## Assignee 
- [ ] I have closed the PR after the review and necessary changes (squashing preferred)