### PR TITLE
Use default http port for internet connections

### DIFF
--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -1,7 +1,7 @@
 locals {
   postgres_password     = var.use_custom_db_password_info ? "/${terraform.workspace}/custom/postgres_custom_password" : "/${terraform.workspace}/postgres_password"
   postgres_user         = var.use_custom_db_user_info ? "/${terraform.workspace}/custom/postgres_custom_user" : "/${terraform.workspace}/postgres_user"
-  endpoint_api_postgres = var.acm_certificate_domain_api_postgres == "" ? "http://${aws_alb.api_postgres.dns_name}:8000" : "https://${var.acm_certificate_domain_api_postgres}"
+  endpoint_api_postgres = var.acm_certificate_domain_api_postgres == "" ? "http://${aws_alb.api_postgres.dns_name}" : "https://${var.acm_certificate_domain_api_postgres}"
   django_settings_module = {
     "prod" : "carts.settings"
   }
@@ -157,10 +157,10 @@ resource "aws_security_group_rule" "alb_api_postgres_egress" {
   security_group_id        = aws_security_group.alb_api_postgres.id
 }
 
-resource "aws_security_group_rule" "alb_api_postgres_ingress_8000" {
+resource "aws_security_group_rule" "alb_api_postgres_ingress_80" {
   type              = "ingress"
-  from_port         = 8000
-  to_port           = 8000
+  from_port         = 80
+  to_port           = 80
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.alb_api_postgres.id
@@ -219,7 +219,7 @@ resource "aws_alb_listener" "https_forward_api_postgres" {
 resource "aws_alb_listener" "http_forward_api_postgres" {
   count             = var.acm_certificate_domain_api_postgres == "" ? 1 : 0
   load_balancer_arn = aws_alb.api_postgres.id
-  port              = "8000"
+  port              = "80"
   protocol          = "HTTP"
   default_action {
     target_group_arn = aws_alb_target_group.api_postgres.id
@@ -230,7 +230,7 @@ resource "aws_alb_listener" "http_forward_api_postgres" {
 resource "aws_alb_listener" "http_to_https_redirect_api_postgres" {
   count             = var.acm_certificate_domain_api_postgres == "" ? 0 : 1
   load_balancer_arn = aws_alb.api_postgres.id
-  port              = "8000"
+  port              = "80"
   protocol          = "HTTP"
   default_action {
     target_group_arn = aws_alb_target_group.api_postgres.id


### PR DESCRIPTION
# Description

Addresses High Security Hub Findings where the security group for the API load balancer was allowing traffic from anywhere on port `8000` when incoming traffic should be limit to authorized ports (80 and 443) when coming from anywhere.

Part of MDCT-126

## How to test

One deployed will check security hub and confirm security group resource is in compliance with the rule.

Confirmed the rule passed now.

## Dependencies

None.

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
