### PR TITLE
Run destroy script in same context as workflow

### DIFF
--- a/.github/workflows/dev-destroy.yml
+++ b/.github/workflows/dev-destroy.yml
@@ -59,4 +59,4 @@ jobs:
       - name: Destroy serverless
         run: |
           cd serverless
-          sudo ./destroy.sh ${{env.BRANCH_NAME}}
+          ./destroy.sh ${{env.BRANCH_NAME}}


### PR DESCRIPTION
# Description

Removes `sudo` command that was causing issues cleaning up serverless stacks

## How to test

When this merges, destroy should successfully run.

## Dependencies

None.

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
