### PR TITLE
Workaround for local docker-compose

### DIFF
--- a/frontend/api_postgres/Dockerfile.local
+++ b/frontend/api_postgres/Dockerfile.local
@@ -32,8 +32,5 @@ RUN pip install pdfkit --no-cache
 # copy project
 COPY . /usr/src/app/
 
-RUN python utils/section-schemas/generate_fixtures.py
-RUN python utils/section-schemas/compare_fixtures.py
-
 # run entrypoint.sh
 ENTRYPOINT ["/usr/src/app/entrypoint_local.sh"]

--- a/frontend/api_postgres/entrypoint_local.sh
+++ b/frontend/api_postgres/entrypoint_local.sh
@@ -11,6 +11,8 @@ then
     echo "PostgreSQL started"
 fi
 
+python utils/section-schemas/generate_fixtures.py
+python utils/section-schemas/compare_fixtures.py
 python manage.py makemigrations && python manage.py migrate && python manage.py idempotent_fixtures --overwrite && python manage.py add_state_permissions
 python manage.py load_formtemplates
 python manage.py setup_trigger


### PR DESCRIPTION
# Description

Local docker-compose for api_postgres is set up to shadow the api_postgres folder from the developers machine overtop the built image. This means that the fixtures generated in the image are not present if they have not been built on the local developer's machine. To unblock people from doing local development for now, reverting to generating the fixtures at run time just for the local docker-compose workflow.

## How to test

Starting up api_postgres should be successful when running the local docker-compose project.

## Dependencies

None.

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
