### PR TITLE
Ensure using application bucket set in environment

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -223,7 +223,7 @@ jobs:
           terraform_version: 1.0.11
           terraform_wrapper: false
       - name: Deploy Frontend Layer
-        run: ./frontend_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}} ${{env.BUILD_TAG}}
+        run: ./frontend_deploy.sh ${{env.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}} ${{env.BUILD_TAG}}
         env:
           VPC_NAME: ${{secrets.DEV_VPC_NAME}}
           OIDC_CLIENT_ID: ${{secrets.MASTER_OIDC_CLIENT_ID}}

--- a/.github/workflows/dev-destroy.yml
+++ b/.github/workflows/dev-destroy.yml
@@ -54,7 +54,7 @@ jobs:
           terraform_version: 1.0.11
           terraform_wrapper: false
       - name: Destroy frontend
-        run: ./frontend_destroy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} destroy application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}} ${{env.BUILD_TAG}}
+        run: ./frontend_destroy.sh ${{env.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} destroy application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}} ${{env.BUILD_TAG}}
         env:
           VPC_NAME: ${{secrets.DEV_VPC_NAME}}
           OIDC_CLIENT_ID: ${{secrets.MASTER_OIDC_CLIENT_ID}}
@@ -89,7 +89,7 @@ jobs:
           terraform_version: 1.0.11
           terraform_wrapper: false
       - name: Destroy data Layer
-        run: ./data_layer_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} destroy application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}}
+        run: ./data_layer_deploy.sh ${{env.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} destroy application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}}
         env:
           VPC_NAME: ${{secrets.NEW_DEV_VPC}}
           APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}

--- a/.github/workflows/master-deploy.yml
+++ b/.github/workflows/master-deploy.yml
@@ -232,7 +232,7 @@ jobs:
           terraform_version: 1.0.11
           terraform_wrapper: false
       - name: Deploy Frontend Layer
-        run: ./frontend_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}} ${{env.BUILD_TAG}}
+        run: ./frontend_deploy.sh ${{env.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}} ${{env.BUILD_TAG}}
         env:
           BUILD_TAG: ${{ needs.build-info.outputs.build_tag }}
           VPC_NAME: ${{secrets.DEV_VPC_NAME}}

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -169,7 +169,7 @@ jobs:
           terraform_version: 1.0.11
           terraform_wrapper: false
       - name: Deploy Frontend Layer
-        run: ./frontend_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{ github.event.inputs.environment }} apply application_version=${{ github.event.inputs.version }} vpc_name=${{env.VPC_NAME}} ${{ github.event.inputs.version }}
+        run: ./frontend_deploy.sh ${{env.APPLICATION_BUCKET}} ${{ github.event.inputs.environment }} apply application_version=${{ github.event.inputs.version }} vpc_name=${{env.VPC_NAME}} ${{ github.event.inputs.version }}
         env:
           VPC_NAME: ${{secrets.PROD_VPC_NAME}}
           OIDC_CLIENT_ID: ${{secrets.PROD_OIDC_CLIENT_ID}}

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -169,7 +169,7 @@ jobs:
           terraform_version: 1.0.11
           terraform_wrapper: false
       - name: Deploy Frontend Layer
-        run: ./frontend_deploy.sh ${{secrets.APPLICATION_BUCKET}} ${{ github.event.inputs.environment }} apply application_version=${{ github.event.inputs.version }} vpc_name=${{env.VPC_NAME}} ${{ github.event.inputs.version }}
+        run: ./frontend_deploy.sh ${{env.APPLICATION_BUCKET}} ${{ github.event.inputs.environment }} apply application_version=${{ github.event.inputs.version }} vpc_name=${{env.VPC_NAME}} ${{ github.event.inputs.version }}
         env:
           VPC_NAME: ${{secrets.STAGING_VPC_NAME}}
           OIDC_CLIENT_ID: ${{secrets.STAGING_OIDC_CLIENT_ID}}


### PR DESCRIPTION
# Description

Some of the application bucket references were using the GitHub secret (which is always the legacy terraform bucket) instead of the environment variable, which may be the legacy bucket or the new accounts bucket depending on usage.

This corrects those to ensure they are using the defined environment variable instead of the secret.

## How to test

Has to test after merge with destroy.

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
