### PR TITLE
Fix parameter order for startsWith

### DIFF
--- a/.github/workflows/dev-destroy.yml
+++ b/.github/workflows/dev-destroy.yml
@@ -10,7 +10,7 @@ jobs:
     # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
     # This is a list of branch names that are commonly used for protected branches/environments.
     # Add/remove names from this list as appropriate.
-    if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "staging", "production", "prod"]'), github.event.ref) && startsWith('refs/heads/dev-', github.event.ref)
+    if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "staging", "production", "prod"]'), github.event.ref) && startsWith(github.event.ref,'dev-')
     runs-on: ubuntu-latest
     steps:
       - name: set branch_name


### PR DESCRIPTION
# Description

Update parameter order for startsWith to match https://docs.github.com/en/actions/learn-github-actions/expressions#startswith

## How to test

Needs to be tested after merge.

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
