### PR TITLE
Fix getting current user attributes when logging in via IDM

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -121,6 +121,7 @@ resources:
           - email
           - openid
           - profile
+          - aws.cognito.signin.user.admin # needed for retrieving user attributes in IDM flow
         CallbackURLs:
           - ${self:custom.application_endpoint_url}
           - http://localhost:3000/

--- a/services/ui-src/src/hooks/authHooks/userProvider.js
+++ b/services/ui-src/src/hooks/authHooks/userProvider.js
@@ -7,21 +7,7 @@ import { loadUser } from "../../actions/initial";
 import { useDispatch } from "react-redux";
 
 const authenticateWithIDM = () => {
-  const authConfig = Auth.configure();
-  if (authConfig?.oauth) {
-    const oAuthOpts = authConfig.oauth;
-    const domain = oAuthOpts.domain;
-    const responseType = oAuthOpts.responseType;
-    let redirectSignIn;
-
-    if ("redirectSignOut" in oAuthOpts) {
-      redirectSignIn = oAuthOpts.redirectSignOut;
-    }
-
-    const clientId = authConfig.userPoolWebClientId;
-    const url = `https://${domain}/oauth2/authorize?identity_provider=Okta&redirect_uri=${redirectSignIn}&response_type=${responseType}&client_id=${clientId}`;
-    window.location.assign(url);
-  }
+  Auth.federatedSignIn({ customProvider: "Okta" });
 };
 
 export const UserProvider = ({ children }) => {

--- a/services/ui-src/src/index.js
+++ b/services/ui-src/src/index.js
@@ -39,7 +39,7 @@ Amplify.configure({
       domain: config.cognito.APP_CLIENT_DOMAIN,
       redirectSignIn: config.cognito.REDIRECT_SIGNIN,
       redirectSignOut: config.cognito.REDIRECT_SIGNOUT,
-      scope: ["email", "openid"],
+      scope: ["email", "openid", "profile", "aws.cognito.signin.user.admin"],
       responseType: "token",
     },
   },


### PR DESCRIPTION
# Description

CognitoUser objects returned by the amplify library do not include the user attributes unless the requested scope includes the aws.cognito.signin.user.admin scope required for any calls to the Cognito User Pool library. See [discussion on scope for the cognito AUTHORIZATION endpoint](https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html). When logging via username and password with cognito this scope is automatically set and the user object has its attributes. However, when doing federated login, you need to ensure you request the scope before the returned user object will include those attributes.

This PR ensures we set the user admin scope on the cognito requests and replaces the custom oauth redirect code with the standard amplify library call for federated login.

While the scope has a scary name, it is the intended scope for getting the current user details, as evident by its inclusion when signing in via username and password and not IDM. Additionally you can see [the quick start also already includes this scope](https://github.com/CMSgov/macpro-quickstart-serverless/blob/db758d9dac7647aefdd081a67b1c23b8990c811e/services/ui-auth/serverless.yml#L116).

## How to test

This same change was made in MCR and tested after merging https://github.com/CMSgov/mdct-mcr/pull/2485. We will need to test again after merging this.

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
