### PR TITLE
Connect frontend and data layers across AWS accounts

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -200,8 +200,8 @@ jobs:
       - name: Deploy Data Layer
         run: ./data_layer_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}}
         env:
-          VPC_NAME: env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && ${{secrets.NEW_DEV_VPC}} || ${{secrets.DEV_VPC_NAME}}
-          APPLICATION_BUCKET: env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && ${{secrets.NEW_APPLICATION_BUCKET}} || ${{secrets.APPLICATION_BUCKET}}
+          VPC_NAME: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_DEV_VPC || secrets.DEV_VPC_NAME}}
+          APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
   frontend:
     needs:
       - prevalidate

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - "dev-*"
 
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
 concurrency:
   group: dev-${{ github.ref_name }}
   cancel-in-progress: false

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -197,7 +197,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Configure AWS credentials
+      - name: Configure datalayer AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure Terraform Datalayer Provider Credentials
+        run: |
+          echo "TF_VAR_datalayer_aws_access_key=${{env.AWS_ACCESS_KEY_ID}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_secret_key=${{env.AWS_SECRET_ACCESS_KEY}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_session_token=${{env.AWS_SESSION_TOKEN}}" >> $GITHUB_ENV
+      - name: Configure frontend AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -19,7 +19,7 @@ env:
   BUILD_TAG: ${{ github.ref_name }}.${{ github.sha }}
   ECR_REPOSITORY_POSTGRESS_DEPLOYER: "postgres_deployer"
   ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
-  DATALAYER_IN_NEW_ACCOUNTS: ${{ secrets.DEV_DATALAYER_IN_NEW_ACCOUNTS }}
+  DATALAYER_IN_NEW_ACCOUNTS: ${{ secrets.DEV_DATALAYER_IN_NEW_ACCOUNTS == 'dev-datalayer-in-new-accounts' }}
 
 jobs:
   prevalidate:

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -203,7 +203,7 @@ jobs:
           terraform_version: 1.0.11
           terraform_wrapper: false
       - name: Deploy Data Layer
-        run: ./data_layer_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}}
+        run: ./data_layer_deploy.sh ${{env.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}}
         env:
           VPC_NAME: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_DEV_VPC || secrets.DEV_VPC_NAME}}
           APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -14,6 +14,7 @@ env:
   BUILD_TAG: ${{ github.ref_name }}.${{ github.sha }}
   ECR_REPOSITORY_POSTGRESS_DEPLOYER: "postgres_deployer"
   ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
+  DATALAYER_IN_NEW_ACCOUNTS: ${{ secrets.DEV_DATALAYER_IN_NEW_ACCOUNTS }}
 
 jobs:
   prevalidate:
@@ -35,7 +36,14 @@ jobs:
           key: ${{ runner.os }}-postgres_deployer-docker-cache-{hash}
           restore-keys: |
             ${{ runner.os }}-postgres_deployer-docker-cache-
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -171,7 +179,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -185,8 +200,8 @@ jobs:
       - name: Deploy Data Layer
         run: ./data_layer_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}}
         env:
-          VPC_NAME: ${{secrets.DEV_VPC_NAME}}
-          APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
+          VPC_NAME: env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && ${{secrets.NEW_DEV_VPC}} || ${{secrets.DEV_VPC_NAME}}
+          APPLICATION_BUCKET: env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && ${{secrets.NEW_APPLICATION_BUCKET}} || ${{secrets.APPLICATION_BUCKET}}
   frontend:
     needs:
       - prevalidate
@@ -197,7 +212,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Configure datalayer AWS credentials
+      - name: Configure datalayer AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure datalayer AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -246,7 +268,14 @@ jobs:
           path: serverless/**/node_modules
           key: ${{ runner.os }}-serverless-modules-${{ hashFiles('serverless/**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-serverless-modules-
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/dev-destroy.yml
+++ b/.github/workflows/dev-destroy.yml
@@ -54,12 +54,12 @@ jobs:
           terraform_wrapper: false
       - name: Destroy frontend
         run: ./frontend_destroy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} destroy application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}} ${{env.BUILD_TAG}}
-      - name: Destroy data Layer
-        run: ./data_layer_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} destroy application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}}
         env:
           TF_VAR_datalayer_aws_access_key: env.AWS_ACCESS_KEY_ID
           TF_VAR_datalayer_aws_secret_key: env.AWS_SECRET_ACCESS_KEY
           TF_VAR_datalayer_aws_session_token: env.AWS_SESSION_TOKEN
