### PR TITLE
MDCT-292: Autosave Hotfix

### DIFF
--- a/services/ui-src/src/components/layout/Header.js
+++ b/services/ui-src/src/components/layout/Header.js
@@ -39,7 +39,7 @@ class Header extends Component {
   showAutoSaveOnReport = (location, currentUser, reportStatus) => {
     const { role } = currentUser;
     if (location.pathname.includes("/sections/") && role === UserRoles.STATE) {
-      switch (reportStatus) {
+      switch (reportStatus.status) {
         case REPORT_STATUS.not_started:
         case REPORT_STATUS.in_progress:
         case REPORT_STATUS.uncertified:
@@ -90,7 +90,7 @@ class Header extends Component {
                   {this.showAutoSaveOnReport(
                     location,
                     currentUser,
-                    reportStatus.status
+                    reportStatus
                   ) && <Autosave />}
                   {isLoggedIn &&
                     renderDropDownMenu(

--- a/services/ui-src/src/components/layout/Header.js
+++ b/services/ui-src/src/components/layout/Header.js
@@ -5,6 +5,8 @@ import Autosave from "./Autosave";
 import Logout from "./Logout";
 import UsaBanner from "@cmsgov/design-system/dist/components/UsaBanner/UsaBanner";
 import { Link, withRouter } from "react-router-dom";
+import { getCurrentReportStatus } from "../../store/selectors";
+import { REPORT_STATUS, UserRoles } from "../../types";
 
 class Header extends Component {
   constructor() {
@@ -26,6 +28,29 @@ class Header extends Component {
     });
   };
 
+  findDiff = (str1, str2) => {
+    let diff = "";
+    str2.split("").forEach((val, i) => {
+      if (val != str1.charAt(i)) diff += val;
+    });
+    return diff;
+  };
+
+  showAutoSaveOnReport = (location, currentUser, reportStatus) => {
+    const { role } = currentUser;
+    if (location.pathname.includes("/sections/") && role === UserRoles.STATE) {
+      switch (reportStatus) {
+        case REPORT_STATUS.not_started:
+        case REPORT_STATUS.in_progress:
+        case REPORT_STATUS.uncertified:
+          return true;
+        default:
+          return false;
+      }
+    }
+    return false;
+  };
+
   componentDidUpdate() {
     const { isMenuOpen } = this.state;
     setTimeout(() => {
@@ -40,10 +65,10 @@ class Header extends Component {
   render() {
     const { currentUser } = this.props;
     const { currentYear } = this.props;
+    const { reportStatus } = this.props;
     const { location } = this.props;
     const { email } = currentUser;
     const isLoggedIn = !!currentUser.username;
-    const showAutoSave = location.pathname.includes("/views/sections/");
     const { isMenuOpen } = this.state;
 
     return (
@@ -62,7 +87,11 @@ class Header extends Component {
               </div>
               <div className="user-details ds-l-col--8 ds-u-padding--2">
                 <div data-testid={"userDetailsRow"} className="ds-l-row">
-                  {showAutoSave && <Autosave />}
+                  {this.showAutoSaveOnReport(
+                    location,
+                    currentUser,
+                    reportStatus.status
+                  ) && <Autosave />}
                   {isLoggedIn &&
                     renderDropDownMenu(
                       isMenuOpen,
@@ -129,11 +158,13 @@ function renderDropDownMenu(isMenuOpen, toggleDropDownMenu, email) {
 Header.propTypes = {
   currentUser: PropTypes.object.isRequired,
   currentYear: PropTypes.number.isRequired,
+  reportStatus: PropTypes.object.isRequired,
 };
 
 const mapStateToProps = (state) => ({
   currentUser: state.stateUser.currentUser,
   currentYear: state.global.currentYear,
+  reportStatus: getCurrentReportStatus(state),
 });
 
 export default connect(mapStateToProps)(withRouter(Header));

--- a/services/ui-src/src/components/layout/Header.js
+++ b/services/ui-src/src/components/layout/Header.js
@@ -62,6 +62,11 @@ class Header extends Component {
     const { email } = currentUser;
     const isLoggedIn = !!currentUser.username;
     const { isMenuOpen } = this.state;
+    const shouldShowAutosave = this.showAutoSaveOnReport(
+      location,
+      currentUser,
+      reportStatus
+    );
 
     return (
       <div className="component-header" data-test="component-header">
@@ -79,11 +84,7 @@ class Header extends Component {
               </div>
               <div className="user-details ds-l-col--8 ds-u-padding--2">
                 <div data-testid={"userDetailsRow"} className="ds-l-row">
-                  {this.showAutoSaveOnReport(
-                    location,
-                    currentUser,
-                    reportStatus
-                  ) && <Autosave />}
+                  {shouldShowAutosave && <Autosave />}
                   {isLoggedIn &&
                     renderDropDownMenu(
                       isMenuOpen,

--- a/services/ui-src/src/components/layout/Header.js
+++ b/services/ui-src/src/components/layout/Header.js
@@ -28,14 +28,6 @@ class Header extends Component {
     });
   };
 
-  findDiff = (str1, str2) => {
-    let diff = "";
-    str2.split("").forEach((val, i) => {
-      if (val != str1.charAt(i)) diff += val;
-    });
-    return diff;
-  };
-
   showAutoSaveOnReport = (location, currentUser, reportStatus) => {
     const { role } = currentUser;
     if (location.pathname.includes("/sections/") && role === UserRoles.STATE) {

--- a/services/ui-src/src/components/layout/Header.test.js
+++ b/services/ui-src/src/components/layout/Header.test.js
@@ -53,6 +53,133 @@ const noUserNameStore = mockStore({
   },
 });
 
+const stateUserWithReportInProgressStore = mockStore({
+  stateUser: {
+    name: "Alabama",
+    abbr: "AL",
+    imageURI: "/img/states/al.svg",
+    currentUser: {
+      username: "stateuser2@test.com",
+      state: {
+        id: "AL",
+      },
+      role: "mdctcarts-state-user",
+      lastname: "States",
+      firstname: "Frank",
+      email: "stateuser2@test.com",
+    },
+    localLogin: false,
+  },
+  global: {
+    formName: "CARTS FY",
+    largeTextBoxHeight: 6,
+    isFetching: false,
+    url: "/sections/2021/00",
+    queryParams: "",
+    currentYear: 2021,
+    formYear: 2021,
+    stateName: "Alabama",
+  },
+  reportStatus: {
+    AL2021: {
+      status: "in_progress",
+      year: 2021,
+      stateCode: "AL",
+      lastChanged: "2021-01-04 18:28:18.524133+00",
+      username: "al@test.com",
+      programType: "combo",
+    },
+  },
+  save: {
+    error: false,
+    saving: false,
+  },
+});
+
+const stateUserWithReportCertifiedStore = mockStore({
+  stateUser: {
+    name: "Alabama",
+    abbr: "AL",
+    imageURI: "/img/states/al.svg",
+    currentUser: {
+      username: "stateuser2@test.com",
+      state: {
+        id: "AL",
+      },
+      role: "mdctcarts-state-user",
+      lastname: "States",
+      firstname: "Frank",
+      email: "stateuser2@test.com",
+    },
+    localLogin: false,
+  },
+  global: {
+    formName: "CARTS FY",
+    largeTextBoxHeight: 6,
+    isFetching: false,
+    url: "/sections/2021/00",
+    queryParams: "",
+    currentYear: 2021,
+    formYear: 2021,
+    stateName: "Alabama",
+  },
+  reportStatus: {
+    AL2021: {
+      status: "certified",
+      year: 2021,
+      stateCode: "AL",
+      lastChanged: "2021-01-04 18:28:18.524133+00",
+      username: "al@test.com",
+      programType: "combo",
+    },
+  },
+  save: {
+    error: false,
+    saving: false,
+  },
+});
+
+const adminUserWithReportStore = mockStore({
+  stateUser: {
+    name: null,
+    abbr: null,
+    imageURI: null,
+    currentUser: {
+      username: "adminuser@test.com",
+      state: {},
+      role: "mdctcarts-approver",
+      lastname: "Admins",
+      firstname: "Adam",
+      email: "adminuser@test.com",
+    },
+    localLogin: false,
+  },
+  global: {
+    formName: "CARTS FY",
+    largeTextBoxHeight: 6,
+    isFetching: false,
+    url: "/",
+    queryParams: "",
+    currentYear: 2021,
+    formYear: 2021,
+    stateName: "Alabama",
+  },
+  reportStatus: {
+    AL2021: {
+      status: "in_progress",
+      year: 2021,
+      stateCode: "AL",
+      lastChanged: "2021-01-04 18:28:18.524133+00",
+      username: "al@test.com",
+      programType: "combo",
+    },
+  },
+  save: {
+    error: false,
+    saving: false,
+  },
+});
+
 const header = (
   <Provider store={store}>
     <MemoryRouter initialEntries={["/"]}>
@@ -69,9 +196,25 @@ const headerWithNoUsername = (
   </Provider>
 );
 
-const headerWithAutosave = (
-  <Provider store={store}>
-    <MemoryRouter initialEntries={["/views/sections/"]}>
+const headerOnReportPageAsStateUserThatsInProgress = (
+  <Provider store={stateUserWithReportInProgressStore}>
+    <MemoryRouter initialEntries={["/sections/2021/00"]}>
+      <Header />
+    </MemoryRouter>
+  </Provider>
+);
+
+const headerOnReportPageAsStateUserThatsCertified = (
+  <Provider store={stateUserWithReportCertifiedStore}>
+    <MemoryRouter initialEntries={["/sections/2021/00"]}>
+      <Header />
+    </MemoryRouter>
+  </Provider>
+);
+
+const headerOnReportPageAsAdminUser = (
+  <Provider store={adminUserWithReportStore}>
+    <MemoryRouter initialEntries={["views/sections/AL/2021/00/a"]}>
       <Header />
     </MemoryRouter>
   </Provider>
@@ -94,8 +237,16 @@ describe("Test Header", () => {
     const wrapper = mount(header);
     expect(wrapper.containsMatchingElement(<Autosave />)).toEqual(false);
   });
-  it("should show autosave component when on a report", () => {
-    const wrapper = mount(headerWithAutosave);
+  it("should not show the autosave when user is an admin", () => {
+    const wrapper = mount(headerOnReportPageAsAdminUser);
+    expect(wrapper.containsMatchingElement(<Autosave />)).toEqual(false);
+  });
+  it("should not show the autosave when user is an state user on a report thats certified", () => {
+    const wrapper = mount(headerOnReportPageAsStateUserThatsCertified);
+    expect(wrapper.containsMatchingElement(<Autosave />)).toEqual(false);
+  });
+  it("should show autosave component only when user is a state user, is on a report page, and status is in progress", () => {
+    const wrapper = mount(headerOnReportPageAsStateUserThatsInProgress);
     expect(wrapper.containsMatchingElement(<Autosave />)).toEqual(true);
   });
   it("should render the dropdownmenu if user is logged in", () => {

--- a/services/ui-src/src/components/layout/Header.test.js
+++ b/services/ui-src/src/components/layout/Header.test.js
@@ -7,178 +7,28 @@ import Header from "./Header";
 import Autosave from "./Autosave";
 import { MemoryRouter } from "react-router";
 import { screen, render, fireEvent } from "@testing-library/react";
+import {
+  adminUserWithReportInProgress,
+  stateUserNoUsername,
+  stateUserSimple,
+  stateUserWithReportCertified,
+  stateUserWithReportInProgress,
+} from "../../store/fakeStoreExamples";
 
 const mockStore = configureMockStore();
-const store = mockStore({
-  stateUser: {
-    currentUser: {
-      email: "garthVader@DeathStarInc.com",
-      username: "garthVader",
-      firstname: "Garth",
-      lastname: "Vader",
-      role: "",
-      state: {
-        id: "",
-      },
-    },
-  },
-  global: {
-    currentYear: 2077,
-  },
-  save: {
-    error: false,
-    saving: false,
-  },
-});
+const store = mockStore(stateUserSimple);
 
-const noUserNameStore = mockStore({
-  stateUser: {
-    currentUser: {
-      email: "garthVader@DeathStarInc.com",
-      username: "",
-      firstname: "",
-      lastname: "",
-      role: "",
-      state: {
-        id: "",
-      },
-    },
-  },
-  global: {
-    currentYear: 2077,
-  },
-  save: {
-    error: false,
-    saving: false,
-  },
-});
+const noUserNameStore = mockStore(stateUserNoUsername);
 
-const stateUserWithReportInProgressStore = mockStore({
-  stateUser: {
-    name: "Alabama",
-    abbr: "AL",
-    imageURI: "/img/states/al.svg",
-    currentUser: {
-      username: "stateuser2@test.com",
-      state: {
-        id: "AL",
-      },
-      role: "mdctcarts-state-user",
-      lastname: "States",
-      firstname: "Frank",
-      email: "stateuser2@test.com",
-    },
-    localLogin: false,
-  },
-  global: {
-    formName: "CARTS FY",
-    largeTextBoxHeight: 6,
-    isFetching: false,
-    url: "/sections/2021/00",
-    queryParams: "",
-    currentYear: 2021,
-    formYear: 2021,
-    stateName: "Alabama",
-  },
-  reportStatus: {
-    AL2021: {
-      status: "in_progress",
-      year: 2021,
-      stateCode: "AL",
-      lastChanged: "2021-01-04 18:28:18.524133+00",
-      username: "al@test.com",
-      programType: "combo",
-    },
-  },
-  save: {
-    error: false,
-    saving: false,
-  },
-});
+const stateUserWithReportInProgressStore = mockStore(
+  stateUserWithReportInProgress
+);
 
-const stateUserWithReportCertifiedStore = mockStore({
-  stateUser: {
-    name: "Alabama",
-    abbr: "AL",
-    imageURI: "/img/states/al.svg",
-    currentUser: {
-      username: "stateuser2@test.com",
-      state: {
-        id: "AL",
-      },
-      role: "mdctcarts-state-user",
-      lastname: "States",
-      firstname: "Frank",
-      email: "stateuser2@test.com",
-    },
-    localLogin: false,
-  },
-  global: {
-    formName: "CARTS FY",
-    largeTextBoxHeight: 6,
-    isFetching: false,
-    url: "/sections/2021/00",
-    queryParams: "",
-    currentYear: 2021,
-    formYear: 2021,
-    stateName: "Alabama",
-  },
-  reportStatus: {
-    AL2021: {
-      status: "certified",
-      year: 2021,
-      stateCode: "AL",
-      lastChanged: "2021-01-04 18:28:18.524133+00",
-      username: "al@test.com",
-      programType: "combo",
-    },
-  },
-  save: {
-    error: false,
-    saving: false,
-  },
-});
+const stateUserWithReportCertifiedStore = mockStore(
+  stateUserWithReportCertified
+);
 
-const adminUserWithReportStore = mockStore({
-  stateUser: {
-    name: null,
-    abbr: null,
-    imageURI: null,
-    currentUser: {
-      username: "adminuser@test.com",
-      state: {},
-      role: "mdctcarts-approver",
-      lastname: "Admins",
-      firstname: "Adam",
-      email: "adminuser@test.com",
-    },
-    localLogin: false,
-  },
-  global: {
-    formName: "CARTS FY",
-    largeTextBoxHeight: 6,
-    isFetching: false,
-    url: "/",
-    queryParams: "",
-    currentYear: 2021,
-    formYear: 2021,
-    stateName: "Alabama",
-  },
-  reportStatus: {
-    AL2021: {
-      status: "in_progress",
-      year: 2021,
-      stateCode: "AL",
-      lastChanged: "2021-01-04 18:28:18.524133+00",
-      username: "al@test.com",
-      programType: "combo",
-    },
-  },
-  save: {
-    error: false,
-    saving: false,
-  },
-});
+const adminUserWithReportStore = mockStore(adminUserWithReportInProgress);
 
 const header = (
   <Provider store={store}>

--- a/services/ui-src/src/store/fakeStoreExamples.js
+++ b/services/ui-src/src/store/fakeStoreExamples.js
@@ -1,0 +1,170 @@
+export const stateUserSimple = {
+  stateUser: {
+    currentUser: {
+      email: "garthVader@DeathStarInc.com",
+      username: "garthVader",
+      firstname: "Garth",
+      lastname: "Vader",
+      role: "",
+      state: {
+        id: "",
+      },
+    },
+  },
+  global: {
+    currentYear: 2077,
+  },
+  save: {
+    error: false,
+    saving: false,
+  },
+};
+
+export const stateUserNoUsername = {
+  stateUser: {
+    currentUser: {
+      email: "garthVader@DeathStarInc.com",
+      username: "",
+      firstname: "",
+      lastname: "",
+      role: "",
+      state: {
+        id: "",
+      },
+    },
+  },
+  global: {
+    currentYear: 2077,
+  },
+  save: {
+    error: false,
+    saving: false,
+  },
+};
+
+export const stateUserWithReportInProgress = {
+  stateUser: {
+    name: "Alabama",
+    abbr: "AL",
+    imageURI: "/img/states/al.svg",
+    currentUser: {
+      username: "stateuser2@test.com",
+      state: {
+        id: "AL",
+      },
+      role: "mdctcarts-state-user",
+      lastname: "States",
+      firstname: "Frank",
+      email: "stateuser2@test.com",
+    },
+    localLogin: false,
+  },
+  global: {
+    formName: "CARTS FY",
+    largeTextBoxHeight: 6,
+    isFetching: false,
+    url: "/sections/2021/00",
+    queryParams: "",
+    currentYear: 2021,
+    formYear: 2021,
+    stateName: "Alabama",
+  },
+  reportStatus: {
+    AL2021: {
+      status: "in_progress",
+      year: 2021,
+      stateCode: "AL",
+      lastChanged: "2021-01-04 18:28:18.524133+00",
+      username: "al@test.com",
+      programType: "combo",
+    },
+  },
+  save: {
+    error: false,
+    saving: false,
+  },
+};
+
+export const stateUserWithReportCertified = {
+  stateUser: {
+    name: "Alabama",
+    abbr: "AL",
+    imageURI: "/img/states/al.svg",
+    currentUser: {
+      username: "stateuser2@test.com",
+      state: {
+        id: "AL",
+      },
+      role: "mdctcarts-state-user",
+      lastname: "States",
+      firstname: "Frank",
+      email: "stateuser2@test.com",
+    },
+    localLogin: false,
+  },
+  global: {
+    formName: "CARTS FY",
+    largeTextBoxHeight: 6,
+    isFetching: false,
+    url: "/sections/2021/00",
+    queryParams: "",
+    currentYear: 2021,
+    formYear: 2021,
+    stateName: "Alabama",
+  },
+  reportStatus: {
+    AL2021: {
+      status: "certified",
+      year: 2021,
+      stateCode: "AL",
+      lastChanged: "2021-01-04 18:28:18.524133+00",
+      username: "al@test.com",
+      programType: "combo",
+    },
+  },
+  save: {
+    error: false,
+    saving: false,
+  },
+};
+
+export const adminUserWithReportInProgress = {
+  stateUser: {
+    name: null,
+    abbr: null,
+    imageURI: null,
+    currentUser: {
+      username: "adminuser@test.com",
+      state: {},
+      role: "mdctcarts-approver",
+      lastname: "Admins",
+      firstname: "Adam",
+      email: "adminuser@test.com",
+    },
+    localLogin: false,
+  },
+  global: {
+    formName: "CARTS FY",
+    largeTextBoxHeight: 6,
+    isFetching: false,
+    url: "/",
+    queryParams: "",
+    currentYear: 2021,
+    formYear: 2021,
+    stateName: "Alabama",
+  },
+  reportStatus: {
+    AL2021: {
+      status: "in_progress",
+      year: 2021,
+      stateCode: "AL",
+      lastChanged: "2021-01-04 18:28:18.524133+00",
+      username: "al@test.com",
+      programType: "combo",
+    },
+  },
+  save: {
+    error: false,
+    saving: false,
+  },
+};

--- a/services/ui-src/src/store/fakeStoreExamples.js
+++ b/services/ui-src/src/store/fakeStoreExamples.js
@@ -18,6 +18,7 @@ export const stateUserSimple = {
     error: false,
     saving: false,
   },
+  reportStatus: {},
 };
 
 export const stateUserNoUsername = {
@@ -40,6 +41,7 @@ export const stateUserNoUsername = {
     error: false,
     saving: false,
   },
+  reportStatus: {},
 };
 
 export const stateUserWithReportInProgress = {

--- a/services/ui-src/src/store/selectors.js
+++ b/services/ui-src/src/store/selectors.js
@@ -147,7 +147,7 @@ export const selectSectionsForNav = (state) => {
  * @returns {object} The reportStatus object associated with the current report
  */
 export const getCurrentReportStatus = (state) => {
-  if (state.reportStatus.status === null) {
+  if (!state.reportStatus || state.reportStatus.status === null) {
     return { status: "" };
   }
 
@@ -157,11 +157,12 @@ export const getCurrentReportStatus = (state) => {
   if (stateUser.currentUser.role === UserRoles.STATE) {
     currentReport = `${stateUser.abbr}${global.formYear}`;
   } else {
+    if (formData?.[0] === undefined) return { status: "" };
     currentReport = `${formData[0].stateId}${formData[0].year}`;
   }
 
   const status = reportStatus[currentReport];
-  return status;
+  return status !== undefined ? status : { status: "" };
 };
 
 /**

--- a/services/ui-src/src/store/selectors.js
+++ b/services/ui-src/src/store/selectors.js
@@ -147,22 +147,18 @@ export const selectSectionsForNav = (state) => {
  * @returns {object} The reportStatus object associated with the current report
  */
 export const getCurrentReportStatus = (state) => {
-  if (!state.reportStatus || state.reportStatus.status === null) {
-    return { status: "" };
-  }
-
   const { reportStatus, formData, stateUser, global } = state;
 
   let currentReport = "";
   if (stateUser.currentUser.role === UserRoles.STATE) {
     currentReport = `${stateUser.abbr}${global.formYear}`;
   } else {
-    if (formData?.[0] === undefined) return { status: "" };
+    if (formData?.[0] === undefined) return {};
     currentReport = `${formData[0].stateId}${formData[0].year}`;
   }
 
   const status = reportStatus[currentReport];
-  return status !== undefined ? status : { status: "" };
+  return status || {};
 };
 
 /**


### PR DESCRIPTION
# Description

Hotfix for the Autosave showing in the header. This should now make it so the autosave only shows for State users who are viewing a report that's status is Not Started, In Progress, or Uncertified. 

## How to test

`./dev local`

- Sign in as stateuser2@test.com. Only state users should ever see the autosave in the header.
- Click on a report. If it is In Progress, Uncertified, or Not Started it should show the autosave in the header. Every other scenario or page should not show the autosave in the header.
- Sign out and sign in as another user (Like adminuser@test.com). 
- If the user is an admin, they should never see the autosave on any page they go to.

## Dependencies

Please spell out any dependencies for this change -- ex -- requires an install / update / migration etc

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
