### PR TITLE
Unable to view Report As Admin

### DIFF
--- a/services/ui-src/src/components/Utils/InvokeSection.js
+++ b/services/ui-src/src/components/Utils/InvokeSection.js
@@ -10,15 +10,15 @@ const InvokeSection = (username) => {
   const { state, year, sectionOrdinal, subsectionMarker } = useParams();
   const dispatch = useDispatch();
   const currentPath = window.location.href;
-  if (currentPath.includes("views")) {
-    const stateInitials = window.location.href.toString().split("/")[5];
-    const linkYear = window.location.href.toString().split("/")[6];
-    dispatch(updateStateName(stateInitials));
-    dispatch(updateFormYear(linkYear));
-  }
 
   useEffect(() => {
     if (username) {
+      if (currentPath.includes("views")) {
+        const stateInitials = window.location.href.toString().split("/")[5];
+        const linkYear = window.location.href.toString().split("/")[6];
+        dispatch(updateStateName(stateInitials));
+        dispatch(updateFormYear(linkYear));
+      }
       dispatch(loadForm(state));
     }
   }, [username]);


### PR DESCRIPTION
# Description

I was receiving the following error when attempting to open a report as an admin user:

```
Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
```

Moving all `dispatch` calls to `useEffect()` resolved the error for me locally.

## How to test

Confirm you can click into a report when logged in as an admin user.

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