+      - name: Destroy data Layer
+        run: ./data_layer_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} destroy application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}}
       - name: Destroy serverless
         run: |
           cd serverless

--- a/.github/workflows/dev-destroy.yml
+++ b/.github/workflows/dev-destroy.yml
@@ -56,6 +56,10 @@ jobs:
         run: ./frontend_destroy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} destroy application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}} ${{env.BUILD_TAG}}
       - name: Destroy data Layer
         run: ./data_layer_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} destroy application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}}
+        env:
+          TF_VAR_datalayer_aws_access_key: env.AWS_ACCESS_KEY_ID
+          TF_VAR_datalayer_aws_secret_key: env.AWS_SECRET_ACCESS_KEY
+          TF_VAR_datalayer_aws_session_token: env.AWS_SESSION_TOKEN
       - name: Destroy serverless
         run: |
           cd serverless

--- a/.github/workflows/master-deploy.yml
+++ b/.github/workflows/master-deploy.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - "master"
 
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: false
@@ -13,6 +18,7 @@ env:
   BRANCH_NAME: ${{ github.ref_name }}
   ECR_REPOSITORY_POSTGRESS_DEPLOYER: "postgres_deployer"
   ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
+  DATALAYER_IN_NEW_ACCOUNTS: ${{ secrets.MASTER_DATALAYER_IN_NEW_ACCOUNTS == 'master-datalayer-in-new-accounts' }}
 
 jobs:
   build-info:
@@ -38,7 +44,14 @@ jobs:
           key: ${{ runner.os }}-postgres_deployer-docker-cache-{hash}
           restore-keys: |
             ${{ runner.os }}-postgres_deployer-docker-cache-
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -174,7 +187,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -186,10 +206,10 @@ jobs:
           terraform_version: 1.0.11
           terraform_wrapper: false
       - name: Deploy Data Layer
-        run: ./data_layer_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}}
+        run: ./data_layer_deploy.sh ${{env.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}}
         env:
-          VPC_NAME: ${{secrets.DEV_VPC_NAME}}
-          APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
+          VPC_NAME: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_DEV_VPC || secrets.DEV_VPC_NAME}}
+          APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
           BUILD_TAG: ${{ needs.build-info.outputs.build_tag }}
           TF_VAR_skip_data_deployment: true
   frontend:
@@ -202,7 +222,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Configure AWS credentials
+      - name: Configure datalayer AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure datalayer AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure Terraform Datalayer Provider Credentials
+        run: |
+          echo "TF_VAR_datalayer_aws_access_key=${{env.AWS_ACCESS_KEY_ID}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_secret_key=${{env.AWS_SECRET_ACCESS_KEY}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_session_token=${{env.AWS_SESSION_TOKEN}}" >> $GITHUB_ENV
+      - name: Configure frontend AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -245,7 +283,14 @@ jobs:
           path: serverless/**/node_modules
           key: ${{ runner.os }}-serverless-modules-${{ hashFiles('serverless/**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-serverless-modules-
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -15,18 +15,32 @@ on:
         options:
           - prod
 
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.environment }}
   cancel-in-progress: false
+
 env:
   ECR_REPOSITORY_POSTGRESS_DEPLOYER: "postgres_deployer"
   ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
+  DATALAYER_IN_NEW_ACCOUNTS: ${{ secrets.PROD_DATALAYER_IN_NEW_ACCOUNTS == 'prod-datalayer-in-new-accounts' }}
 
 jobs:
   scan-postgres_deployer:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PROD_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -111,7 +125,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.version }}
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PROD_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -123,10 +144,10 @@ jobs:
           terraform_version: 1.0.11
           terraform_wrapper: false
       - name: Deploy Data Layer
-        run: ./data_layer_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{ github.event.inputs.environment }} apply application_version=${{ github.event.inputs.version }} vpc_name=${{env.VPC_NAME}}
+        run: ./data_layer_deploy.sh ${{env.APPLICATION_BUCKET}} ${{ github.event.inputs.environment }} apply application_version=${{ github.event.inputs.version }} vpc_name=${{env.VPC_NAME}}
         env:
-          VPC_NAME: ${{secrets.PROD_VPC_NAME}}
-          APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
+          VPC_NAME: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_PROD_VPC_NAME || secrets.PROD_VPC_NAME}}
+          APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
           TF_VAR_skip_data_deployment: true
   frontend:
     needs:
