### PR TITLE
MDCT-130: Prepare for data layer migration to new aws accounts

### DIFF
--- a/.github/build_vars.sh
+++ b/.github/build_vars.sh
@@ -15,7 +15,6 @@ var_list=(
   'TF_VAR_acm_certificate_domain_ui'
   'TF_VAR_acm_certificate_domain_api_postgres'
   'TF_VAR_skip_data_deployment'
-  'TF_VAR_postgres_custom_password'
   'TF_VAR_use_custom_db_password_info'
 )
 

--- a/.github/workflows/master-deploy.yml
+++ b/.github/workflows/master-deploy.yml
@@ -62,7 +62,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
         with:
-          registries: ${{ secrets.POSTGRES_DEPLOYER_ACCOUNT_ID }}
+          registries: ${{ secrets.MASTER_POSTGRES_DEPLOYER_ACCOUNT_ID }}
       - name: Build, tag, and push postgres_deployer (data layer) image
         id: postgres_deployer_build
         env:

--- a/.github/workflows/master-deploy.yml
+++ b/.github/workflows/master-deploy.yml
@@ -19,6 +19,7 @@ env:
   ECR_REPOSITORY_POSTGRESS_DEPLOYER: "postgres_deployer"
   ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
   DATALAYER_IN_NEW_ACCOUNTS: ${{ secrets.MASTER_DATALAYER_IN_NEW_ACCOUNTS == 'master-datalayer-in-new-accounts' }}
+  USE_CUSTOM_PASSWORD: ${{ secrets.MASTER_USE_CUSTOM_PASSWORD == 'master-use-custom-password' }}
 
 jobs:
   build-info:
@@ -60,6 +61,8 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registries: ${{ secrets.POSTGRES_DEPLOYER_ACCOUNT_ID }}
       - name: Build, tag, and push postgres_deployer (data layer) image
         id: postgres_deployer_build
         env:
@@ -263,8 +266,7 @@ jobs:
           APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
           TF_VAR_acm_certificate_domain_ui: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
           TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
-          TF_VAR_postgres_custom_password: ${{secrets.MASTER_TF_VAR_POSTGRES_CUSTOM_PASSWORD}}
-          TF_VAR_use_custom_db_password_info: true
+          TF_VAR_use_custom_db_password_info: ${{ env.USE_CUSTOM_PASSWORD }}
   serverless:
     needs:
       - data

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -51,7 +51,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
         with:
-          registries: ${{ secrets.POSTGRES_DEPLOYER_ACCOUNT_ID }}
+          registries: ${{ secrets.PROD_POSTGRES_DEPLOYER_ACCOUNT_ID }}
       - name: Scan postgres_deployer(data layer) Docker image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -28,6 +28,7 @@ env:
   ECR_REPOSITORY_POSTGRESS_DEPLOYER: "postgres_deployer"
   ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
   DATALAYER_IN_NEW_ACCOUNTS: ${{ secrets.PROD_DATALAYER_IN_NEW_ACCOUNTS == 'prod-datalayer-in-new-accounts' }}
+  USE_CUSTOM_PASSWORD: ${{ secrets.PROD_USE_CUSTOM_PASSWORD == 'prod-use-custom-password' }}
 
 jobs:
   scan-postgres_deployer:
@@ -49,6 +50,8 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registries: ${{ secrets.POSTGRES_DEPLOYER_ACCOUNT_ID }}
       - name: Scan postgres_deployer(data layer) Docker image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -199,8 +202,7 @@ jobs:
           APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
           TF_VAR_acm_certificate_domain_ui: ${{secrets.PROD_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
           TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.PROD_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
-          TF_VAR_postgres_custom_password: ${{secrets.PROD_TF_VAR_POSTGRES_CUSTOM_PASSWORD}}
-          TF_VAR_use_custom_db_password_info: true
+          TF_VAR_use_custom_db_password_info: ${{ env.USE_CUSTOM_PASSWORD }}
   serverless:
     needs:
       - data

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -51,7 +51,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
         with:
-          registries: ${{ secrets.POSTGRES_DEPLOYER_ACCOUNT_ID }}
+          registries: ${{ secrets.STAGING_POSTGRES_DEPLOYER_ACCOUNT_ID }}
       - name: Scan postgres_deployer(data layer) Docker image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -28,6 +28,7 @@ env:
   ECR_REPOSITORY_POSTGRESS_DEPLOYER: "postgres_deployer"
   ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
   DATALAYER_IN_NEW_ACCOUNTS: ${{ secrets.STAGING_DATALAYER_IN_NEW_ACCOUNTS == 'staging-datalayer-in-new-accounts' }}
+  USE_CUSTOM_PASSWORD: ${{ secrets.STAGING_USE_CUSTOM_PASSWORD == 'staging-use-custom-password' }}
 
 jobs:
   scan-postgres_deployer:
@@ -49,6 +50,8 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registries: ${{ secrets.POSTGRES_DEPLOYER_ACCOUNT_ID }}
       - name: Scan postgres_deployer(data layer) Docker image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -199,8 +202,7 @@ jobs:
           APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
           TF_VAR_acm_certificate_domain_ui: ${{secrets.STAGING_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
           TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.STAGING_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
-          TF_VAR_postgres_custom_password: ${{secrets.STAGING_TF_VAR_POSTGRES_CUSTOM_PASSWORD}}
-          TF_VAR_use_custom_db_password_info: true
+          TF_VAR_use_custom_db_password_info: ${{ env.USE_CUSTOM_PASSWORD }}
   serverless:
     needs:
       - data


### PR DESCRIPTION
# Description

Some final changes to get ready to switch the data layer over to the new aws accounts.

1. Allow configuring whether to use the custom db password ssm parameter or not at deploy time using github secrets (migrated accounts will at first not have this parameter set).
2. Explicitly set the ECR registry account to use for the postgres deployer image. Needed for staging and prod as they will be pulling the image from a registry other than on their own account (They will pull the image built and pushed to the dev account).

Secrets have already been added.

```
❯ gh secret list | grep POSTGRES_DEPLOYER_ACCOUNT_ID
MASTER_POSTGRES_DEPLOYER_ACCOUNT_ID     2022-06-02
PROD_POSTGRES_DEPLOYER_ACCOUNT_ID       2022-06-02
STAGING_POSTGRES_DEPLOYER_ACCOUNT_ID    2022-06-02

❯ gh secret list | grep USE_CUSTOM_PASSWORD
MASTER_USE_CUSTOM_PASSWORD      2022-06-02
PROD_USE_CUSTOM_PASSWORD        2022-06-02
STAGING_USE_CUSTOM_PASSWORD     2022-06-02
```
## How to test

Nothing to test in this PR, will be tested as part of MDCT-130

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [x] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [x] I have closed the PR after the review and necessary changes (squashing preferred)
