### PR TITLE
MDCT-188: Em-dashes and En-dashes to Hyphens (Prince PDF)

### DIFF
--- a/frontend/react/src/components/sections/Print.js
+++ b/frontend/react/src/components/sections/Print.js
@@ -62,7 +62,9 @@ const Print = ({ currentUser, state, name }) => {
       .replaceAll(`’`, `'`)
       .replaceAll(`‘`, `'`)
       .replaceAll(`”`, `"`)
-      .replaceAll(`“`, `"`);
+      .replaceAll(`“`, `"`)
+      .replaceAll("\u2013", "-")
+      .replaceAll("\u2014", "-");
     const base64String = btoa(unescape(encodeURIComponent(htmlString)));
     const res = await axios.post("prince", {
       encodedHtml: base64String,


### PR DESCRIPTION
# Description

Closes [MDCT-188](https://qmacbis.atlassian.net/browse/MDCT-188). The em-dashes (—) and en-dashes (–) are being replaced with hyphens (-) throughout the Prince-generated PDF to avoid issues with parsing the characters.

## How to test

`cd frontend/react`
`nvm use 14.4.0`
`npm run start`

In an **Incognito** browser window, view a report and print "Entire Form". There should be no strange characters, em-dashes, or en-dashes.

## Dependencies

N/A

# Get it done

N/A

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
