### PR TITLE
MDCT-73 remove accepted and published status from filter

### DIFF
--- a/frontend/react/src/components/sections/homepage/CMSHomepage.js
+++ b/frontend/react/src/components/sections/homepage/CMSHomepage.js
@@ -15,11 +15,9 @@ const CMSHomepage = ({
   yearList,
 }) => {
   const statusList = [
-    { label: "Accepted", value: "accepted" },
     { label: "Certified", value: "certified" },
     { label: "In progress", value: "in_progress" },
     { label: "Not started", value: "not_started" },
-    { label: "Published", value: "published" },
   ];
 
   // using state below allows the user to keep both of the other filters working properly when they "remove" from a different drop down


### PR DESCRIPTION
# Description

Closes [MDCT-73](https://qmacbis.atlassian.net/browse/MDCT-73?atlOrigin=eyJpIjoiOTk5M2YyZjU0ODdjNGEzMWEzNWQ0ZTZmNTM2NDczODAiLCJwIjoiaiJ9) - Removed 'accepted' and 'published' options from filter. These options show up elsewhere in the codebase though I left them for now since they seem to be used in other places and I don't want to disrupt existing work. Ex: [selectors.js](https://github.com/CMSgov/cms-carts-seds/blob/master/frontend/react/src/store/selectors.js#L167). If you think these or others can safely be removed, let me know and I'll expand the scope.

## How to test

- checkout branch
- `cd frontend/react`
- `nvm use`
- `npm run start`

Navigate to localhost:3000, login, verify those two statuses don't appear in the status dropdown

Alternatively startup the dockerized version and verify it with all user types (other than state)

## Dependencies

2 minutes of your time

# Get it done

Crush the ticket and slam dunk it

## Code authors checklist

- [x] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [x] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
