### PR TITLE
MDCT-125: Migrating Data Layer

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -207,6 +207,7 @@ jobs:
         env:
           VPC_NAME: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_DEV_VPC || secrets.DEV_VPC_NAME}}
           APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
+          TF_VAR_postgres_restore_snapshot_id: ${{secrets.DEV_RESTORE_SNAPSHOT_ID}}
   frontend:
     needs:
       - prevalidate

--- a/.github/workflows/master-deploy.yml
+++ b/.github/workflows/master-deploy.yml
@@ -212,6 +212,7 @@ jobs:
           APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
           BUILD_TAG: ${{ needs.build-info.outputs.build_tag }}
           TF_VAR_skip_data_deployment: true
+          TF_VAR_postgres_restore_snapshot_id: ${{secrets.MASTER_RESTORE_SNAPSHOT_ID}}
   frontend:
     needs:
       - build-info

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -149,6 +149,7 @@ jobs:
           VPC_NAME: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_PROD_VPC_NAME || secrets.PROD_VPC_NAME}}
           APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
           TF_VAR_skip_data_deployment: true
+          TF_VAR_postgres_restore_snapshot_id: ${{secrets.PROD_RESTORE_SNAPSHOT_ID}}
   frontend:
     needs:
       - data

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -149,6 +149,7 @@ jobs:
           VPC_NAME: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_STAGING_VPC_NAME || secrets.STAGING_VPC_NAME}}
           APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
           TF_VAR_skip_data_deployment: true
+          TF_VAR_postgres_restore_snapshot_id: ${{secrets.STAGING_RESTORE_SNAPSHOT_ID}}
   frontend:
     needs:
       - data

--- a/docs/CARTS-MigrateDataLayerOut.yml
+++ b/docs/CARTS-MigrateDataLayerOut.yml
@@ -1,0 +1,82 @@
+description: Shuts down the data layer for the specified CARTS environment and shares an encrypted snapshot of the RDS instance with the specified account.
+schemaVersion: "0.3"
+outputs:
+  - CreateShareableCopy.SharedSnapshot
+parameters:
+  Environment:
+    type: String
+    description: Stage or Workspace name for the environment to run
+  EncryptionKeyARN:
+    type: String
+    description: ARN for KMS key to encrypted the shared snapshot
+  AccountIds:
+    type: StringList
+    description: Target accounts to share the snapshot with
+mainSteps:
+  - name: GetKafkaConnectClusterName
+    action: "aws:executeAwsApi"
+    inputs:
+      Service: cloudformation
+      Api: DescribeStackResource
+      LogicalResourceId: KafkaConnectCluster
+      StackName: "carts-bigmac-streams-{{Environment}}"
+    outputs:
+      - Name: ClusterName
+        Selector: $.StackResourceDetail.PhysicalResourceId
+        Type: String
+  - name: StopKafkaConnectService
+    action: "aws:executeAwsApi"
+    inputs:
+      Service: ecs
+      Api: UpdateService
+      service: kafka-connect
+      cluster: "{{GetKafkaConnectClusterName.ClusterName}}"
+      desiredCount: 0
+    description: Scales _kafka-connect_ service within the KafkaConnectCluster to 0
+  - name: StopRDSInstance
+    action: "aws:executeAwsApi"
+    inputs:
+      Service: rds
+      Api: StopDBInstance
+      DBInstanceIdentifier: "postgres-rf-{{Environment}}"
+      DBSnapshotIdentifier: "postgres-rf-{{Environment}}-stopped"
+  - name: WaitForSnapshot
+    action: "aws:waitForAwsResourceProperty"
+    inputs:
+      Service: rds
+      Api: DescribeDBSnapshots
+      PropertySelector: "$.DBSnapshots[0].Status"
+      DesiredValues:
+        - available
+      DBSnapshotIdentifier: "postgres-rf-{{Environment}}-stopped"
+  - name: CreateShareableCopy
+    action: "aws:executeAwsApi"
+    inputs:
+      Service: rds
+      Api: CopyDBSnapshot
+      SourceDBSnapshotIdentifier: "postgres-rf-{{Environment}}-stopped"
+      TargetDBSnapshotIdentifier: "postgres-rf-{{Environment}}-shared"
+      KmsKeyId: "{{EncryptionKeyARN}}"
+    description: Creates a copy of the stopped snapshot encrypted with the provided KMS key that will be suitable for sharing
+    outputs:
+      - Name: SharedSnapshot
+        Selector: $.DBSnapshot.DBSnapshotIdentifier
+        Type: String
+  - name: WaitForSharableSnapshot
+    action: "aws:waitForAwsResourceProperty"
+    inputs:
+      Service: rds
+      Api: DescribeDBSnapshots
+      PropertySelector: "$.DBSnapshots[0].Status"
+      DesiredValues:
+        - available
+      DBSnapshotIdentifier: "{{CreateShareableCopy.SharedSnapshot}}"
+  - name: ShareSnapshot
+    action: "aws:executeAwsApi"
+    inputs:
+      Service: rds
+      Api: ModifyDBSnapshotAttribute
+      DBSnapshotIdentifier: "{{CreateShareableCopy.SharedSnapshot}}"
+      AttributeName: restore
+      ValuesToAdd: "{{ AccountIds }}"
+    description: Shares snapshot with given aws accounts


### PR DESCRIPTION
# Description

The steps for the actual data layer migration from the legacy AWS accounts to the new accounts was added at [🔒CARTS Data Layer Migration Steps (MDCT Confluence)](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2957606913/CARTS+Data+Layer+Migration+Steps). This PR adds the two additional required changes to execute those steps when ever we are ready for the migration.

1. Adds a copy of the Systems Manager Automation document referenced in the steps that handles shutting down the old data layer and exporting a copy of the data base to the new accounts.
2. Adds the ability to set the restore snapshot id via GitHub secrets.

In addition to reviewing the changes here, please also review the steps listed in the above confluence page and leave comments there as part of your review.

## How to test

I tested this run book with @gmrabian yesterday on this branch. The deployed data layer here was moved from the legacy account to the new dev account, and we confirmed that the frontend layer was correctly referencing the new data layer and that the new data layer was created from the imported snapshot.

## Dependencies

None.

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [x] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
