### PR TITLE
Only allow data layer in new environments

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -19,7 +19,6 @@ env:
   BUILD_TAG: ${{ github.ref_name }}.${{ github.sha }}
   ECR_REPOSITORY_POSTGRESS_DEPLOYER: "postgres_deployer"
   ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
-  DATALAYER_IN_NEW_ACCOUNTS: ${{ secrets.DEV_DATALAYER_IN_NEW_ACCOUNTS == 'dev-datalayer-in-new-accounts' }}
 
 jobs:
   prevalidate:
@@ -42,17 +41,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-postgres_deployer-docker-cache-
       - name: Configure AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
@@ -185,17 +176,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform setup
         uses: hashicorp/setup-terraform@v2
@@ -205,8 +188,8 @@ jobs:
       - name: Deploy Data Layer
         run: ./data_layer_deploy.sh ${{env.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}}
         env:
-          VPC_NAME: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_DEV_VPC || secrets.DEV_VPC_NAME}}
-          APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
+          VPC_NAME: ${{secrets.NEW_DEV_VPC }}
+          APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.DEV_RESTORE_SNAPSHOT_ID}}
   frontend:
     needs:
@@ -219,17 +202,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure datalayer AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure datalayer AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Configure Terraform Datalayer Provider Credentials
         run: |
@@ -275,17 +250,9 @@ jobs:
           key: ${{ runner.os }}-serverless-modules-${{ hashFiles('serverless/**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-serverless-modules-
       - name: Configure AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Serverless
         working-directory: serverless

--- a/.github/workflows/dev-destroy.yml
+++ b/.github/workflows/dev-destroy.yml
@@ -17,7 +17,6 @@ env:
   BUILD_TAG: ${{ github.event.ref }}.${{ github.sha }}
   ECR_REPOSITORY_POSTGRESS_DEPLOYER: "postgres_deployer"
   ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
-  DATALAYER_IN_NEW_ACCOUNTS: ${{ secrets.DEV_DATALAYER_IN_NEW_ACCOUNTS == 'dev-datalayer-in-new-accounts' }}
 
 jobs:
   destroy-frontend:
@@ -34,17 +33,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure datalayer AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure datalayer AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Configure Terraform Datalayer Provider Credentials
         run: |
@@ -88,17 +79,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform setup
         uses: hashicorp/setup-terraform@v2
@@ -108,8 +91,8 @@ jobs:
       - name: Destroy data Layer
         run: ./data_layer_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} destroy application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}}
         env:
-          VPC_NAME: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_DEV_VPC || secrets.DEV_VPC_NAME}}
-          APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
+          VPC_NAME: ${{secrets.NEW_DEV_VPC}}
+          APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.DEV_RESTORE_SNAPSHOT_ID}}
   destroy-serverless-legacy-account:
     # Protected branches should be designated as such in the GitHub UI.

--- a/.github/workflows/master-deploy.yml
+++ b/.github/workflows/master-deploy.yml
@@ -18,7 +18,6 @@ env:
   BRANCH_NAME: ${{ github.ref_name }}
   ECR_REPOSITORY_POSTGRESS_DEPLOYER: "postgres_deployer"
   ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
-  DATALAYER_IN_NEW_ACCOUNTS: ${{ secrets.MASTER_DATALAYER_IN_NEW_ACCOUNTS == 'master-datalayer-in-new-accounts' }}
   USE_CUSTOM_PASSWORD: ${{ secrets.MASTER_USE_CUSTOM_PASSWORD == 'master-use-custom-password' }}
 
 jobs:
@@ -46,17 +45,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-postgres_deployer-docker-cache-
       - name: Configure AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
@@ -191,17 +182,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform setup
         uses: hashicorp/setup-terraform@v2
@@ -211,8 +194,8 @@ jobs:
       - name: Deploy Data Layer
         run: ./data_layer_deploy.sh ${{env.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}}
         env:
-          VPC_NAME: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_DEV_VPC || secrets.DEV_VPC_NAME}}
-          APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
+          VPC_NAME: ${{secrets.NEW_DEV_VPC}}
+          APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
           BUILD_TAG: ${{ needs.build-info.outputs.build_tag }}
           TF_VAR_skip_data_deployment: true
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.MASTER_RESTORE_SNAPSHOT_ID}}
@@ -228,17 +211,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure datalayer AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure datalayer AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Configure Terraform Datalayer Provider Credentials
         run: |
