### PR TITLE
Enable dev environment destroy for both cross-account CARTS v2 and v3

### DIFF
--- a/.github/workflows/dev-destroy.yml
+++ b/.github/workflows/dev-destroy.yml
@@ -74,6 +74,7 @@ jobs:
     # This is a list of branch names that are commonly used for protected branches/environments.
     # Add/remove names from this list as appropriate.
     if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref) && startsWith(github.event.ref,'dev-')
+    runs-on: ubuntu-latest
     needs:
       - destroy-frontend
     steps:
@@ -109,6 +110,7 @@ jobs:
     # This is a list of branch names that are commonly used for protected branches/environments.
     # Add/remove names from this list as appropriate.
     if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref)
+    runs-on: ubuntu-latest
     needs:
       - destroy-data
     steps:
@@ -140,6 +142,7 @@ jobs:
     # This is a list of branch names that are commonly used for protected branches/environments.
     # Add/remove names from this list as appropriate.
     if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref)
+    runs-on: ubuntu-latest
     needs:
       - destroy-data
     steps:

--- a/.github/workflows/dev-destroy.yml
+++ b/.github/workflows/dev-destroy.yml
@@ -3,45 +3,52 @@ name: dev-destroy
 on:
   delete:
 
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
 concurrency:
   group: dev-${{ github.event.ref }}
   cancel-in-progress: false
 
+env:
+  BRANCH_NAME: ${{ github.event.ref }}
+  BUILD_TAG: ${{ github.event.ref }}.${{ github.sha }}
+  ECR_REPOSITORY_POSTGRESS_DEPLOYER: "postgres_deployer"
+  ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
+  DATALAYER_IN_NEW_ACCOUNTS: ${{ secrets.DEV_DATALAYER_IN_NEW_ACCOUNTS == 'dev-datalayer-in-new-accounts' }}
+
 jobs:
-  destroy:
+  destroy-frontend:
     # Protected branches should be designated as such in the GitHub UI.
     # So, a protected branch should never have this workflow run, since the branch should never be deleted.
     # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
     # This is a list of branch names that are commonly used for protected branches/environments.
     # Add/remove names from this list as appropriate.
-    if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "staging", "production", "prod"]'), github.event.ref) && startsWith(github.event.ref,'dev-')
+    if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref) && startsWith(github.event.ref,'dev-')
     runs-on: ubuntu-latest
     steps:
-      - name: set branch_name
-        run: echo "BRANCH_NAME=${{ github.event.ref }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
-      - name: set branch specific variable names
+      - uses: actions/checkout@v3
+      - name: Configure datalayer AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure datalayer AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure Terraform Datalayer Provider Credentials
         run: |
-          ./.github/build_vars.sh set_names
-          echo "BUILD_TAG=${BRANCH_NAME}.${{ github.sha }}" >> "$GITHUB_ENV"
-      - name: Create env var for  postgress deployer ECR repo name
-        run: echo "ECR_REPOSITORY_POSTGRESS_DEPLOYER=postgres_deployer" >> "$GITHUB_ENV"
-      - name: Create env var for  API postgress django ecr repo name
-        run: echo "ECR_REPOSITORY_API_POSTGRESS=postgres_django" >> "$GITHUB_ENV"
-      - name: set variable values
-        run: ./.github/build_vars.sh set_values
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
-          VPC_NAME: ${{secrets.DEV_VPC_NAME}}
-          OIDC_CLIENT_ID: ${{secrets.MASTER_OIDC_CLIENT_ID}}
-          OIDC_ISSUER: ${{secrets.MASTER_OIDC_ISSUER}}
-          TF_VAR_openid_discovery_url: ${{secrets.MASTER_TF_VAR_OPENID_DISCOVERY_URL}}
-          ECR_REPOSITORY_POSTGRESS_DEPLOYER: "postgres_deployer"
-          ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
-          APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
-      - name: Configure AWS credentials
+          echo "TF_VAR_datalayer_aws_access_key=${{env.AWS_ACCESS_KEY_ID}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_secret_key=${{env.AWS_SECRET_ACCESS_KEY}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_session_token=${{env.AWS_SESSION_TOKEN}}" >> $GITHUB_ENV
+      - name: Configure frontend AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -55,12 +62,104 @@ jobs:
       - name: Destroy frontend
         run: ./frontend_destroy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} destroy application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}} ${{env.BUILD_TAG}}
         env:
-          TF_VAR_datalayer_aws_access_key: env.AWS_ACCESS_KEY_ID
-          TF_VAR_datalayer_aws_secret_key: env.AWS_SECRET_ACCESS_KEY
-          TF_VAR_datalayer_aws_session_token: env.AWS_SESSION_TOKEN
+          VPC_NAME: ${{secrets.DEV_VPC_NAME}}
+          OIDC_CLIENT_ID: ${{secrets.MASTER_OIDC_CLIENT_ID}}
+          OIDC_ISSUER: ${{secrets.MASTER_OIDC_ISSUER}}
+          TF_VAR_openid_discovery_url: ${{secrets.MASTER_TF_VAR_OPENID_DISCOVERY_URL}}
+          APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
+  destroy-data:
+    # Protected branches should be designated as such in the GitHub UI.
+    # So, a protected branch should never have this workflow run, since the branch should never be deleted.
+    # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
+    # This is a list of branch names that are commonly used for protected branches/environments.
+    # Add/remove names from this list as appropriate.
+    if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref) && startsWith(github.event.ref,'dev-')
+    needs:
+      - destroy-frontend
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure AWS credentials (new account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure AWS credentials (legacy account)
+        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Terraform setup
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.0.11
+          terraform_wrapper: false
       - name: Destroy data Layer
         run: ./data_layer_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} destroy application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}}
