### PR TITLE
Configure frontend a11y unit testing & test coverage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ npx jest src/components --watch  # run all component tests and watch for changes
 
 ### Accessibility Tests
 
-Frontend accessibility (a11y) unit tests are being done using Jest with [axe-core](https://github.com/dequelabs/axe-core) and [jest-axe](https://github.com/nickcolley/jest-axe).
+Frontend accessibility (a11y) unit tests are being done using Jest with [axe-core](https://github.com/dequelabs/axe-core) and [jest-axe](https://github.com/nickcolley/jest-axe). To test a component's accessibility, import `axe` from `jest-axe` and pass the rendered component to `axe()`, then check for a11y issues using `toHaveNoViolations()`.
 
 To test the accessibility of an endpoint, [pa11y](https://github.com/pa11y/pa11y) is being used in combination with [aXe](https://www.axe-core.org/) and [HTML CodeSniffer](https://squizlabs.github.io/HTML_CodeSniffer/) as test runners.
 

--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -104,11 +104,19 @@
     ],
     "testEnvironment": "jsdom",
     "collectCoverageFrom": [
-      "services/ui-src/src/**/*.js",
-      "!services/ui-src/src/index.js"
+      "src/**/*.js",
+      "!src/index.js"
     ],
     "coverageReporters": [
-      "text"
+      "json",
+      [
+        "lcov",
+        {
+          "projectRoot": "../../"
+        }
+      ],
+      "text",
+      "text-summary"
     ],
     "setupFilesAfterEnv": [
       "<rootDir>/src/setupTests.js"

--- a/services/ui-src/src/components/sections/UserProfile.js
+++ b/services/ui-src/src/components/sections/UserProfile.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 
 const UserProfile = ({ currentUser }) => {
   return (
-    <div className="page-info">
+    <main className="page-info">
       <div className="ds-l-col--12 content ds-u-padding-left--4 ">
         <h1>User Profile</h1>
         <div className="main">
@@ -32,7 +32,7 @@ const UserProfile = ({ currentUser }) => {
           </div>
         </div>
       </div>
-    </div>
+    </main>
   );
 };
 

--- a/services/ui-src/src/components/sections/UserProfile.js
+++ b/services/ui-src/src/components/sections/UserProfile.js
@@ -4,10 +4,12 @@ import PropTypes from "prop-types";
 
 const UserProfile = ({ currentUser }) => {
   return (
-    <main className="page-info">
+    <div className="page-info">
       <div className="ds-l-col--12 content ds-u-padding-left--4 ">
-        <h1>User Profile</h1>
-        <div className="main">
+        <header>
+          <h1>User Profile</h1>
+        </header>
+        <main className="main">
           If any information is incorrect, please contact the{" "}
           <a href="mailto:mdct_help@cms.hhs.gov">mdct_help@cms.hhs.gov</a>.
           <div className="profile-information">
@@ -30,9 +32,9 @@ const UserProfile = ({ currentUser }) => {
               <div>{currentUser.role}</div>
             </div>
           </div>
-        </div>
+        </main>
       </div>
-    </main>
+    </div>
   );
 };
 

--- a/services/ui-src/src/components/sections/UserProfile.test.js
+++ b/services/ui-src/src/components/sections/UserProfile.test.js
@@ -1,11 +1,26 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
+import { render } from "@testing-library/react";
+import { axe } from "jest-axe";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
 import UserProfile from "./UserProfile";
 
 const mockStore = configureMockStore();
-const store = mockStore({});
+const store = mockStore({
+  stateUser: {
+    currentUser: {
+      email: "",
+      username: "",
+      firstname: "",
+      lastname: "",
+      role: "",
+      state: {
+        id: "",
+      },
+    },
+  },
+});
 
 const userProfile = (
   <Provider store={store}>
@@ -16,5 +31,13 @@ const userProfile = (
 describe("UserProfile", () => {
   it("should render the UserProfile Component correctly", () => {
     expect(shallow(userProfile).exists()).toBe(true);
+  });
+});
+
+describe("Test UserProfile accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    const wrapper = mount(userProfile);
+    const results = await axe(wrapper.html());
+    expect(results).toHaveNoViolations();
   });
 });

--- a/services/ui-src/src/components/sections/UserProfile.test.js
+++ b/services/ui-src/src/components/sections/UserProfile.test.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { mount, shallow } from "enzyme";
-import { render } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";

--- a/services/ui-src/src/setupTests.js
+++ b/services/ui-src/src/setupTests.js
@@ -4,7 +4,8 @@
  * expect(element).toHaveTextContent(/react/i)
  * learn more: https://github.com/testing-library/jest-dom
  */
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
+import "jest-axe/extend-expect";
 
 import { configure } from "enzyme";
 


### PR DESCRIPTION
# Description
Added a sample unit test that utilizes `jest-axe` to check for basic accessibility issues. Also configured coverage reporting. This PR shows how to do it on the only current substantive unit test file and can be used as an example/template for a11y testing of future frontend components. 💛 

## How to test
1. `cd services/ui-src`
2. To view coverage report, run `yarn coverage`
3. To run all tests, run `yarn test`
4. To run just the one changed test, run `yarn test -t UserProfile`

Note: You can test a11y failure by adding a simple error to `UserProfile`.

## Dependencies 
No changed deps.

# Get it done

## Code authors checklist
- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] ~~Necessary analytics were added, or no new analytics were required~~
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)
- [x] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review 

## Assignee 
- [ ] I have closed the PR after the review and necessary changes (squashing preferred)