### PR TITLE
MDCT-237 - duplicate the changes going to master for readonly

### DIFF
--- a/services/ui-src/src/components/fields/Text.js
+++ b/services/ui-src/src/components/fields/Text.js
@@ -100,6 +100,7 @@ const Text = ({ question, state, ...props }) => {
 Text.propTypes = {
   question: PropTypes.object.isRequired,
   state: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
 };
 
 const mapState = (state) => ({

--- a/services/ui-src/src/components/fields/Text.js
+++ b/services/ui-src/src/components/fields/Text.js
@@ -92,7 +92,7 @@ const Text = ({ question, state, ...props }) => {
         label=""
         onBlur={updatePrintHelper}
         {...props}
-        disabled={prevYearDisabled}
+        disabled={prevYearDisabled || !!props.disabled}
       />
     </>
   );

--- a/services/ui-src/src/store/formData.js
+++ b/services/ui-src/src/store/formData.js
@@ -26,15 +26,25 @@ export default (state = initialState, action) => {
       updatedData = action.data.sort(sortByOrdinal);
       if (action.lastYearData) {
         let lastYearData = action.lastYearData.data.sort(sortByOrdinal);
-        updatedData[0].contents.section.subsections[0].parts[0].questions[0] =
-          lastYearData[0].contents.section.subsections[0].parts[0].questions[0];
-        updatedData[0].contents.section.subsections[0].parts[0].questions[1] =
-          lastYearData[0].contents.section.subsections[0].parts[0].questions[1];
+        if (
+          !updatedData[0].contents.section.subsections[0].parts[0].questions[0]
+            .answer.entry
+        ) {
+          updatedData[0].contents.section.subsections[0].parts[0].questions[0] =
+            lastYearData[0].contents.section.subsections[0].parts[0].questions[0]; // Name
+        }
+        if (
+          !updatedData[0].contents.section.subsections[0].parts[0].questions[1]
+            .answer.entry
+        ) {
+          updatedData[0].contents.section.subsections[0].parts[0].questions[1] =
+            lastYearData[0].contents.section.subsections[0].parts[0].questions[1]; // Type
+        }
+        // TODO: Cohort Questions - These should be revolving around a 2 year cycle, but today just pull forward
         updatedData[3].contents.section.subsections[2].parts[5].questions[1].answer =
-          lastYearData[3].contents.section.subsections[2].parts[5].questions[1].answer;
+          lastYearData[3].contents.section.subsections[2].parts[5].questions[1].answer; // How does your state define “newly enrolled” for this cohort?
         updatedData[3].contents.section.subsections[2].parts[5].questions[2].answer =
-          lastYearData[3].contents.section.subsections[2].parts[5].questions[2].answer;
-
+          lastYearData[3].contents.section.subsections[2].parts[5].questions[2].answer; // Do you have data for individual age groups?
         // Added mid year as a quick fix for 2021 forms see: https://qmacbis.atlassian.net/browse/OY2-12744 Should be removed ASAP!!
         updatedData[2].contents.section.subsections[0].parts[1].text =
           "This table is pre-filled with data on uninsured children (age 18 and under) who are below 200% of the Federal Poverty Level (FPL) based on annual estimates from the American Community Survey. Due to the impacts of the COVID-19 PHE on collection of ACS data, the 2020 children's uninsurance rates are currently unavailable. Please skip to Question 3.";


### PR DESCRIPTION
# Description

The same readonly fix for the ui that just went into master, duplicating it here.

## How to test

This has been tested on the other branch, but if you feel it is necessary, the State Name field should always see readonly, and non-state users see text fields as readonly.

Additionally it does not override with previous year data if data exists (but this is not able to happen in v3 just yet).

## Dependencies 

None

# Get it done

Give me approvals

## Code authors checklist
- [x] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [x] I have done the lgtm review 

## Assignee 
- [ ] I have closed the PR after the review and necessary changes (squashing preferred)