### PR TITLE
Db snapshot

### DIFF
--- a/data/aws/postgres.tf
+++ b/data/aws/postgres.tf
@@ -49,7 +49,7 @@ module "db" {
   family                          = "postgres12"
   major_engine_version            = "12"
   final_snapshot_identifier       = terraform.workspace == "prod" || terraform.workspace == "master" || terraform.workspace == "staging" ? "postgres-${terraform.workspace}" : "false"
-  deletion_protection             = local.is_legacy_account && (terraform.workspace == "prod" || terraform.workspace == "master" || terraform.workspace == "staging")  ? "true" : "false"
+  deletion_protection             = terraform.workspace == "prod" || terraform.workspace == "master" || terraform.workspace == "staging"  ? "true" : "false"
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
 }
 

--- a/data/aws/postgres.tf
+++ b/data/aws/postgres.tf
@@ -49,7 +49,7 @@ module "db" {
   family                          = "postgres12"
   major_engine_version            = "12"
   final_snapshot_identifier       = terraform.workspace == "prod" || terraform.workspace == "master" || terraform.workspace == "staging" ? "postgres-${terraform.workspace}" : "false"
-  deletion_protection             = !local.is_legacy_account && (terraform.workspace == "prod" || terraform.workspace == "master" || terraform.workspace == "staging")  ? "true" : "false"
+  deletion_protection             = local.is_legacy_account && (terraform.workspace == "prod" || terraform.workspace == "master" || terraform.workspace == "staging")  ? "true" : "false"
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
 }
 

--- a/data/aws/postgres.tf
+++ b/data/aws/postgres.tf
@@ -22,6 +22,7 @@ locals {
 
 data "aws_db_snapshot" "db_snapshot" {
     most_recent = true
+    db_snapshot_identifier = "postgres-rf-prod"
 }
 module "db" {
   source                      = "terraform-aws-modules/rds/aws"

--- a/data/aws/postgres.tf
+++ b/data/aws/postgres.tf
@@ -20,6 +20,9 @@ locals {
   }
 }
 
+data "aws_db_snapshot" "db_snapshot" {
+    most_recent = true
+}
 module "db" {
   source                      = "terraform-aws-modules/rds/aws"
   version                     = "~> 2.0"
@@ -42,6 +45,10 @@ module "db" {
   backup_window               = "03:00-06:00"
   skip_final_snapshot         = terraform.workspace == "prod" || terraform.workspace == "master" || terraform.workspace == "staging" ? "false" : "true"
   backup_retention_period     = terraform.workspace == "prod" ? 21 : 0
+  snapshot_identifier = data.aws_db_snapshot.db_snapshot.id
+  lifecycle {
+    ignore_changes = [snapshot_identifier]
+  }
   tags = {
     Environment = terraform.workspace
   }

--- a/data/aws/variables.tf
+++ b/data/aws/variables.tf
@@ -15,6 +15,8 @@ variable "skip_data_deployment" {
   default = false
 }
 
-variable "new_env_snapshot_id" {
-  default = "postgres-rf-master-dev-migration-test"
+variable "postgres_restore_snapshot_id" {
+  default     = null
+  type        = string
+  description = "The PostgreSQL database snapshot used to restore or recreate the database"
 }

--- a/data/aws/variables.tf
+++ b/data/aws/variables.tf
@@ -14,3 +14,7 @@ variable "postgres_db" {
 variable "skip_data_deployment" {
   default = false
 }
+
+variable "new_env_snapshot_id" {
+  default = "postgres-rf-master-dev-migration-test"
+}


### PR DESCRIPTION
# Description

Added a snapshot identifier attribute so that we can create the DB in the new AWS env from a snapshot.
- The attribute will only apply in the new account
- The attribute can be removed after the initial creation with no change to the DB ([Terraform changelog](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#3320-march-12-2021), [Specific terraform pr](https://github.com/hashicorp/terraform-provider-aws/pull/18013/files))
- The snapshot id is passed as a variable since we will make use of it only once

Also put deletion protection (update in place, no interruption) on the db for the existing environment and the new environment

## How to test

- `brew install tfenv` (if you've already installed terraform with homebrew you may need to run `brew unlink terraform` for this to work. No need to relink after -> tfenv handles it all)
- `tfenv install 1.0.11`
- `tfenv use 1.0.11`
- `cd data/aws`
- export AWS credentials for mdct-carts-dev
- `terraform init` when it prompts for the s3 bucket name use `carts-seds-dev-terraform-state`
- `terraform workspace list`
- `terraform workspace new {name}` (name just needs to be unique in case multiple people are trying this (although there could be other issues like snapshot availability and resource overlap 🤔 (but that would only matter if you actually apply it, not just plan(which is kinda what the test is going for but nbd if you just plan(planning is good(I used to be someone who planned a lot(lately I just wing it(not sure what happened but I actually think it suits me better(I worry a lot less this way)))))))))
- `terraform workspace select {name}`
- `terraform plan -var application_version=dev-iampath -var vpc_name=mdct-carts-east-dev -var postgres_restore_snapshot_id=postgres-rf-master-dev-migration-test` (the vars here will be different depending on the AWS environment. These are for mdct-carts-dev regardless of workspace)
- IF YOU WISH TO CREATE RESOURCES FOR _THE REAL TEST_ ™️ 
- `terraform apply -var application_version=dev-iampath -var vpc_name=mdct-carts-east-dev -var postgres_restore_snapshot_id=postgres-rf-master-dev-migration-test` (this'll take 10-20 minutes for the DB)
- Once above completes, go to postgres.tf and comment out the snapshot_identifier line
- `terraform plan -var application_version=dev-iampath -var vpc_name=mdct-carts-east-dev -var postgres_restore_snapshot_id=postgres-rf-master-dev-migration-test` If this tells you that there are no changes, then we are good :)

Once you're finished you should remove the resources with this command
- `terraform destroy -var application_version=dev-iampath -var vpc_name=mdct-carts-east-dev -var postgres_restore_snapshot_id=postgres-rf-master-dev-migration-test`

Want to dive deeper? You can ***just run plan*** against the existing AWS env (if you use the read-only credentials that should also ensure you don't change anything)

- export AWS credentials for MACPro
- `rm -rf .terraform`
- `terraform init` (s3 bucket name is `carts-seds-application-state`)
- `terraform workspace list`
- `terraform workspace select master`
- `terraform plan -var application_version=master -var vpc_name=macpro-dev`

Make sure db only has deletion-protection update with no recreate!

Wow 😮 ! Wasn't that fun?!

Reach out for help at any time! Especially if you are unsure about what you are creating! You can bug Brandon too :) 


## Dependencies 

tfenv, as listed in instructions

## Code authors checklist
- [x] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review 

## Assignee 
- [ ] I have closed the PR after the review and necessary changes (squashing preferred)