### PR TITLE
MDCT-270.1: Print a Single Section (PDF)

### DIFF
--- a/services/ui-src/src/components/layout/FormActions.js
+++ b/services/ui-src/src/components/layout/FormActions.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { Button } from "@cmsgov/design-system";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPrint, faWindowClose } from "@fortawesome/free-solid-svg-icons";
-import { connect, useDispatch } from "react-redux";
+import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import { UserRoles } from "../../types";
 
@@ -16,7 +16,6 @@ const FormActions = (props) => {
   // Initialise printDialogeRef
   const printDialogeRef = useRef(null);
   const { currentUser, formYear } = props;
-  const dispatch = useDispatch();
 
   // Get section IDs and subsection IDs for printing single section
   let searchParams = document.location.pathname

--- a/services/ui-src/src/components/layout/FormActions.js
+++ b/services/ui-src/src/components/layout/FormActions.js
@@ -18,14 +18,26 @@ const FormActions = (props) => {
   const { currentUser, formYear } = props;
   const dispatch = useDispatch();
 
+  // Get section IDs and subsection IDs for printing single section
+  let searchParams = document.location.pathname
+    .toString()
+    .replace("/sections/", "")
+    .replace(formYear + "/", "");
+
+  const sectionId = formYear + "-" + searchParams.substring(0, 2);
+  let subsectionId = sectionId + "-";
+
+  if (sectionId.slice(-2) === "03") {
+    subsectionId += searchParams.slice(-1);
+  } else {
+    subsectionId += "a";
+  }
+
   /**
    * Print dialogue box state
    * Defaults to false
    */
   const [printShow, setPrintShow] = useState(false);
-
-  const searchParams = document.location.toString();
-  console.log(searchParams);
 
   /**
    * If click occurs outside component, setPrintShow to false
@@ -58,14 +70,6 @@ const FormActions = (props) => {
   };
 
   /**
-   * Set print type
-   */
-  const setPrintType = (printType) => {
-    dispatch({ type: "UPDATE_PRINT_TYPE", printType: printType });
-    togglePrintDialogue();
-  };
-
-  /**
    * Generates the URL to print a form.
    * @param {object} currentUser - the current user object
    * @param {string} formYear - the year associated with the report
@@ -74,8 +78,8 @@ const FormActions = (props) => {
   const printFormUrl = (
     currentUser,
     formYear,
-    section = null,
-    subSection = null
+    sectionId = null,
+    subsectionId = null
   ) => {
     let stateId = "";
 
@@ -86,11 +90,13 @@ const FormActions = (props) => {
     }
 
     let urlString = `/print?year=${formYear}&state=${stateId}`;
-    if (section) {
-      urlString += `&sectionId=${section}`;
+
+    if (sectionId) {
+      urlString += `&sectionId=${sectionId}`;
     }
-    if (subSection) {
-      urlString += `&subsectionId=${subSection}`;
+
+    if (subsectionId) {
+      urlString += `&subsectionId=${subsectionId}`;
     }
 
     return urlString;
@@ -126,12 +132,12 @@ const FormActions = (props) => {
                 href={printFormUrl(
                   currentUser,
                   formYear,
-                  sectionParam,
-                  subsectionParam
+                  sectionId,
+                  subsectionId
                 )}
                 title="This Section"
                 target="_blank"
-                onClick={() => setPrintType("section")}
+                onClick={togglePrintDialogue}
               >
                 <FontAwesomeIcon icon={faPrint} /> This Section
               </Button>
@@ -142,7 +148,7 @@ const FormActions = (props) => {
                 href={printFormUrl(currentUser, formYear)}
                 title="Entire Form"
                 target="_blank"
-                onClick={() => setPrintType("all")}
+                onClick={togglePrintDialogue}
               >
                 <FontAwesomeIcon icon={faPrint} /> Entire Form
               </Button>

--- a/services/ui-src/src/components/layout/FormActions.test.js
+++ b/services/ui-src/src/components/layout/FormActions.test.js
@@ -1,0 +1,11 @@
+import React from "react";
+import { shallow } from "enzyme";
+import FormActions from "./FormActions";
+
+const form = <FormActions />;
+
+describe("Fill Form Component", () => {
+  it("should render correctly", () => {
+    expect(shallow(form).exists()).toBe(true);
+  });
+});

--- a/services/ui-src/src/components/layout/FormActions.test.js
+++ b/services/ui-src/src/components/layout/FormActions.test.js
@@ -1,11 +1,19 @@
 import React from "react";
 import { shallow } from "enzyme";
 import FormActions from "./FormActions";
+import { Provider } from "react-redux";
+import configureMockStore from "redux-mock-store";
 
-const form = <FormActions />;
+const mockStore = configureMockStore();
+const store = mockStore({});
+const formActions = (
+  <Provider store={store}>
+    <FormActions />
+  </Provider>
+);
 
 describe("Fill Form Component", () => {
   it("should render correctly", () => {
-    expect(shallow(form).exists()).toBe(true);
+    expect(shallow(formActions).exists()).toBe(true);
   });
 });

--- a/services/ui-src/src/components/sections/Print.js
+++ b/services/ui-src/src/components/sections/Print.js
@@ -108,28 +108,44 @@ const Print = ({ currentUser, state, name }) => {
   const { formData } = state;
   if (formData !== undefined && formData.length !== 0) {
     sections.push(<Title urlStateName={stateName} />);
-    // Loop through each section to get sectionId
-    /* eslint-disable no-plusplus */
-    for (let i = 0; i < formData.length; i++) {
-      const sectionId = formData[i].contents.section.id;
 
-      // Loop through subsections to get subsectionId
+    const searchParams = new URLSearchParams(window.location.search);
+
+    const sectionParam = searchParams.get("sectionId");
+    const subsectionParam = searchParams.get("subsectionId");
+
+    if (sectionParam) {
+      sections.push(
+        <Section
+          sectionId={sectionParam}
+          subsectionId={subsectionParam}
+          readonly="false"
+        />
+      );
+    } else {
+      // Loop through each section to get sectionId
       /* eslint-disable no-plusplus */
-      for (
-        let j = 0;
-        j < formData[i].contents.section.subsections.length;
-        j++
-      ) {
-        const subsectionId = formData[i].contents.section.subsections[j].id;
+      for (let i = 0; i < formData.length; i++) {
+        const sectionId = formData[i].contents.section.id;
 
-        // Add section to sections array
-        sections.push(
-          <Section
-            sectionId={sectionId}
-            subsectionId={subsectionId}
-            readonly="false"
-          />
-        );
+        // Loop through subsections to get subsectionId
+        /* eslint-disable no-plusplus */
+        for (
+          let j = 0;
+          j < formData[i].contents.section.subsections.length;
+          j++
+        ) {
+          const subsectionId = formData[i].contents.section.subsections[j].id;
+
+          // Add section to sections array
+          sections.push(
+            <Section
+              sectionId={sectionId}
+              subsectionId={subsectionId}
+              readonly="false"
+            />
+          );
+        }
       }
     }
   }

--- a/services/ui-src/src/components/sections/Print.js
+++ b/services/ui-src/src/components/sections/Print.js
@@ -23,10 +23,15 @@ import { Helmet } from "react-helmet";
 const Print = ({ currentUser, state, name }) => {
   const dispatch = useDispatch();
   const search = useLocation().search;
-  const stateInitials = new URLSearchParams(search).get("state");
+  const searchParams = new URLSearchParams(search);
+  const stateInitials = searchParams.get("state");
   const stateName =
     name || statesArray.find(({ value }) => value === stateInitials)?.label;
-  const formYear = new URLSearchParams(search).get("year");
+  const formYear = searchParams.get("year");
+  const sectionId = searchParams.get("sectionId");
+  const subsectionId = searchParams.get("subsectionId");
+
+  console.log(sectionId, subsectionId);
 
   const openPdf = (basePdf) => {
     let byteCharacters = atob(basePdf);
@@ -109,16 +114,12 @@ const Print = ({ currentUser, state, name }) => {
   if (formData !== undefined && formData.length !== 0) {
     sections.push(<Title urlStateName={stateName} />);
 
-    const searchParams = new URLSearchParams(window.location.search);
-
-    const sectionParam = searchParams.get("sectionId");
-    const subsectionParam = searchParams.get("subsectionId");
-
-    if (sectionParam) {
+    if (sectionId) {
+      // Add section to sections array
       sections.push(
         <Section
-          sectionId={sectionParam}
-          subsectionId={subsectionParam}
+          sectionId={sectionId}
+          subsectionId={subsectionId}
           readonly="false"
         />
       );

--- a/services/ui-src/src/components/sections/Print.js
+++ b/services/ui-src/src/components/sections/Print.js
@@ -116,6 +116,7 @@ const Print = ({ currentUser, state, name }) => {
       // Add section to sections array
       sections.push(
         <Section
+          data-testid="print-section"
           sectionId={sectionId}
           subsectionId={subsectionId}
           readonly="false"
@@ -139,6 +140,7 @@ const Print = ({ currentUser, state, name }) => {
           // Add section to sections array
           sections.push(
             <Section
+              data-testid="print-section"
               sectionId={sectionId}
               subsectionId={subsectionId}
               readonly="false"

--- a/services/ui-src/src/components/sections/Print.js
+++ b/services/ui-src/src/components/sections/Print.js
@@ -31,8 +31,6 @@ const Print = ({ currentUser, state, name }) => {
   const sectionId = searchParams.get("sectionId");
   const subsectionId = searchParams.get("subsectionId");
 
-  console.log(sectionId, subsectionId);
-
   const openPdf = (basePdf) => {
     let byteCharacters = atob(basePdf);
     let byteNumbers = new Array(byteCharacters.length);

--- a/services/ui-src/src/components/sections/Print.test.js
+++ b/services/ui-src/src/components/sections/Print.test.js
@@ -3,31 +3,98 @@ import { shallow } from "enzyme";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
 import Print from "./Print";
+import { mockInitialState } from "../../util/testing/testUtils";
+import { screen, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import thunk from "redux-thunk";
 
-const mockStore = configureMockStore();
-const store = mockStore({
-  stateUser: {
-    currentUser: {
-      email: "",
-      username: "",
-      firstname: "",
-      lastname: "",
-      role: "",
-      state: {
-        id: "",
-      },
-    },
-  },
+jest.mock("../layout/Section", () => () => {
+  const MockName = "default-section";
+  return <MockName data-testid="print-section" />;
 });
-
-const printPage = (
+jest.mock("../../actions/initial", () => ({
+  loadSections: () => ({ type: "none" }),
+}));
+const mockStore = configureMockStore([thunk]);
+const formState = {
+  formData: [
+    {
+      pk: "AL-2020",
+      sectionId: 0,
+      year: 2020,
+      contents: {
+        section: {
+          subsections: [{ type: "subsection", parts: [], id: "2020-00-a" }],
+        },
+      },
+      stateId: "AL",
+    },
+    {
+      pk: "AL-2020",
+      sectionId: 1,
+      year: 2020,
+      contents: {
+        section: {
+          subsections: [{ type: "subsection", parts: [], id: "2020-01-a" }],
+        },
+      },
+      stateId: "AL",
+    },
+    {
+      pk: "AL-2020",
+      sectionId: 2,
+      year: 2020,
+      contents: {
+        section: {
+          subsections: [{ type: "subsection", parts: [], id: "2020-02-a" }],
+        },
+      },
+      stateId: "AL",
+    },
+    {
+      pk: "AL-2020",
+      sectionId: 3,
+      year: 2020,
+      contents: {
+        section: {
+          subsections: [
+            { type: "subsection", parts: [], id: "2020-03-a" },
+            { type: "subsection", parts: [], id: "2020-03-b" },
+          ],
+        },
+      },
+      stateId: "AL",
+    },
+  ],
+};
+const store = mockStore({ ...mockInitialState, ...formState });
+const setup = (path) => (
   <Provider store={store}>
-    <Print />
+    <MemoryRouter initialEntries={[path]}>
+      <Print />
+    </MemoryRouter>
   </Provider>
 );
 
 describe("Print", () => {
   it("should render the Print Component correctly", () => {
-    expect(shallow(printPage).exists()).toBe(true);
+    const path = "/print?year=2020&state=AL";
+    const printComponent = setup(path);
+    expect(shallow(printComponent).exists()).toBe(true);
+  });
+
+  it("should render for full form", () => {
+    const path = "/print?year=2020&state=AL";
+    render(setup(path));
+    const sections = screen.getAllByTestId("print-section");
+    expect(sections.length).toBe(5);
+  });
+
+  it("should render for a subsection when provided the subsection query param", () => {
+    const path =
+      "print?year=2020&state=AL&sectionId=2020-03&subsectionId=2020-03-b";
+    render(setup(path));
+    const sections = screen.getAllByTestId("print-section");
+    expect(sections.length).toBe(1);
   });
 });

--- a/services/ui-src/src/components/sections/Print.test.js
+++ b/services/ui-src/src/components/sections/Print.test.js
@@ -1,0 +1,33 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { Provider } from "react-redux";
+import configureMockStore from "redux-mock-store";
+import Print from "./Print";
+
+const mockStore = configureMockStore();
+const store = mockStore({
+  stateUser: {
+    currentUser: {
+      email: "",
+      username: "",
+      firstname: "",
+      lastname: "",
+      role: "",
+      state: {
+        id: "",
+      },
+    },
+  },
+});
+
+const printPage = (
+  <Provider store={store}>
+    <Print />
+  </Provider>
+);
+
+describe("Print", () => {
+  it("should render the Print Component correctly", () => {
+    expect(shallow(printPage).exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
# Description

Meets part of the AC in [MDCT-270](https://qmacbis.atlassian.net/browse/MDCT-270). As is right now, printing a single section of a CARTS report simply prints the window the user is on. This fix will ensure each section can be generated using Prince individually.

## How to test

`./dev local`

* View any CARTS report
* Click **Print**
* Click **This Section**

_et voilá_, you should have a single section in a new tab 💘 

## Dependencies

None.

# Get it done

Printing is one step closer, @karla-vm and @BearHanded are one level less sane.

## Code authors checklist

- [x] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
