### PR TITLE
Pin django-cors-headers to 3.11.0

### DIFF
--- a/frontend/api_postgres/requirements.txt
+++ b/frontend/api_postgres/requirements.txt
@@ -5,7 +5,7 @@ djangorestframework
 markdown
 django-json-widget
 django-filter
-django-cors-headers
+django-cors-headers==3.11.0
 jsonschema==4.4.0
 jsonpath_ng
 python_jwt


### PR DESCRIPTION
# Description

django-cors-headers 3.12.0 dropped support for django 2.2. As we are in the process of rewriting the backend and will not be updating django, we will need to pin this library to it's prior version to fix builds.

## How to test

Building the postgres django container should pass.

```
cd frontend/api_postgres
docker build .
```

## Dependencies

Pin django-cors-headers to 3.11.0

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
