### PR TITLE
MDCT-108: Read-Only Fields for CMS Review

### DIFF
--- a/services/ui-src/src/components/fields/DateRange.js
+++ b/services/ui-src/src/components/fields/DateRange.js
@@ -2,12 +2,12 @@ import React from "react";
 import PropTypes from "prop-types";
 import DateRange from "../layout/DateRange";
 
-const DateRangeWrapper = ({ onChange, question }) => {
+const DateRangeWrapper = ({ onChange, question, ...props }) => {
   const changeHandler = ([questionId, data]) => {
     onChange({ target: { name: questionId, value: data } });
   };
 
-  return <DateRange onChange={changeHandler} question={question} />;
+  return <DateRange onChange={changeHandler} question={question} {...props} />;
 };
 DateRangeWrapper.propTypes = {
   onChange: PropTypes.func.isRequired,

--- a/services/ui-src/src/components/fields/Ranges.js
+++ b/services/ui-src/src/components/fields/Ranges.js
@@ -14,7 +14,16 @@ const inputs = new Map([
   ["text", Text],
 ]);
 
-const Range = ({ category, id, index, onChange, row, type, values }) => {
+const Range = ({
+  category,
+  id,
+  index,
+  onChange,
+  row,
+  type,
+  values,
+  ...props
+}) => {
   const [rangeError, setRangeError] = useState("");
   const [rangeValues, setRangeValues] = useState(values);
 
@@ -103,6 +112,7 @@ const Range = ({ category, id, index, onChange, row, type, values }) => {
         <div className="ds-l-row">
           <div className="cmsrange-container range-start">
             <Input
+              {...props}
               id={`${id}-${row}-${index}-0`}
               label={category[0]}
               className="cmsrange-input"
@@ -111,6 +121,7 @@ const Range = ({ category, id, index, onChange, row, type, values }) => {
               onChange={changeStart}
               onBlur={validateInequality}
               value={rangeValues[0] ? rangeValues[0] : values[0]}
+              disabled={props.disabled}
             />
           </div>
           <div className="cmsrange-arrow">
@@ -118,6 +129,7 @@ const Range = ({ category, id, index, onChange, row, type, values }) => {
           </div>
           <div className="cmsrange-container cmsrange-end">
             <Input
+              {...props}
               id={`${id}-${row}-${index}-1`}
               label={category[1]}
               className="cmsrange-input"
@@ -126,6 +138,7 @@ const Range = ({ category, id, index, onChange, row, type, values }) => {
               onChange={changeEnd}
               onBlur={validateInequality}
               value={rangeValues[1] ? rangeValues[1] : values[1]}
+              disabled={props.disabled}
             />
           </div>
         </div>
@@ -143,7 +156,7 @@ Range.propTypes = {
   values: PropTypes.array.isRequired,
 };
 
-const Ranges = ({ onChange, question }) => {
+const Ranges = ({ onChange, question, ...props }) => {
   const {
     answer: {
       entry,
@@ -193,6 +206,7 @@ const Ranges = ({ onChange, question }) => {
       {values.map((rowValues, row) =>
         rowValues.map((categoryValues, index) => (
           <Range
+            {...props}
             key={`${row}.${index}`}
             category={categories[index]}
             id={question.id}
@@ -201,12 +215,13 @@ const Ranges = ({ onChange, question }) => {
             row={row}
             type={types[index]}
             values={categoryValues}
+            disabled={props.disabled}
           />
         ))
       )}
 
       {values.length < max || max === 0 ? (
-        <Button onClick={addRow} type="button" variation="primary">
+        <Button onClick={addRow} type="button" variation="primary" {...props}>
           Add another? <FontAwesomeIcon icon={faPlus} />
         </Button>
       ) : null}

--- a/services/ui-src/src/components/layout/DateRange.js
+++ b/services/ui-src/src/components/layout/DateRange.js
@@ -247,6 +247,7 @@ class DateRange extends Component {
               onChange={this.handleInput}
               onBlur={this.validateStartInput}
               value={monthStart}
+              disabled={this.props.disabled}
             />
             <div className="ds-c-datefield__separator">/</div>
             <TextField
@@ -257,6 +258,7 @@ class DateRange extends Component {
               onBlur={this.validateStartInput}
               numeric
               value={yearStart}
+              disabled={this.props.disabled}
             />
           </div>
         </div>
@@ -285,6 +287,7 @@ class DateRange extends Component {
               onChange={this.handleInput}
               onBlur={this.validateEndInput}
               value={monthEnd}
+              disabled={this.props.disabled}
             />
             <div className="ds-c-datefield__separator">/</div>
 
@@ -296,6 +299,7 @@ class DateRange extends Component {
               onBlur={this.validateEndInput}
               numeric
               value={yearEnd}
+              disabled={this.props.disabled}
             />
           </div>
           <div className="errors">


### PR DESCRIPTION
# Description

Closes [MDCT-108](https://qmacbis.atlassian.net/browse/MDCT-108). All fields are disabled for an Approver (in this case, an Admin) within a CARTS report. State Users are still able to edit their reports accordingly.

## How to test

`nvm use`
`./dev local`

Log in as a State User and verify that all fields are editable, then log in as an Admin user and verify that all fields are read-only (specifically, **Section 1** and **Section 4** had some editable stragglers). 

## Dependencies

N/A

## Code authors checklist

- [x] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [x] I have closed the PR after the review and necessary changes (squashing preferred)
