### PR TITLE
MDCT 292 - Remove autosave where not needed

### DIFF
--- a/services/ui-src/src/AppRoutes.js
+++ b/services/ui-src/src/AppRoutes.js
@@ -20,12 +20,10 @@ const AppRoutes = () => {
     return <LocalLogins loginWithIDM={loginWithIDM} />;
   }
 
-  const ShowAutoSave = window.location.pathname.split("/")[2] === "sections";
-
   const VisibleHeader =
     window.location.pathname.split("/")[1] === "reports" ||
     window.location.pathname.split("/")[1] === "coming-soon" ? null : (
-      <Header currentUser={user} showAutoSave={ShowAutoSave} />
+      <Header currentUser={user} />
     );
 
   const VisibleFooter =
@@ -39,10 +37,10 @@ const AppRoutes = () => {
       className={"App " + window.location.pathname.split("/")[1]}
       data-test="component-app"
     >
-      {VisibleHeader}
       <div className="app-content">
         <Spinner />
         <Router>
+          {VisibleHeader}
           <Home user={user} role={userRole} />
           {/* These routes are available to everyone, so define them here */}
           <Route exact path="/userinfo" component={Userinfo} />

--- a/services/ui-src/src/AppRoutes.js
+++ b/services/ui-src/src/AppRoutes.js
@@ -15,14 +15,17 @@ import "./styles/app.scss";
 
 const AppRoutes = () => {
   const { user, userRole, showLocalLogins, loginWithIDM } = useUser();
+
   if (!user && showLocalLogins) {
     return <LocalLogins loginWithIDM={loginWithIDM} />;
   }
 
+  const ShowAutoSave = window.location.pathname.split("/")[2] === "sections";
+
   const VisibleHeader =
     window.location.pathname.split("/")[1] === "reports" ||
     window.location.pathname.split("/")[1] === "coming-soon" ? null : (
-      <Header currentUser={user} />
+      <Header currentUser={user} showAutoSave={ShowAutoSave} />
     );
 
   const VisibleFooter =

--- a/services/ui-src/src/components/layout/Header.js
+++ b/services/ui-src/src/components/layout/Header.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import Autosave from "./Autosave";
 import Logout from "./Logout";
 import UsaBanner from "@cmsgov/design-system/dist/components/UsaBanner/UsaBanner";
+import { Link, withRouter } from "react-router-dom";
 
 class Header extends Component {
   constructor() {
@@ -34,9 +35,10 @@ class Header extends Component {
   render() {
     const { currentUser } = this.props;
     const { currentYear } = this.props;
-    const { showAutoSave } = this.props;
+    const { location } = this.props;
     const { email } = currentUser;
     const isLoggedIn = !!currentUser.username;
+    const showAutoSave = location.pathname.includes("/views/sections/");
     return (
       <div className="component-header" data-test="component-header">
         <UsaBanner
@@ -47,9 +49,9 @@ class Header extends Component {
           <div className="ds-l-container">
             <div className="ds-l-row header-row">
               <div className="site-title ds-l-col--4 ds-u-padding--2">
-                <a data-testid={"cartsCurrentYear"} href="/">
+                <Link data-testid={"cartsCurrentYear"} to="/">
                   Carts-{currentYear}
-                </a>
+                </Link>
               </div>
               <div className="user-details ds-l-col--8 ds-u-padding--2">
                 <div className="ds-l-row">
@@ -73,7 +75,7 @@ function renderMenu(toggleUserNav, email) {
           <a href="mailto:mdct_help@cms.hhs.gov">Contact Us</a>
         </li>
         <li className="manage-account">
-          <a href="/user/profile">Manage Account</a>
+          <Link to="/user/profile">Manage Account</Link>
         </li>
         <li className="logout">
           <Logout />
@@ -113,4 +115,4 @@ const mapStateToProps = (state) => ({
   currentYear: state.global.currentYear,
 });
 
-export default connect(mapStateToProps)(Header);
+export default connect(mapStateToProps)(withRouter(Header));

--- a/services/ui-src/src/components/layout/Header.js
+++ b/services/ui-src/src/components/layout/Header.js
@@ -34,6 +34,7 @@ class Header extends Component {
   render() {
     const { currentUser } = this.props;
     const { currentYear } = this.props;
+    const { showAutoSave } = this.props;
     const { email } = currentUser;
     const isLoggedIn = !!currentUser.username;
     return (
@@ -52,7 +53,7 @@ class Header extends Component {
               </div>
               <div className="user-details ds-l-col--8 ds-u-padding--2">
                 <div className="ds-l-row">
-                  <Autosave />
+                  {showAutoSave && <Autosave />}
                   {isLoggedIn && renderMenu(this.toggleUserNav, email)}
                 </div>
               </div>

--- a/services/ui-src/src/components/layout/Header.test.js
+++ b/services/ui-src/src/components/layout/Header.test.js
@@ -58,7 +58,7 @@ describe("Test Header", () => {
     const wrapper = mount(header);
     expect(wrapper.containsMatchingElement(<Autosave />)).toEqual(false);
   });
-  it("should show the autosave component when passed by prop ", () => {
+  it("should show the autosave component when prop passed is true", () => {
     const wrapper = mount(headerWithAutosave);
     expect(wrapper.containsMatchingElement(<Autosave />)).toEqual(true);
   });

--- a/services/ui-src/src/components/layout/Header.test.js
+++ b/services/ui-src/src/components/layout/Header.test.js
@@ -5,6 +5,8 @@ import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
 import Header from "./Header";
 import Autosave from "./Autosave";
+import { MemoryRouter } from "react-router";
+import { screen, render } from "@testing-library/react";
 
 const mockStore = configureMockStore();
 const store = mockStore({
@@ -31,13 +33,17 @@ const store = mockStore({
 
 const header = (
   <Provider store={store}>
-    <Header />
+    <MemoryRouter initialEntries={["/"]}>
+      <Header />
+    </MemoryRouter>
   </Provider>
 );
 
 const headerWithAutosave = (
   <Provider store={store}>
-    <Header showAutoSave />
+    <MemoryRouter initialEntries={["/views/sections/"]}>
+      <Header />
+    </MemoryRouter>
   </Provider>
 );
 
@@ -50,15 +56,15 @@ describe("Test Header", () => {
     expect(wrapper.find({ "data-testid": "usaBanner" }).length).toBe(1);
   });
   it("should have the current year reporting year in the header", () => {
-    const wrapper = mount(header);
-    const results = wrapper.find({ "data-testid": "cartsCurrentYear" }).html();
-    expect(results.includes(2077)).toBeTruthy();
+    render(header);
+    const currentYearElement = screen.getByTestId("cartsCurrentYear");
+    expect(currentYearElement).toHaveTextContent(2077);
   });
   it("should not show the autosave component by default ", () => {
     const wrapper = mount(header);
     expect(wrapper.containsMatchingElement(<Autosave />)).toEqual(false);
   });
-  it("should show the autosave component when prop passed is true", () => {
+  it("should show autosave component when on a report", () => {
     const wrapper = mount(headerWithAutosave);
     expect(wrapper.containsMatchingElement(<Autosave />)).toEqual(true);
   });

--- a/services/ui-src/src/components/layout/Header.test.js
+++ b/services/ui-src/src/components/layout/Header.test.js
@@ -4,6 +4,7 @@ import { axe } from "jest-axe";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
 import Header from "./Header";
+import Autosave from "./Autosave";
 
 const mockStore = configureMockStore();
 const store = mockStore({
@@ -34,6 +35,12 @@ const header = (
   </Provider>
 );
 
+const headerWithAutosave = (
+  <Provider store={store}>
+    <Header showAutoSave />
+  </Provider>
+);
+
 describe("Test Header", () => {
   it("should render the Header Component correctly", () => {
     expect(shallow(header).exists()).toBe(true);
@@ -46,6 +53,14 @@ describe("Test Header", () => {
     const wrapper = mount(header);
     const results = wrapper.find({ "data-testid": "cartsCurrentYear" }).html();
     expect(results.includes(2077)).toBeTruthy();
+  });
+  it("should not show the autosave component by default ", () => {
+    const wrapper = mount(header);
+    expect(wrapper.containsMatchingElement(<Autosave />)).toEqual(false);
+  });
+  it("should show the autosave component when passed by prop ", () => {
+    const wrapper = mount(headerWithAutosave);
+    expect(wrapper.containsMatchingElement(<Autosave />)).toEqual(true);
   });
 });
 

--- a/services/ui-src/src/components/sections/homepage/ReportItem.js
+++ b/services/ui-src/src/components/sections/homepage/ReportItem.js
@@ -91,9 +91,9 @@ const ReportItem = ({
             {theDateTime[0]} at {theDateTime[1]} by {username}
           </div>
           <div className="actions ds-l-col--1">
-            <a href={link1URL} target={anchorTarget}>
+            <Link to={link1URL} target={anchorTarget}>
               {link1Text}
-            </a>
+            </Link>
           </div>
           {statusText === "Certified" &&
           (userRole === UserRoles.CO || userRole === UserRoles.BO) ? (
@@ -126,9 +126,9 @@ const ReportItem = ({
             {lastChanged && new Date(lastChanged)?.toLocaleDateString("en-US")}
           </div>
           <div className="actions ds-l-col--1">
-            <a href={link1URL} target={anchorTarget}>
+            <Link to={link1URL} target={anchorTarget}>
               {link1Text}
-            </a>
+            </Link>
           </div>
         </div>
       )}

--- a/services/ui-src/src/components/sections/homepage/ReportItem.js
+++ b/services/ui-src/src/components/sections/homepage/ReportItem.js
@@ -91,9 +91,9 @@ const ReportItem = ({
             {theDateTime[0]} at {theDateTime[1]} by {username}
           </div>
           <div className="actions ds-l-col--1">
-            <Link to={link1URL} target={anchorTarget}>
+            <a href={link1URL} target={anchorTarget}>
               {link1Text}
-            </Link>
+            </a>
           </div>
           {statusText === "Certified" &&
           (userRole === UserRoles.CO || userRole === UserRoles.BO) ? (
@@ -126,9 +126,9 @@ const ReportItem = ({
             {lastChanged && new Date(lastChanged)?.toLocaleDateString("en-US")}
           </div>
           <div className="actions ds-l-col--1">
-            <Link to={link1URL} target={anchorTarget}>
+            <a href={link1URL} target={anchorTarget}>
               {link1Text}
-            </Link>
+            </a>
           </div>
         </div>
       )}

--- a/services/ui-src/src/setupTests.js
+++ b/services/ui-src/src/setupTests.js
@@ -5,6 +5,7 @@
  * learn more: https://github.com/testing-library/jest-dom
  */
 import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/extend-expect";
 import "jest-axe/extend-expect";
 
 import { configure } from "enzyme";


### PR DESCRIPTION
# Description

Fixes [MDCT-292 - Remove autosave where not needed](https://qmacbis.atlassian.net/browse/MDCT-292). The autosave in the header should no longer show unless you're on a specific report that is meant to be autosaved. It also cleans up the interactions between webpages. Before we were not using react-router-dom's Links and were using regular a tags. While this provides for a smoother transition between pages, that might not be the intended outcome here. Please let me know if the a tags were intentional or if the new Link causes unexpected behavior.

## How to test

`./dev local`

Click around the app and checkout the various pages.

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
