### PR TITLE
Allow scans from other accounts

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -54,12 +54,12 @@ jobs:
           registries: ${{ secrets.PROD_POSTGRES_DEPLOYER_ACCOUNT_ID }}
       - name: Scan postgres_deployer(data layer) Docker image
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY_ID: ${{ secrets.PROD_POSTGRES_DEPLOYER_ACCOUNT_ID }}
           ECR_REPOSITORY: ${{env.ECR_REPOSITORY_POSTGRESS_DEPLOYER }}
           IMAGE_TAG: ${{ github.event.inputs.version }}
         run: |
-          aws ecr wait image-scan-complete --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG
-          aws ecr describe-image-scan-findings --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --output json | tee ecr_scan_result_$ECR_REPOSITORY_POSTGRESS_DEPLOYER.json >/dev/null
+          aws ecr wait image-scan-complete --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --registry-id $ECR_REGISTRY_ID
+          aws ecr describe-image-scan-findings --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --registry-id $ECR_REGISTRY_ID --output json | tee ecr_scan_result_$ECR_REPOSITORY_POSTGRESS_DEPLOYER.json >/dev/null
       - name: Archive ecr images scan results
         if: ${{ always() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -54,12 +54,12 @@ jobs:
           registries: ${{ secrets.STAGING_POSTGRES_DEPLOYER_ACCOUNT_ID }}
       - name: Scan postgres_deployer(data layer) Docker image
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY_ID: ${{ secrets.STAGING_POSTGRES_DEPLOYER_ACCOUNT_ID }}
           ECR_REPOSITORY: ${{env.ECR_REPOSITORY_POSTGRESS_DEPLOYER }}
           IMAGE_TAG: ${{ github.event.inputs.version }}
         run: |
-          aws ecr wait image-scan-complete --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG
-          aws ecr describe-image-scan-findings --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --output json | tee ecr_scan_result_$ECR_REPOSITORY_POSTGRESS_DEPLOYER.json >/dev/null
+          aws ecr wait image-scan-complete --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --registry-id $ECR_REGISTRY_ID
+          aws ecr describe-image-scan-findings --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --registry-id $ECR_REGISTRY_ID --output json | tee ecr_scan_result_$ECR_REPOSITORY_POSTGRESS_DEPLOYER.json >/dev/null
       - name: Archive ecr images scan results
         if: ${{ always() }}
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
# Description

ECS scans need to also have their registry id set when checking the scans from another account.

## How to test

Ran these commands locally with staging creds and ensured they worked.

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
