### PR TITLE
Allow pulling Kafka Connect image from ECR

### DIFF
--- a/serverless/services/carts-bigmac-streams/serverless.yml
+++ b/serverless/services/carts-bigmac-streams/serverless.yml
@@ -25,6 +25,7 @@ provider:
 custom:
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
+  kafkaConnectImage: ${ssm:/configuration/${self:custom.stage}/kafka_connect_image~true, ssm:/configuration/default/kafka_connect_image~true,"confluentinc/cp-kafka-connect:6.2.0"}
   bootstrapBrokerStringTls: ${ssm:/configuration/${self:custom.stage}/bigmac/bootstrapBrokerStringTls~true, ssm:/configuration/default/bigmac/bootstrapBrokerStringTls~true}
   vpcId: ${ssm:/configuration/${self:custom.stage}/vpc/id~true, ssm:/configuration/default/vpc/id~true}
   privateSubnets:
@@ -149,7 +150,7 @@ resources:
       Properties:
         ContainerDefinitions:
           - Name: ${self:service}-${self:custom.stage}-worker
-            Image: "confluentinc/cp-kafka-connect:6.2.0"
+            Image: ${self:custom.kafkaConnectImage}
             Memory: 4096
             Cpu: 2048
             Command:


### PR DESCRIPTION
# Description

With the recent kafka issues, our dev branches had been restarting the kafka-connect service over and over again. Since the image for this service is pulled from docker hub, this would lead to us being unable to start a new kafka-connect task because we would exceed the 100 pulls per 6 hours rate limit that is applied to unauthenticated pulls from docker hub.

This PR allows us to set an alternative source for the image using SSM and pull from there instead. I have already pushed the current 6.2.0 image to our own private ECR repository and have the SSM parameter set to pull from that ECR repository instead.

Note: The serverless job is currently having an issue due to a rolling upgrade underway right now for kafka. Will rerun it once that is finished.

## How to test

The `kafka-connect` service pulls the image from our own ecr repository.

<img width="533" alt="image" src="https://user-images.githubusercontent.com/121035/167898760-16072bf5-d406-4a69-8ed5-f9e715dd5681.png">

## Dependencies

Changing docker registry used for kafka connect image, same image though.

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
