### PR TITLE
Close suppressed and resolved issues from security hub.

### DIFF
--- a/services/.sechub/handlers/sync.js
+++ b/services/.sechub/handlers/sync.js
@@ -59,6 +59,16 @@ async function getAllActiveFindings() {
                 Value: "ACTIVE",
               },
             ],
+            WorkflowStatus: [
+              {
+                Comparison: "NOT_EQUALS",
+                Value: "SUPPRESSED",
+              },
+              {
+                Comparison: "NOT_EQUALS",
+                Value: "RESOLVED",
+              },
+            ],
             SeverityLabel: severityLabels,
           },
           MaxResults: 100,


### PR DESCRIPTION
# Description

Security Hub reporter is not closing findings that have been suppressed or resolved in SecurityHub. Since these are findings that require no more action and do not present by default in security hub, we should ignore them when searching for active findings.

Uses the latest version of the [sync](https://github.com/CMSgov/macpro-quickstart-serverless/blob/db758d9dac7647aefdd081a67b1c23b8990c811e/services/.sechub/handlers/sync.js) from the quickstart.

## How to test

Requires merge.

## Dependencies

None.

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