@@ -288,17 +263,9 @@ jobs:
           key: ${{ runner.os }}-serverless-modules-${{ hashFiles('serverless/**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-serverless-modules-
       - name: Configure AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Serverless
         working-directory: serverless

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -27,7 +27,6 @@ concurrency:
 env:
   ECR_REPOSITORY_POSTGRESS_DEPLOYER: "postgres_deployer"
   ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
-  DATALAYER_IN_NEW_ACCOUNTS: ${{ secrets.PROD_DATALAYER_IN_NEW_ACCOUNTS == 'prod-datalayer-in-new-accounts' }}
   USE_CUSTOM_PASSWORD: ${{ secrets.PROD_USE_CUSTOM_PASSWORD == 'prod-use-custom-password' }}
 
 jobs:
@@ -35,17 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.PROD_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
@@ -129,17 +120,9 @@ jobs:
         with:
           ref: ${{ github.event.inputs.version }}
       - name: Configure AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.PROD_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform setup
         uses: hashicorp/setup-terraform@v2
@@ -149,8 +132,8 @@ jobs:
       - name: Deploy Data Layer
         run: ./data_layer_deploy.sh ${{env.APPLICATION_BUCKET}} ${{ github.event.inputs.environment }} apply application_version=${{ github.event.inputs.version }} vpc_name=${{env.VPC_NAME}}
         env:
-          VPC_NAME: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_PROD_VPC_NAME || secrets.PROD_VPC_NAME}}
-          APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
+          VPC_NAME: ${{secrets.NEW_PROD_VPC_NAME}}
+          APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
           TF_VAR_skip_data_deployment: true
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.PROD_RESTORE_SNAPSHOT_ID}}
           TF_VAR_postgres_deployer_registry_id: ${{secrets.PROD_POSTGRES_DEPLOYER_ACCOUNT_ID}}
@@ -165,17 +148,9 @@ jobs:
         with:
           ref: ${{ github.event.inputs.version }}
       - name: Configure datalayer AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.PROD_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure datalayer AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Configure Terraform Datalayer Provider Credentials
         run: |
@@ -226,17 +201,9 @@ jobs:
           key: ${{ runner.os }}-serverless-modules-${{ hashFiles('serverless/**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-serverless-modules-
       - name: Configure AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.PROD_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Serverless
         working-directory: serverless

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -27,7 +27,6 @@ concurrency:
 env:
   ECR_REPOSITORY_POSTGRESS_DEPLOYER: "postgres_deployer"
   ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
-  DATALAYER_IN_NEW_ACCOUNTS: ${{ secrets.STAGING_DATALAYER_IN_NEW_ACCOUNTS == 'staging-datalayer-in-new-accounts' }}
   USE_CUSTOM_PASSWORD: ${{ secrets.STAGING_USE_CUSTOM_PASSWORD == 'staging-use-custom-password' }}
 
 jobs:
@@ -35,17 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.STAGING_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
@@ -129,17 +120,9 @@ jobs:
         with:
           ref: ${{ github.event.inputs.version }}
       - name: Configure AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.STAGING_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform setup
         uses: hashicorp/setup-terraform@v2
@@ -149,8 +132,8 @@ jobs:
       - name: Deploy Data Layer
         run: ./data_layer_deploy.sh ${{env.APPLICATION_BUCKET}} ${{ github.event.inputs.environment }} apply application_version=${{ github.event.inputs.version }} vpc_name=${{env.VPC_NAME}}
         env:
-          VPC_NAME: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_STAGING_VPC_NAME || secrets.STAGING_VPC_NAME}}
-          APPLICATION_BUCKET: ${{env.DATALAYER_IN_NEW_ACCOUNTS == 'true' && secrets.NEW_APPLICATION_BUCKET || secrets.APPLICATION_BUCKET}}
+          VPC_NAME: ${{secrets.NEW_STAGING_VPC_NAME}}
+          APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
           TF_VAR_skip_data_deployment: true
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.STAGING_RESTORE_SNAPSHOT_ID}}
           TF_VAR_postgres_deployer_registry_id: ${{secrets.STAGING_POSTGRES_DEPLOYER_ACCOUNT_ID}}
@@ -165,17 +148,9 @@ jobs:
         with:
           ref: ${{ github.event.inputs.version }}
       - name: Configure datalayer AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.STAGING_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure datalayer AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Configure Terraform Datalayer Provider Credentials
         run: |
@@ -226,17 +201,9 @@ jobs:
           key: ${{ runner.os }}-serverless-modules-${{ hashFiles('serverless/**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-serverless-modules-
       - name: Configure AWS credentials (new account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.STAGING_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure AWS credentials (legacy account)
-        if: env.DATALAYER_IN_NEW_ACCOUNTS != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Serverless
         working-directory: serverless


### PR DESCRIPTION
# Description

This removes the conditionals from the deployments that had allowed the data layer to deploy in either the legacy account or the new accounts. Since we do not want the data layer to deploy to the legacy accounts anymore, we are removing those conditionals.

## How to test

This is being ran as a `dev-` branch to show the dev flow works correctly. Successful deployment == good.

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
