### PR TITLE
add sticky header

### DIFF
--- a/services/ui-src/src/components/layout/Header.js
+++ b/services/ui-src/src/components/layout/Header.js
@@ -37,7 +37,7 @@ class Header extends Component {
     const { email } = currentUser;
     const isLoggedIn = !!currentUser.username;
     return (
-      <div data-test="component-header">
+      <div className="component-header" data-test="component-header">
         <UsaBanner
           data-testid={"usaBanner"}
           className={"usabanner-section-layout"}

--- a/services/ui-src/src/components/sections/UserProfile.js
+++ b/services/ui-src/src/components/sections/UserProfile.js
@@ -4,8 +4,8 @@ import PropTypes from "prop-types";
 
 const UserProfile = ({ currentUser }) => {
   return (
-    <div className="page-info">
-      <div className="ds-l-col--12 content ds-u-padding-left--4 ">
+    <div className="page-info ds-l-container">
+      <div className="ds-l-col--12">
         <header>
           <h1>User Profile</h1>
         </header>

--- a/services/ui-src/src/styles/_header.scss
+++ b/services/ui-src/src/styles/_header.scss
@@ -2,6 +2,12 @@
   HEADER
 **********************/
 
+.component-header {
+  position: sticky;
+  top: 0;
+  background-color: $color-gray-lightest;
+}
+
 .header {
   background: $brand-tertiary;
   color: $white;
@@ -117,7 +123,8 @@
         top: ($padding * 6.25);
         transition: all 2s;
       }
-      a, button {
+      a,
+      button {
         &:focus {
           background-color: initial;
         }
@@ -189,12 +196,12 @@
 }
 
 /**********************
-  USA BANNER 
+  USA BANNER
 **********************/
 .usabanner-section-layout {
   margin-left: auto;
   margin-right: auto;
-  background-color: inherit;
+  background-color: $color-gray-lightest;
   max-width: 1040px;
   padding-left: 16px;
 }

--- a/services/ui-src/src/styles/_header.scss
+++ b/services/ui-src/src/styles/_header.scss
@@ -5,6 +5,7 @@
 .component-header {
   position: sticky;
   top: 0;
+  z-index: 1;
   background-color: $color-gray-lightest;
 }
 


### PR DESCRIPTION
# Description
This PR makes the header (including `usaBanner`) sticky and constrains the user profile page content. No associated ticket -- did it 'cause this was bothering me while reviewing another PR. 

## How to test
1. Pull and run
2. On `/` scroll around to see sticky header. On `/user/profile` see constrained body.

## Dependencies
No changed deps.

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] ~~I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)~~
- [x] ~~Necessary analytics were added, or no new analytics were required~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