+        env:
+          VPC_NAME: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_DEV_VPC || secrets.DEV_VPC_NAME}}
+          APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
+          TF_VAR_postgres_restore_snapshot_id: ${{secrets.DEV_RESTORE_SNAPSHOT_ID}}
+  destroy-serverless-legacy-account:
+    # Protected branches should be designated as such in the GitHub UI.
+    # So, a protected branch should never have this workflow run, since the branch should never be deleted.
+    # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
+    # This is a list of branch names that are commonly used for protected branches/environments.
+    # Add/remove names from this list as appropriate.
+    if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref)
+    needs:
+      - destroy-data
+    steps:
+      - uses: actions/checkout@v3
+      - name: read .nvmrc
+        id: node_version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
+      - uses: actions/cache@v3
+        with:
+          path: serverless/**/node_modules
+          key: ${{ runner.os }}-serverless-modules-${{ hashFiles('serverless/**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-serverless-modules-
+      - name: Configure AWS credentials (legacy account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Destroy serverless
-        run: |
-          cd serverless
-          ./destroy.sh ${{env.BRANCH_NAME}}
+        working-directory: serverless
+        run: ./destroy.sh ${{env.BRANCH_NAME}}
+  destroy-serverless-new-account:
+    # Protected branches should be designated as such in the GitHub UI.
+    # So, a protected branch should never have this workflow run, since the branch should never be deleted.
+    # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
+    # This is a list of branch names that are commonly used for protected branches/environments.
+    # Add/remove names from this list as appropriate.
+    if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref)
+    needs:
+      - destroy-data
+    steps:
+      - uses: actions/checkout@v3
+      - name: read .nvmrc
+        id: node_version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
+      - uses: actions/cache@v3
+        with:
+          path: serverless/**/node_modules
+          key: ${{ runner.os }}-serverless-modules-${{ hashFiles('serverless/**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-serverless-modules-
+      - name: Configure AWS credentials (new account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Destroy serverless
+        working-directory: serverless
+        run: ./destroy.sh ${{env.BRANCH_NAME}}

--- a/.github/workflows/dev-destroy.yml
+++ b/.github/workflows/dev-destroy.yml
@@ -26,7 +26,10 @@ jobs:
     # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
     # This is a list of branch names that are commonly used for protected branches/environments.
     # Add/remove names from this list as appropriate.
-    if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref) && startsWith(github.event.ref,'dev-')
+    if: |
+      github.event.ref_type == 'branch' &&
+      !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref) &&
+      startsWith(github.event.ref,'dev-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -73,7 +76,12 @@ jobs:
     # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
     # This is a list of branch names that are commonly used for protected branches/environments.
     # Add/remove names from this list as appropriate.
-    if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref) && startsWith(github.event.ref,'dev-')
+    if: |
+      always() &&
+      (needs.destroy-frontend.result == 'success' || needs.destroy-frontend.result == 'skipped') &&
+      github.event.ref_type == 'branch' &&
+      !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref) &&
+      startsWith(github.event.ref,'dev-')
     runs-on: ubuntu-latest
     needs:
       - destroy-frontend
@@ -109,7 +117,11 @@ jobs:
     # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
     # This is a list of branch names that are commonly used for protected branches/environments.
     # Add/remove names from this list as appropriate.
-    if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref)
+    if: |
+      always() &&
+      (needs.destroy-data.result == 'success' || needs.destroy-data.result == 'skipped') &&
+      github.event.ref_type == 'branch' &&
+      !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref)
     runs-on: ubuntu-latest
     needs:
       - destroy-data
@@ -141,7 +153,11 @@ jobs:
     # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
     # This is a list of branch names that are commonly used for protected branches/environments.
     # Add/remove names from this list as appropriate.
-    if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref)
+    if: |
+      always() &&
+      (needs.destroy-data.result == 'success' || needs.destroy-data.result == 'skipped') &&
+      github.event.ref_type == 'branch' &&
+      !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref)
     runs-on: ubuntu-latest
     needs:
       - destroy-data


### PR DESCRIPTION
# Description

Updates to the dev destroy workflow to ensure:
1. Environments are destroyed across AWS accounts if the data layer is deployed to the new AWS accounts instead of the legacy accounts.
2. Dev Branches based on the CARTS v3 (main) codebase trigger only serverless destruction and not the terraform destroys (since we don't use terraform for that codebase).

Needed for [MDCT-299](https://qmacbis.atlassian.net/browse/MDCT-299)

## How to test

Tested this with two destroys.

1. Off the v2 codebase (deleted branch: dev-detest off of master): https://github.com/CMSgov/cms-carts-seds/actions/runs/2339140715
2. Off the v3 codebase (deleted branch: v3-deploy-test off of main): https://github.com/CMSgov/cms-carts-seds/actions/runs/2339121427 

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
