### PR TITLE
MDCT 327: BO & CO Print Page

### DIFF
--- a/frontend/react/src/components/layout/Part.js
+++ b/frontend/react/src/components/layout/Part.js
@@ -88,7 +88,8 @@ const mapStateToProps = (state, { partId }) => {
   const questions = selectQuestionsForPart(state, partId);
   const contextData = part.context_data;
   const location = window.location.pathname.split("/");
-  const userState = location[3]; // Current state, ie: "AL" or "CT"
+  const queryParams = new URLSearchParams(window.location.search);
+  const userState = location[3] ?? queryParams.get("state"); // Current state, ie: "AL" or "CT"
   const programData = state.allStatesData.find(
     (element) => element.code === userState
   );


### PR DESCRIPTION
# Description
The BO & CO users cannot view sections on the print page. The root of this issue is that the conditional data based on programType is not populating for page.

In v2, the ui displays all for the admin.
State user has programType on the userLogin, so it is always informed. 

For other roles it is earmarked to display based off of the programType passed in to the component, which works on the normal section page based on the url path.
Print page doesn't have the same path, it has query params. v2 fix is to just pull those in to get the right data.

This differs from the v3 fix, as we are storing that programData in a new location.

## How to test
Change the print onClick to use history.push() locally, because the new tab just redirects you to login when running local. I can demo this and walk through it for anyone who prefers that.

Sections should display for users when appropriate.

## Dependencies
The history.push thing is goofy, and I'd like to know if there's another way.

# Get it done
Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [x] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
