### PR TITLE
MDCT-252: Help Desk User View All CARTS Reports

### DIFF
--- a/services/app-api/handlers/stateStatus/get.ts
+++ b/services/app-api/handlers/stateStatus/get.ts
@@ -18,7 +18,8 @@ export const getStateStatus = handler(async (event, _context) => {
   } else if (
     user.role === UserRoles.ADMIN ||
     user.role === UserRoles.BO ||
-    user.role === UserRoles.CO
+    user.role === UserRoles.CO ||
+    user.role === UserRoles.HELP
   ) {
     // Return all
     const params = {

--- a/services/ui-src/src/components/layout/Home.js
+++ b/services/ui-src/src/components/layout/Home.js
@@ -15,6 +15,7 @@ const Home = ({ role }) => {
       break;
     case UserRoles.BO:
     case UserRoles.CO:
+    case UserRoles.HELP:
       content = <CMSHome />;
       break;
     case UserRoles.STATE:

--- a/services/ui-src/src/components/layout/HomeAdmin.js
+++ b/services/ui-src/src/components/layout/HomeAdmin.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Link, Route } from "react-router-dom";
+import { Route } from "react-router-dom";
 import JobCodeRoleAssociations from "../Utils/JobCodeRoleAssociations";
 import StateAssociations from "../Utils/StateAssociations";
 import UserRoleAssociations from "../Utils/UserRoleAssociations";
@@ -28,20 +28,7 @@ const AdminHome = () => {
               </h1>
             </div>
             <div className="page-info">
-              <div className="edit-info">admin</div>
-            </div>
-            <div className="ds-l-row">
-              <ul>
-                <li>
-                  <Link to="/users">List users</Link>
-                </li>
-                <li>
-                  <Link to="/add_user">Add user</Link>
-                </li>
-                <li>
-                  <Link to="/templates">Generate Form Base Templates</Link>
-                </li>
-              </ul>
+              <div className="edit-info">help desk</div>
             </div>
             <div className="cmslist">
               <CMSHomepage />

--- a/services/ui-src/src/components/sections/homepage/CMSHomepage.js
+++ b/services/ui-src/src/components/sections/homepage/CMSHomepage.js
@@ -62,6 +62,7 @@ const CMSHomepage = ({
   const clearFilter = () => {
     window.location.reload(false);
   };
+
   return (
     <div className="homepage ds-l-col--12">
       <div className="ds-l-container-large">
@@ -144,9 +145,10 @@ const CMSHomepage = ({
               </div>
               <div className="report-status">
                 {statuses
-                  .sort((a, b) => (a.stateCode < b.stateCode ? -1 : 1))
-                  .sort((a, b) => (a.year > b.year ? -1 : 1))
-                  .sort((a, b) => (a.lastChanged > b.lastChanged ? -1 : 1))
+                  // if there is a difference in year, sort by year first, otherwise, sort by state
+                  .sort(
+                    (a, b) => b.year - a.year || (a.state < b.state ? -1 : 1)
+                  )
                   .map(
                     ({
                       state,
@@ -157,7 +159,6 @@ const CMSHomepage = ({
                       lastChanged,
                     }) => {
                       return (
-                        // eslint-disable-next-line
                         <div>
                           {
                             // eslint-disable-next-line

--- a/services/ui-src/src/components/sections/homepage/CMSHomepage.js
+++ b/services/ui-src/src/components/sections/homepage/CMSHomepage.js
@@ -144,6 +144,8 @@ const CMSHomepage = ({
               </div>
               <div className="report-status">
                 {statuses
+                  .sort((a, b) => (a.stateCode < b.stateCode ? -1 : 1))
+                  .sort((a, b) => (a.year > b.year ? -1 : 1))
                   .sort((a, b) => (a.lastChanged > b.lastChanged ? -1 : 1))
                   .map(
                     ({


### PR DESCRIPTION
# Description

Closes [MDCT-252](https://qmacbis.atlassian.net/browse/MDCT-252). The new Help Desk user (functionally, an admin user) can view a list of all CARTS reports. These reports are now sorted by year, then alphabetically. For example:

`2022 Alabama`
`2022 Alaska`
`2022 California`
`2021 Alaska`
`2020 California`

Also, the "List Users", "Add Users", and "Generate Form Base Templates" buttons should be _gone_.

## How to test

`./dev local`

Log in as an admin user, check out how everything is sorted and those buttons don't exist anymore!

## Dependencies

N/A

# Get it done

N/A

## Code authors checklist

- [x] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [x] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
