### PR TITLE
MDCT-237 - Program Type Fix & Text Disable

### DIFF
--- a/frontend/react/src/components/fields/Text.js
+++ b/frontend/react/src/components/fields/Text.js
@@ -80,7 +80,7 @@ const Text = ({ question, state, ...props }) => {
 
     getPrevYearValue().then();
   }, [state]);
-
+  console.log(props)
   return (
     <>
       <div className="print-helper">{ReactHtmlParser(printValue)}</div>
@@ -92,7 +92,7 @@ const Text = ({ question, state, ...props }) => {
         label=""
         onBlur={updatePrintHelper}
         {...props}
-        disabled={prevYearDisabled}
+        disabled={prevYearDisabled || !!props.disabled}
       />
     </>
   );
@@ -100,6 +100,7 @@ const Text = ({ question, state, ...props }) => {
 Text.propTypes = {
   question: PropTypes.object.isRequired,
   state: PropTypes.string.isRequired,
+  disabled: PropTypes.bool
 };
 
 const mapState = (state) => ({

--- a/frontend/react/src/components/fields/Text.js
+++ b/frontend/react/src/components/fields/Text.js
@@ -99,7 +99,7 @@ const Text = ({ question, state, ...props }) => {
 Text.propTypes = {
   question: PropTypes.object.isRequired,
   state: PropTypes.string.isRequired,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
 };
 
 const mapState = (state) => ({

--- a/frontend/react/src/components/fields/Text.js
+++ b/frontend/react/src/components/fields/Text.js
@@ -80,7 +80,6 @@ const Text = ({ question, state, ...props }) => {
 
     getPrevYearValue().then();
   }, [state]);
-  console.log(props)
   return (
     <>
       <div className="print-helper">{ReactHtmlParser(printValue)}</div>

--- a/frontend/react/src/store/formData.js
+++ b/frontend/react/src/store/formData.js
@@ -26,11 +26,17 @@ export default (state = initialState, action) => {
       updatedData = action.data.sort(sortByOrdinal);
       if (action.lastYearData) {
         let lastYearData = action.lastYearData.data.sort(sortByOrdinal);
-        if (!updatedData[0].contents.section.subsections[0].parts[0].questions[0].answer.entry) {
+        if (
+          !updatedData[0].contents.section.subsections[0].parts[0].questions[0]
+            .answer.entry
+        ) {
           updatedData[0].contents.section.subsections[0].parts[0].questions[0] =
             lastYearData[0].contents.section.subsections[0].parts[0].questions[0]; // Name
         }
-        if (!updatedData[0].contents.section.subsections[0].parts[0].questions[1].answer.entry) {
+        if (
+          !updatedData[0].contents.section.subsections[0].parts[0].questions[1]
+            .answer.entry
+        ) {
           updatedData[0].contents.section.subsections[0].parts[0].questions[1] =
             lastYearData[0].contents.section.subsections[0].parts[0].questions[1]; // Type
         }

--- a/frontend/react/src/store/formData.js
+++ b/frontend/react/src/store/formData.js
@@ -26,14 +26,19 @@ export default (state = initialState, action) => {
       updatedData = action.data.sort(sortByOrdinal);
       if (action.lastYearData) {
         let lastYearData = action.lastYearData.data.sort(sortByOrdinal);
-        updatedData[0].contents.section.subsections[0].parts[0].questions[0] =
-          lastYearData[0].contents.section.subsections[0].parts[0].questions[0];
-        updatedData[0].contents.section.subsections[0].parts[0].questions[1] =
-          lastYearData[0].contents.section.subsections[0].parts[0].questions[1];
+        if (!updatedData[0].contents.section.subsections[0].parts[0].questions[0].answer.entry) {
+          updatedData[0].contents.section.subsections[0].parts[0].questions[0] =
+            lastYearData[0].contents.section.subsections[0].parts[0].questions[0]; // Name
+        }
+        if (!updatedData[0].contents.section.subsections[0].parts[0].questions[1].answer.entry) {
+          updatedData[0].contents.section.subsections[0].parts[0].questions[1] =
+            lastYearData[0].contents.section.subsections[0].parts[0].questions[1]; // Type
+        }
+        // TODO: Cohort Questions - These should be revolving around a 2 year cycle, but today just pull forward
         updatedData[3].contents.section.subsections[2].parts[5].questions[1].answer =
-          lastYearData[3].contents.section.subsections[2].parts[5].questions[1].answer;
+          lastYearData[3].contents.section.subsections[2].parts[5].questions[1].answer; // How does your state define “newly enrolled” for this cohort?
         updatedData[3].contents.section.subsections[2].parts[5].questions[2].answer =
-          lastYearData[3].contents.section.subsections[2].parts[5].questions[2].answer;
+          lastYearData[3].contents.section.subsections[2].parts[5].questions[2].answer; // Do you have data for individual age groups?
 
         // Added mid year as a quick fix for 2021 forms see: https://qmacbis.atlassian.net/browse/OY2-12744 Should be removed ASAP!!
         updatedData[2].contents.section.subsections[0].parts[1].text =


### PR DESCRIPTION
# Description

Program type and state name should pull through from the previous year only if they don't already exist.

Additionally the text component never respects the readonly flag, despite it being provided on a number of questions. Pass readonly through.

This has the additional effect of blocking admins from attempting to overwrite those fields, the wiring was already present.

Will verify in the am that this is ok. If anyone knows why readonly wasn't passed into the text components, reject this PR and let me know.

## How to test

Pull it down, in the DB, modify values in the 2020 and 2021 reports for a state section 0, question 1 & 2. See how they behave.

Check out the admin readonly functionality. It was just for the TextField, there are other components still not respecting it.

## Dependencies 

None

# Get it done

When this is wrapped we can deploy the KS data fixes and call it done.

## Code authors checklist
- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review 

## Assignee 
- [ ] I have closed the PR after the review and necessary changes (squashing preferred)