### PR TITLE
Do not send welcome email to bootstrap test users

### DIFF
--- a/services/ui-auth/handlers/createUsers.js
+++ b/services/ui-auth/handlers/createUsers.js
@@ -14,7 +14,7 @@ async function myHandler(_event, _context, _callback) {
     var poolData = {
       UserPoolId: userPoolId,
       Username: users[i].username,
-      DesiredDeliveryMediums: ["EMAIL"],
+      MessageAction: "SUPPRESS",
       UserAttributes: users[i].attributes,
     };
     var passwordData = {


### PR DESCRIPTION
# Description

The bootstrap users step was failing sometimes because we were exceeding our email quota sending welcome emails. We should not be sending welcome emails for the fake users, so I added a suppression to prevent the welcome messages from being set. See https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminCreateUser.html

> Alternatively, you can call AdminCreateUser with SUPPRESS for the MessageAction parameter, and Amazon Cognito won't send any email.

## How to test

The deploys.

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
