### PR TITLE
Fix Frontend Python Startup

### DIFF
--- a/frontend/api_postgres/Dockerfile
+++ b/frontend/api_postgres/Dockerfile
@@ -74,5 +74,8 @@ RUN chown -R app:app $APP_HOME
 # change to the app user
 USER app
 
+RUN python utils/section-schemas/generate_fixtures.py
+RUN python utils/section-schemas/compare_fixtures.py
+
 # run entrypoint.sh
 ENTRYPOINT ["/home/app/web/entrypoint.sh"]

--- a/frontend/api_postgres/Dockerfile.dev
+++ b/frontend/api_postgres/Dockerfile.dev
@@ -32,5 +32,8 @@ RUN pip install pdfkit --no-cache
 # copy project
 COPY . /usr/src/app/
 
+RUN python utils/section-schemas/generate_fixtures.py
+RUN python utils/section-schemas/compare_fixtures.py
+
 # run entrypoint.sh
 ENTRYPOINT ["/usr/src/app/entrypoint.sh"]

--- a/frontend/api_postgres/Dockerfile.local
+++ b/frontend/api_postgres/Dockerfile.local
@@ -32,5 +32,8 @@ RUN pip install pdfkit --no-cache
 # copy project
 COPY . /usr/src/app/
 
+RUN python utils/section-schemas/generate_fixtures.py
+RUN python utils/section-schemas/compare_fixtures.py
+
 # run entrypoint.sh
 ENTRYPOINT ["/usr/src/app/entrypoint_local.sh"]

--- a/frontend/api_postgres/entrypoint.sh
+++ b/frontend/api_postgres/entrypoint.sh
@@ -11,8 +11,6 @@ then
     echo "PostgreSQL started"
 fi
 
-python utils/section-schemas/generate_fixtures.py
-python utils/section-schemas/compare_fixtures.py
 python manage.py makemigrations && python manage.py migrate && python manage.py idempotent_fixtures && python manage.py add_state_permissions
 #python manage.py load_formtemplates
 python manage.py setup_trigger

--- a/frontend/api_postgres/entrypoint_local.sh
+++ b/frontend/api_postgres/entrypoint_local.sh
@@ -11,8 +11,6 @@ then
     echo "PostgreSQL started"
 fi
 
-python utils/section-schemas/generate_fixtures.py
-python utils/section-schemas/compare_fixtures.py
 python manage.py makemigrations && python manage.py migrate && python manage.py idempotent_fixtures --overwrite && python manage.py add_state_permissions
 python manage.py load_formtemplates
 python manage.py setup_trigger

--- a/frontend/api_postgres/requirements.txt
+++ b/frontend/api_postgres/requirements.txt
@@ -6,7 +6,7 @@ markdown
 django-json-widget
 django-filter
 django-cors-headers
-jsonschema
+jsonschema==4.4.0
 jsonpath_ng
 python_jwt
 pytest-django


### PR DESCRIPTION
# Description

This PR addresses two issues currently affecting new builds.

1. jsonschema 4.5.0 is causing infinite loops during schema validation. Pinning to jsonschema 4.4.0.
2. Because of the above infinite loop start ups where never finishing for new frontend deployments. We had been generating the fixture files on startup, but these files are static for a given build and thus can be generated at build time. This removes some of the start up time for the frontend service.

## How to test

If this branch deploys, it works.

## Dependencies

jsonschema pinned to 4.4.0

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
