### PR TITLE
CMS-290: Report to multiple code climate locations

### DIFF
--- a/.github/build_vars.sh
+++ b/.github/build_vars.sh
@@ -6,6 +6,7 @@ var_list=(
   'STAGE_PREFIX'
   'SLACK_WEBHOOK_URL'
   'CODE_CLIMATE_ID'
+  'CODE_CLIMATE_CMS_ID'
 )
 
 set_value() {

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,7 @@ jobs:
           STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
+          CODE_CLIMATE_CMS_ID: ${{secrets.CODE_CLIMATE_CMS_ID}}
       - name: Configure AWS credentials for GitHub Actions
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -68,6 +69,15 @@ jobs:
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}
+        with:
+          coverageLocations: |
+            ${{github.workspace}}/services/app-api/coverage/lcov.info:lcov
+            ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
+      - name: publish test coverage to private CMS code climate
+        if: env.CODE_CLIMATE_CMS_ID != ''
+        uses: paambaati/codeclimate-action@v2.7.5
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_CMS_ID }}
         with:
           coverageLocations: |
             ${{github.workspace}}/services/app-api/coverage/lcov.info:lcov


### PR DESCRIPTION
# Description

We need to report to the private CMS Code Climate, which is used as an easily accessed dashboard, in addition to the previously configured Open Source Code Climate space. 

This should just get the reports up there, no functional changes.

If we need to consolidate in the future, just pull the secret ID & step from the deploy script.

## How to test
The deploy step in this PR and post merge should write to both:
- https://codeclimate.com/github/CMSgov/cms-carts-seds
- https://codeclimate.com/repos/6102dd981f91b059fd002f56

## Dependencies
Nothing new

# Get it done
Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
