### PR TITLE
Allow setting postgres deploy image to come from another account

### DIFF
--- a/.github/workflows/master-deploy.yml
+++ b/.github/workflows/master-deploy.yml
@@ -216,6 +216,7 @@ jobs:
           BUILD_TAG: ${{ needs.build-info.outputs.build_tag }}
           TF_VAR_skip_data_deployment: true
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.MASTER_RESTORE_SNAPSHOT_ID}}
+          TF_VAR_postgres_deployer_registry_id: ${{secrets.MASTER_POSTGRES_DEPLOYER_ACCOUNT_ID}}
   frontend:
     needs:
       - build-info

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -153,6 +153,7 @@ jobs:
           APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
           TF_VAR_skip_data_deployment: true
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.PROD_RESTORE_SNAPSHOT_ID}}
+          TF_VAR_postgres_deployer_registry_id: ${{secrets.PROD_POSTGRES_DEPLOYER_ACCOUNT_ID}}
   frontend:
     needs:
       - data

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -153,6 +153,7 @@ jobs:
           APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
           TF_VAR_skip_data_deployment: true
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.STAGING_RESTORE_SNAPSHOT_ID}}
+          TF_VAR_postgres_deployer_registry_id: ${{secrets.STAGING_POSTGRES_DEPLOYER_ACCOUNT_ID}}
   frontend:
     needs:
       - data

--- a/data/aws/ecs_postgres_deployer.tf
+++ b/data/aws/ecs_postgres_deployer.tf
@@ -13,7 +13,8 @@ locals {
 # Create a postgres_deployer ECS Task Def to bootstrap postgres RDS with users, tables, etc
 ####################################################################################################
 data "aws_ecr_repository" "postgres_deployer" {
-  name = "postgres_deployer"
+  name        = "postgres_deployer"
+  registry_id = var.postgres_deployer_registry_id
 }
 
 resource "aws_ecs_task_definition" "postgres_deployer" {

--- a/data/aws/variables.tf
+++ b/data/aws/variables.tf
@@ -20,3 +20,9 @@ variable "postgres_restore_snapshot_id" {
   type        = string
   description = "The PostgreSQL database snapshot used to restore or recreate the database"
 }
+
+variable "postgres_deployer_registry_id" {
+  default     = null
+  type        = string
+  description = "The AWS Account ID where the postgres deployer repository is located"
+}


### PR DESCRIPTION
# Description

This is needed to fix staging and ensure that when terraform attempts to pull the registry information that it can pull it from another account.

## How to test

I test this locally running terraform plan against the staging environment.

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