@@ -138,7 +159,25 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.version }}
-      - name: Configure AWS credentials
+      - name: Configure datalayer AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PROD_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure datalayer AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure Terraform Datalayer Provider Credentials
+        run: |
+          echo "TF_VAR_datalayer_aws_access_key=${{env.AWS_ACCESS_KEY_ID}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_secret_key=${{env.AWS_SECRET_ACCESS_KEY}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_session_token=${{env.AWS_SESSION_TOKEN}}" >> $GITHUB_ENV
+      - name: Configure frontend AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -182,7 +221,14 @@ jobs:
           path: serverless/**/node_modules
           key: ${{ runner.os }}-serverless-modules-${{ hashFiles('serverless/**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-serverless-modules-
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PROD_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -15,6 +15,11 @@ on:
         options:
           - staging
 
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.environment }}
   cancel-in-progress: false
@@ -22,12 +27,20 @@ concurrency:
 env:
   ECR_REPOSITORY_POSTGRESS_DEPLOYER: "postgres_deployer"
   ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
+  DATALAYER_IN_NEW_ACCOUNTS: ${{ secrets.STAGING_DATALAYER_IN_NEW_ACCOUNTS == 'staging-datalayer-in-new-accounts' }}
 
 jobs:
   scan-postgres_deployer:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.STAGING_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -112,7 +125,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.version }}
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.STAGING_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -124,10 +144,10 @@ jobs:
           terraform_version: 1.0.11
           terraform_wrapper: false
       - name: Deploy Data Layer
-        run: ./data_layer_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{ github.event.inputs.environment }} apply application_version=${{ github.event.inputs.version }} vpc_name=${{env.VPC_NAME}}
+        run: ./data_layer_deploy.sh ${{env.APPLICATION_BUCKET}} ${{ github.event.inputs.environment }} apply application_version=${{ github.event.inputs.version }} vpc_name=${{env.VPC_NAME}}
         env:
-          VPC_NAME: ${{secrets.STAGING_VPC_NAME}}
-          APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
+          VPC_NAME: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_STAGING_VPC_NAME || secrets.STAGING_VPC_NAME}}
+          APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
           TF_VAR_skip_data_deployment: true
   frontend:
     needs:
@@ -139,7 +159,25 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.version }}
-      - name: Configure AWS credentials
+      - name: Configure datalayer AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.STAGING_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure datalayer AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure Terraform Datalayer Provider Credentials
+        run: |
+          echo "TF_VAR_datalayer_aws_access_key=${{env.AWS_ACCESS_KEY_ID}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_secret_key=${{env.AWS_SECRET_ACCESS_KEY}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_session_token=${{env.AWS_SESSION_TOKEN}}" >> $GITHUB_ENV
+      - name: Configure frontend AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -183,7 +221,14 @@ jobs:
           path: serverless/**/node_modules
           key: ${{ runner.os }}-serverless-modules-${{ hashFiles('serverless/**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-serverless-modules-
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.STAGING_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/frontend/aws/main.tf
+++ b/frontend/aws/main.tf
@@ -18,6 +18,13 @@ terraform {
 provider "aws" {
   region = "us-east-1"
 }
+provider "aws" {
+  alias      = "datalayer"
+  access_key = var.datalayer_aws_access_key
+  secret_key = var.datalayer_aws_secret_key
+  token      = var.datalayer_aws_session_token
+  region     = "us-east-1"
+}
 provider "null" {
 
 }

--- a/frontend/aws/variables.tf
+++ b/frontend/aws/variables.tf
@@ -3,6 +3,21 @@ variable "application_version" {}
 
 variable "vpc_name" {}
 
+variable "datalayer_aws_access_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "datalayer_aws_secret_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "datalayer_aws_session_token" {
+  type      = string
+  sensitive = true
+}
+
 variable "acm_certificate_domain_ui" {
   default = ""
 }


### PR DESCRIPTION
# Description

Once we are deploying the data layer into a separate account than the frontend account we need the infracode for the frontend to pull specific properties about the data layer from the data layer's AWS account and we need to open up the security groups for the frontend service and the database to allow them to communicate with each other (VPC connection peering has already been set up).

This PR adds the prep work to logically separate the data layer resources from the frontend resources and connect them appropriately using terraform.

## How to test

This has been ran both
- across two accounts (frontend in legacy account and data layer in new dev account) to test the cross layer connections and confirmed that the frontend was able to talk with the database.
- within a single account (both frontend and data layer configured for the legacy account) and confirmed that frontend was still able to talk with database.

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [x] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
