### PR TITLE
MDCT-155: Fix for Prince-Generated PDF "Figures Alt Text" a11y Problem

### DIFF
--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -20,24 +20,6 @@ import { Helmet } from "react-helmet";
 const Print = ({ currentUser, state }) => {
   const dispatch = useDispatch();
 
-  function removeButtonTags(htmlString) {
-    let tempHtml = htmlString;
-    let beforeButton = "";
-    let afterButton = "";
-
-    while (tempHtml.indexOf("<button") >= 0) {
-      // get the string before a <button> tag
-      beforeButton = tempHtml.substring(0, tempHtml.indexOf("<button"));
-
-      // get the string after closing </button> tag
-      afterButton = tempHtml.substring(tempHtml.indexOf("</button") + 9);
-
-      // Concatenate HTML string without <button /> tags
-      tempHtml = beforeButton + afterButton;
-    }
-    return tempHtml;
-  }
-
   const openPdf = (basePdf) => {
     let byteCharacters = atob(basePdf);
     let byteNumbers = new Array(byteCharacters.length);
@@ -58,9 +40,12 @@ const Print = ({ currentUser, state }) => {
     document.querySelectorAll("input").forEach((element) => {
       element.style.height = "50px";
     });
-    let htmlString = document.querySelector("html").outerHTML;
-    htmlString = removeButtonTags(htmlString);
-    htmlString = htmlString
+    document.querySelectorAll("button").forEach((element) => {
+      if (element.title !== "Print") {
+        element.remove();
+      }
+    });
+    const htmlString = document.querySelector("html").outerHTML
       .replaceAll('<link href="', `<link href="https://${window.location.host}`)
       .replaceAll(`’`, `'`)
       .replaceAll(`‘`, `'`)
@@ -138,7 +123,6 @@ const Print = ({ currentUser, state }) => {
       }
     }
   }
-  console.log({ sections });
 
   // Return sections with wrapper div and print dialogue box
   return (

--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -45,8 +45,12 @@ const Print = ({ currentUser, state }) => {
         element.remove();
       }
     });
-    const htmlString = document.querySelector("html").outerHTML
-      .replaceAll('<link href="', `<link href="https://${window.location.host}`)
+    const htmlString = document
+      .querySelector("html")
+      .outerHTML.replaceAll(
+        '<link href="',
+        `<link href="https://${window.location.host}`
+      )
       .replaceAll(`’`, `'`)
       .replaceAll(`‘`, `'`)
       .replaceAll(`”`, `"`)

--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -20,6 +20,24 @@ import { Helmet } from "react-helmet";
 const Print = ({ currentUser, state }) => {
   const dispatch = useDispatch();
 
+  function removeButtonTags(htmlString) {
+    let tempHtml = htmlString;
+    let beforeButton = "";
+    let afterButton = "";
+
+    while (tempHtml.indexOf("<button") >= 0) {
+      // get the string before a <button> tag
+      beforeButton = tempHtml.substring(0, tempHtml.indexOf("<button"));
+
+      // get the string after closing </button> tag
+      afterButton = tempHtml.substring(tempHtml.indexOf("</button") + 9);
+
+      // Concatenate HTML string without <button /> tags
+      tempHtml = beforeButton + afterButton;
+    }
+    return tempHtml;
+  }
+
   const openPdf = (basePdf) => {
     let byteCharacters = atob(basePdf);
     let byteNumbers = new Array(byteCharacters.length);
@@ -40,12 +58,10 @@ const Print = ({ currentUser, state }) => {
     document.querySelectorAll("input").forEach((element) => {
       element.style.height = "50px";
     });
-    const htmlString = document
-      .querySelector("html")
-      .outerHTML.replaceAll(
-        '<link href="',
-        `<link href="https://${window.location.host}`
-      )
+    let htmlString = document.querySelector("html").outerHTML;
+    htmlString = removeButtonTags(htmlString);
+    htmlString = htmlString
+      .replaceAll('<link href="', `<link href="https://${window.location.host}`)
       .replaceAll(`’`, `'`)
       .replaceAll(`‘`, `'`)
       .replaceAll(`”`, `"`)


### PR DESCRIPTION
# Description

Closes [MDCT-155](https://qmacbis.atlassian.net/browse/MDCT-155). The button icons on the Prince-generated PDFs weren't tagged properly and were causing accessibility issues. As a fix, the button itself is being parsed out of the PDF.  

## How to test

`cd frontend/react`
`nvm use 14.4.0`
`npm run start`

* Open `localhost:3000` using Incognito
* Okta Login
* View a CARTS report
* Print Entire Form

The Prince-generated PDF should have no buttons (i.e. Add Another Objective?)

## Dependencies 

N/A

# Get it done

N/A

## Code authors checklist
- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review 

## Assignee 
- [ ] I have closed the PR after the review and necessary changes (squashing preferred)