### PR TITLE
MDCT-126: Deploy Frontend Layer to both legacy and new AWS Accounts at same time

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -240,7 +240,7 @@ jobs:
           VPC_NAME: ${{secrets.NEW_DEV_VPC }}
           APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.DEV_RESTORE_SNAPSHOT_ID}}
-  frontend:
+  frontend-legacy:
     needs:
       - prevalidate
       - data
@@ -279,6 +279,39 @@ jobs:
           OIDC_ISSUER: ${{secrets.MASTER_OIDC_ISSUER}}
           TF_VAR_openid_discovery_url: ${{secrets.MASTER_TF_VAR_OPENID_DISCOVERY_URL}}
           APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
+  frontend-new:
+    needs:
+      - prevalidate
+      - data
+      - uploads-new
+      - build-react
+      - build-push-scan-postgres_django
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure AWS credentials (new account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure Terraform Datalayer Provider Credentials
+        run: |
+          echo "TF_VAR_datalayer_aws_access_key=${{env.AWS_ACCESS_KEY_ID}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_secret_key=${{env.AWS_SECRET_ACCESS_KEY}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_session_token=${{env.AWS_SESSION_TOKEN}}" >> $GITHUB_ENV
+      - name: Terraform setup
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.0.11
+          terraform_wrapper: false
+      - name: Deploy Frontend Layer
+        run: ./frontend_deploy.sh ${{env.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}} ${{env.BUILD_TAG}}
+        env:
+          VPC_NAME: ${{secrets.NEW_DEV_VPC }}
+          OIDC_CLIENT_ID: ${{secrets.MASTER_OIDC_CLIENT_ID}}
+          OIDC_ISSUER: ${{secrets.MASTER_OIDC_ISSUER}}
+          TF_VAR_openid_discovery_url: ${{secrets.MASTER_TF_VAR_OPENID_DISCOVERY_URL}}
+          APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
   serverless:
     needs:
       - data

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -134,22 +134,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Configure AWS credentials
+      - name: Build react artifacts.
+        working-directory: frontend/react
+        run: |
+          docker run --rm -w /app -v $(pwd):/app node:14.4.0 /bin/bash -c "rm -rf build && npm ci && npm run build && cp env.sh .env build/"
+          tar -zcvf cartsbuild.tar.gz build
+      - name: Configure AWS credentials (legacy)
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Build and push react artifacts.
+      - name: Push react artifacts (legacy).
         env:
           IMAGE_TAG: ${{env.BUILD_TAG}}
           APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
         working-directory: frontend/react
-        run: |
-          docker run --rm -w /app -v $(pwd):/app node:14.4.0 /bin/bash -c "rm -rf build && npm ci && npm run build && cp env.sh .env build/"
-          tar -zcvf cartsbuild.tar.gz build
-          aws s3 cp cartsbuild.tar.gz s3://$APPLICATION_BUCKET/artifacts/$IMAGE_TAG/cartsbuild.tar.gz
-          rm -rf cartsbuild.tar.gz
+        run: aws s3 cp cartsbuild.tar.gz s3://$APPLICATION_BUCKET/artifacts/$IMAGE_TAG/cartsbuild.tar.gz
+      - name: Configure AWS credentials (new account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Push react artifacts (new account).
+        env:
+          IMAGE_TAG: ${{env.BUILD_TAG}}
+          APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
+        working-directory: frontend/react
+        run: aws s3 cp cartsbuild.tar.gz s3://$APPLICATION_BUCKET/artifacts/$IMAGE_TAG/cartsbuild.tar.gz
   uploads:
     needs:
       - prevalidate

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -162,7 +162,7 @@ jobs:
           APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
         working-directory: frontend/react
         run: aws s3 cp cartsbuild.tar.gz s3://$APPLICATION_BUCKET/artifacts/$IMAGE_TAG/cartsbuild.tar.gz
-  uploads:
+  uploads-legacy:
     needs:
       - prevalidate
     runs-on: ubuntu-latest
@@ -186,6 +186,33 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Deploy Uploads Scan
+        working-directory: serverless-uploads
+        run: ./deploy.sh ${{env.BRANCH_NAME}}
+  uploads-new:
+    needs:
+      - prevalidate
+    runs-on: ubuntu-latest
+    env:
+      SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
+    steps:
+      - uses: actions/checkout@v3
+      - name: read .nvmrc
+        id: node_version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
+      - uses: actions/cache@v3
+        with:
+          path: serverless-uploads/**/node_modules
+          key: ${{ runner.os }}-serverless-uploads-modules-${{ hashFiles('serverless-uploads/**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-serverless-uploads-
+      - name: Configure AWS credentials (new account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Deploy Uploads Scan
         working-directory: serverless-uploads
@@ -217,7 +244,7 @@ jobs:
     needs:
       - prevalidate
       - data
-      - uploads
+      - uploads-legacy
       - build-react
       - build-push-scan-postgres_django
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -85,28 +85,38 @@ jobs:
           key: ${{ runner.os }}-postgres_django-docker-cache-{hash}
           restore-keys: |
             ${{ runner.os }}-postgres_django-docker-cache-
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (legacy)
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Login to Amazon ECR
-        id: login-ecr
+        id: login-ecr-legacy
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Configure AWS credentials (new account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr-new
         uses: aws-actions/amazon-ecr-login@v1
       - name: Build, tag, and push postgres_django(frontend/api_postgres) image
         id: postgres_django_build
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY_LEGACY: ${{ steps.login-ecr-legacy.outputs.registry }}
+          ECR_REGISTRY_NEW: ${{ steps.login-ecr-new.outputs.registry }}
           ECR_REPOSITORY: ${{env.ECR_REPOSITORY_API_POSTGRESS}}
           IMAGE_TAG: ${{env.BUILD_TAG}}
         working-directory: frontend/api_postgres
         run: |
-          docker build . -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:${{env.BRANCH_NAME}}
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags
+          docker build . -t $ECR_REGISTRY_LEGACY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY_LEGACY/$ECR_REPOSITORY:${{env.BRANCH_NAME}} -t $ECR_REGISTRY_NEW/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY_NEW/$ECR_REPOSITORY:${{env.BRANCH_NAME}}
+          docker push $ECR_REGISTRY_LEGACY/$ECR_REPOSITORY --all-tags
+          docker push $ECR_REGISTRY_NEW/$ECR_REPOSITORY --all-tags
       - name: Scan postgres_django(frontend/api_postgres) Docker image
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY: ${{ steps.login-ecr-new.outputs.registry }}
           ECR_REPOSITORY: ${{env.ECR_REPOSITORY_API_POSTGRESS}}
           IMAGE_TAG: ${{env.BUILD_TAG}}
         run: |

--- a/.github/workflows/dev-destroy.yml
+++ b/.github/workflows/dev-destroy.yml
@@ -19,7 +19,7 @@ env:
   ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
 
 jobs:
-  destroy-frontend:
+  destroy-frontend-legacy:
     # Protected branches should be designated as such in the GitHub UI.
     # So, a protected branch should never have this workflow run, since the branch should never be deleted.
     # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
@@ -61,6 +61,42 @@ jobs:
           OIDC_ISSUER: ${{secrets.MASTER_OIDC_ISSUER}}
           TF_VAR_openid_discovery_url: ${{secrets.MASTER_TF_VAR_OPENID_DISCOVERY_URL}}
           APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
+  destroy-frontend-new:
+    # Protected branches should be designated as such in the GitHub UI.
+    # So, a protected branch should never have this workflow run, since the branch should never be deleted.
+    # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
+    # This is a list of branch names that are commonly used for protected branches/environments.
+    # Add/remove names from this list as appropriate.
+    if: |
+      github.event.ref_type == 'branch' &&
+      !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref) &&
+      startsWith(github.event.ref,'dev-')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure datalayer AWS credentials (new account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure Terraform Datalayer Provider Credentials
+        run: |
+          echo "TF_VAR_datalayer_aws_access_key=${{env.AWS_ACCESS_KEY_ID}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_secret_key=${{env.AWS_SECRET_ACCESS_KEY}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_session_token=${{env.AWS_SESSION_TOKEN}}" >> $GITHUB_ENV
+      - name: Terraform setup
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.0.11
+          terraform_wrapper: false
+      - name: Destroy frontend
+        run: ./frontend_destroy.sh ${{env.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} destroy application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}} ${{env.BUILD_TAG}}
+        env:
+          VPC_NAME: ${{secrets.NEW_DEV_VPC }}
+          OIDC_CLIENT_ID: ${{secrets.MASTER_OIDC_CLIENT_ID}}
+          OIDC_ISSUER: ${{secrets.MASTER_OIDC_ISSUER}}
+          TF_VAR_openid_discovery_url: ${{secrets.MASTER_TF_VAR_OPENID_DISCOVERY_URL}}
+          APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
   destroy-data:
     # Protected branches should be designated as such in the GitHub UI.
     # So, a protected branch should never have this workflow run, since the branch should never be deleted.
@@ -69,13 +105,15 @@ jobs:
     # Add/remove names from this list as appropriate.
     if: |
       always() &&
-      (needs.destroy-frontend.result == 'success' || needs.destroy-frontend.result == 'skipped') &&
+      (needs.destroy-frontend-legacy.result == 'success' || needs.destroy-frontend-legacy.result == 'skipped') &&
+      (needs.destroy-frontend-new.result == 'success' || needs.destroy-frontend-new.result == 'skipped') &&
       github.event.ref_type == 'branch' &&
       !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref) &&
       startsWith(github.event.ref,'dev-')
     runs-on: ubuntu-latest
     needs:
-      - destroy-frontend
+      - destroy-frontend-legacy
+      - destroy-frontend-new
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS credentials (new account)

--- a/.github/workflows/master-deploy.yml
+++ b/.github/workflows/master-deploy.yml
@@ -91,28 +91,38 @@ jobs:
           key: ${{ runner.os }}-postgres_django-docker-cache-{hash}
           restore-keys: |
             ${{ runner.os }}-postgres_django-docker-cache-
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (legacy)
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Login to Amazon ECR
-        id: login-ecr
+        id: login-ecr-legacy
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Configure AWS credentials (new account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr-new
         uses: aws-actions/amazon-ecr-login@v1
       - name: Build, tag, and push postgres_django(frontend/api_postgres) image
         id: postgres_django_build
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY_LEGACY: ${{ steps.login-ecr-legacy.outputs.registry }}
+          ECR_REGISTRY_NEW: ${{ steps.login-ecr-new.outputs.registry }}
           ECR_REPOSITORY: ${{env.ECR_REPOSITORY_API_POSTGRESS}}
           IMAGE_TAG: ${{ needs.build-info.outputs.build_tag }}
         working-directory: frontend/api_postgres
         run: |
-          docker build . -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:${{env.BRANCH_NAME}}
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags
+          docker build . -t $ECR_REGISTRY_LEGACY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY_LEGACY/$ECR_REPOSITORY:${{env.BRANCH_NAME}} -t $ECR_REGISTRY_NEW/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY_NEW/$ECR_REPOSITORY:${{env.BRANCH_NAME}}
+          docker push $ECR_REGISTRY_LEGACY/$ECR_REPOSITORY --all-tags
+          docker push $ECR_REGISTRY_NEW/$ECR_REPOSITORY --all-tags
       - name: Scan postgres_django(frontend/api_postgres) Docker image
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY: ${{ steps.login-ecr-new.outputs.registry }}
           ECR_REPOSITORY: ${{env.ECR_REPOSITORY_API_POSTGRESS}}
           IMAGE_TAG: ${{ needs.build-info.outputs.build_tag }}
         run: |
@@ -130,23 +140,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Configure AWS credentials
+      - name: Build react artifacts.
+        working-directory: frontend/react
+        run: |
+          docker run --rm -w /app -v $(pwd):/app node:14.4.0 /bin/bash -c "rm -rf build && npm ci && npm run build && cp env.sh .env build/"
+          tar -zcvf cartsbuild.tar.gz build
+      - name: Configure AWS credentials (legacy)
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Build and push react artifacts.
+      - name: Push react artifacts (legacy).
         env:
           IMAGE_TAG: ${{ needs.build-info.outputs.build_tag }}
           APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
         working-directory: frontend/react
-        run: |
-          docker run --rm -w /app -v $(pwd):/app node:14.4.0 /bin/bash -c "rm -rf build && npm ci && npm run build && cp env.sh .env build/"
-          tar -zcvf cartsbuild.tar.gz build
-          aws s3 cp cartsbuild.tar.gz s3://$APPLICATION_BUCKET/artifacts/$IMAGE_TAG/cartsbuild.tar.gz
-          rm -rf cartsbuild.tar.gz
-  uploads:
+        run: aws s3 cp cartsbuild.tar.gz s3://$APPLICATION_BUCKET/artifacts/$IMAGE_TAG/cartsbuild.tar.gz
+      - name: Configure AWS credentials (new account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Push react artifacts (new account).
+        env:
+          IMAGE_TAG: ${{ needs.build-info.outputs.build_tag }}
+          APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
+        working-directory: frontend/react
+        run: aws s3 cp cartsbuild.tar.gz s3://$APPLICATION_BUCKET/artifacts/$IMAGE_TAG/cartsbuild.tar.gz
+  uploads-legacy:
     needs:
       - build-info
     runs-on: ubuntu-latest
@@ -170,6 +192,33 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Deploy Uploads Scan
+        working-directory: serverless-uploads
+        run: ./deploy.sh ${{env.BRANCH_NAME}}
+  uploads-new:
+    needs:
+      - build-info
+    runs-on: ubuntu-latest
+    env:
+      SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
+    steps:
+      - uses: actions/checkout@v3
+      - name: read .nvmrc
+        id: node_version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
+      - uses: actions/cache@v3
+        with:
+          path: serverless-uploads/**/node_modules
+          key: ${{ runner.os }}-serverless-uploads-modules-${{ hashFiles('serverless-uploads/**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-serverless-uploads-
+      - name: Configure AWS credentials (new account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Deploy Uploads Scan
         working-directory: serverless-uploads
@@ -200,11 +249,11 @@ jobs:
           TF_VAR_skip_data_deployment: true
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.MASTER_RESTORE_SNAPSHOT_ID}}
           TF_VAR_postgres_deployer_registry_id: ${{secrets.MASTER_POSTGRES_DEPLOYER_ACCOUNT_ID}}
-  frontend:
+  frontend-legacy:
     needs:
       - build-info
       - data
-      - uploads
+      - uploads-legacy
       - build-react
       - build-push-scan-postgres_django
     runs-on: ubuntu-latest
@@ -243,6 +292,45 @@ jobs:
           TF_VAR_acm_certificate_domain_ui: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
           TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
           TF_VAR_use_custom_db_password_info: ${{ env.USE_CUSTOM_PASSWORD }}
+  frontend-new:
+    needs:
+      - build-info
+      - data
+      - uploads-new
+      - build-react
+      - build-push-scan-postgres_django
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure AWS credentials (new account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure Terraform Datalayer Provider Credentials
+        run: |
+          echo "TF_VAR_datalayer_aws_access_key=${{env.AWS_ACCESS_KEY_ID}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_secret_key=${{env.AWS_SECRET_ACCESS_KEY}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_session_token=${{env.AWS_SESSION_TOKEN}}" >> $GITHUB_ENV
+      - name: Terraform setup
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.0.11
+          terraform_wrapper: false
+      - name: Deploy Frontend Layer
+        run: ./frontend_deploy.sh ${{env.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}} ${{env.BUILD_TAG}}
+        env:
+          BUILD_TAG: ${{ needs.build-info.outputs.build_tag }}
+          VPC_NAME: ${{secrets.NEW_DEV_VPC}}
+          OIDC_CLIENT_ID: ${{secrets.MASTER_OIDC_CLIENT_ID}}
+          OIDC_ISSUER: ${{secrets.MASTER_OIDC_ISSUER}}
+          TF_VAR_openid_discovery_url: ${{secrets.MASTER_TF_VAR_OPENID_DISCOVERY_URL}}
+          APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
+          # UI Domain can only be set in one at the time. Should Currently be the legacy environment
+          # TODO: Uncomment after domain switch over.
+          # TF_VAR_acm_certificate_domain_ui: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
+          TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
+          TF_VAR_use_custom_db_password_info: ${{ env.USE_CUSTOM_PASSWORD }}
   serverless:
     needs:
       - data
@@ -274,7 +362,8 @@ jobs:
     needs:
       - uploads
       - data
-      - frontend
+      - frontend-legacy
+      - frontend-new
       - serverless
       - build-info
     runs-on: ubuntu-latest

--- a/.github/workflows/master-deploy.yml
+++ b/.github/workflows/master-deploy.yml
@@ -326,7 +326,7 @@ jobs:
           OIDC_ISSUER: ${{secrets.MASTER_OIDC_ISSUER}}
           TF_VAR_openid_discovery_url: ${{secrets.MASTER_TF_VAR_OPENID_DISCOVERY_URL}}
           APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
-          # UI Domain can only be set in one at the time. Should Currently be the legacy environment
+          # UI Domain can only be set in one at the time. Should currently be the legacy environment
           # TODO: Uncomment after domain switch over.
           # TF_VAR_acm_certificate_domain_ui: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
           TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
@@ -360,7 +360,8 @@ jobs:
         run: ./deploy.sh ${{env.BRANCH_NAME}}
   finalize:
     needs:
-      - uploads
+      - uploads-legacy
+      - uploads-new
       - data
       - frontend-legacy
       - frontend-new

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -50,7 +50,7 @@ jobs:
           IMAGE_TAG: ${{ github.event.inputs.version }}
         run: |
           aws ecr wait image-scan-complete --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --registry-id $ECR_REGISTRY_ID
-          aws ecr describe-image-scan-findings --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --registry-id $ECR_REGISTRY_ID --output json | tee ecr_scan_result_$ECR_REPOSITORY_POSTGRESS_DEPLOYER.json >/dev/null
+          aws ecr describe-image-scan-findings --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --registry-id $ECR_REGISTRY_ID --output json | tee ecr_scan_result_$ECR_REPOSITORY.json >/dev/null
       - name: Archive ecr images scan results
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
@@ -60,30 +60,31 @@ jobs:
   scan-postgres_django:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (new account)
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.PROD_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registries: ${{ secrets.PROD_POSTGRES_DJANGO_ACCOUNT_ID }}
       - name: Scan postgres_django(frontend/api_postgres) Docker image
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY_ID: ${{ secrets.PROD_POSTGRES_DJANGO_ACCOUNT_ID }}
           ECR_REPOSITORY: ${{env.ECR_REPOSITORY_API_POSTGRESS}}
           IMAGE_TAG: ${{ github.event.inputs.version }}
         run: |
-          aws ecr wait image-scan-complete --repository-name ${{ env.ECR_REPOSITORY_API_POSTGRESS }} --image-id imageTag=$IMAGE_TAG
-          aws ecr describe-image-scan-findings --repository-name ${{ env.ECR_REPOSITORY_API_POSTGRESS }} --image-id imageTag=$IMAGE_TAG --output json | tee ecr_scan_result_$ECR_REPOSITORY_API_POSTGRESS.json >/dev/null
+          aws ecr wait image-scan-complete --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --registry-id $ECR_REGISTRY_ID
+          aws ecr describe-image-scan-findings --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --registry-id $ECR_REGISTRY_ID --output json | tee ecr_scan_result_$ECR_REPOSITORY.json >/dev/null
       - name: Archive ecr images scan results
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
           name: image_scan_results
           path: ecr_scan_*.json
-  uploads:
+  uploads-legacy:
     runs-on: ubuntu-latest
     env:
       SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
@@ -107,6 +108,33 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Deploy Uploads Scan
+        working-directory: serverless-uploads
+        run: ./deploy.sh ${{ github.event.inputs.environment }}
+  uploads-new:
+    runs-on: ubuntu-latest
+    env:
+      SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.version }}
+      - name: read .nvmrc
+        id: node_version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
+      - uses: actions/cache@v3
+        with:
+          path: serverless-uploads/**/node_modules
+          key: ${{ runner.os }}-serverless-uploads-modules-${{ hashFiles('serverless-uploads/**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-serverless-uploads-
+      - name: Configure AWS credentials (new account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PROD_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Deploy Uploads Scan
         working-directory: serverless-uploads
@@ -137,10 +165,10 @@ jobs:
           TF_VAR_skip_data_deployment: true
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.PROD_RESTORE_SNAPSHOT_ID}}
           TF_VAR_postgres_deployer_registry_id: ${{secrets.PROD_POSTGRES_DEPLOYER_ACCOUNT_ID}}
-  frontend:
+  frontend-legacy:
     needs:
       - data
-      - uploads
+      - uploads-legacy
       - scan-postgres_django
     runs-on: ubuntu-latest
     steps:
@@ -179,6 +207,45 @@ jobs:
           TF_VAR_acm_certificate_domain_ui: ${{secrets.PROD_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
           TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.PROD_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
           TF_VAR_use_custom_db_password_info: ${{ env.USE_CUSTOM_PASSWORD }}
+  frontend-new:
+    needs:
+      - data
+      - uploads-new
+      - scan-postgres_django
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.version }}
+      - name: Configure AWS credentials (new account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PROD_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure Terraform Datalayer Provider Credentials
+        run: |
+          echo "TF_VAR_datalayer_aws_access_key=${{env.AWS_ACCESS_KEY_ID}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_secret_key=${{env.AWS_SECRET_ACCESS_KEY}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_session_token=${{env.AWS_SESSION_TOKEN}}" >> $GITHUB_ENV
+      - name: Terraform setup
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.0.11
+          terraform_wrapper: false
+      - name: Deploy Frontend Layer
+        run: ./frontend_deploy.sh ${{env.APPLICATION_BUCKET}} ${{ github.event.inputs.environment }} apply application_version=${{ github.event.inputs.version }} vpc_name=${{env.VPC_NAME}} ${{ github.event.inputs.version }}
+        env:
+          VPC_NAME: ${{secrets.NEW_PROD_VPC_NAME}}
+          OIDC_CLIENT_ID: ${{secrets.PROD_OIDC_CLIENT_ID}}
+          OIDC_ISSUER: ${{secrets.PROD_OIDC_ISSUER}}
+          TF_VAR_openid_discovery_url: ${{secrets.PROD_TF_VAR_OPENID_DISCOVERY_URL}}
+          APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
+          # UI Domain can only be set in one at the time. Should currently be the legacy environment
+          # TODO: Uncomment after domain switch over.
+          # TF_VAR_acm_certificate_domain_ui: ${{secrets.PROD_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
+          TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.PROD_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
+          TF_VAR_use_custom_db_password_info: ${{ env.USE_CUSTOM_PASSWORD }}
+          TF_VAR_postgres_django_registry_id: ${{secrets.PROD_POSTGRES_DJANGO_ACCOUNT_ID}}
   serverless:
     needs:
       - data
@@ -210,9 +277,11 @@ jobs:
         run: ./deploy.sh ${{ github.event.inputs.environment }}
   finalize:
     needs:
-      - uploads
+      - uploads-legacy
+      - uploads-new
       - data
-      - frontend
+      - frontend-legacy
+      - frontend-new
       - serverless
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -50,7 +50,7 @@ jobs:
           IMAGE_TAG: ${{ github.event.inputs.version }}
         run: |
           aws ecr wait image-scan-complete --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --registry-id $ECR_REGISTRY_ID
-          aws ecr describe-image-scan-findings --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --registry-id $ECR_REGISTRY_ID --output json | tee ecr_scan_result_$ECR_REPOSITORY_POSTGRESS_DEPLOYER.json >/dev/null
+          aws ecr describe-image-scan-findings --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --registry-id $ECR_REGISTRY_ID --output json | tee ecr_scan_result_$ECR_REPOSITORY.json >/dev/null
       - name: Archive ecr images scan results
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
@@ -60,30 +60,31 @@ jobs:
   scan-postgres_django:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (new account)
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.STAGING_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registries: ${{ secrets.STAGING_POSTGRES_DJANGO_ACCOUNT_ID }}
       - name: Scan postgres_django(frontend/api_postgres) Docker image
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY_ID: ${{ secrets.STAGING_POSTGRES_DJANGO_ACCOUNT_ID }}
           ECR_REPOSITORY: ${{env.ECR_REPOSITORY_API_POSTGRESS}}
           IMAGE_TAG: ${{ github.event.inputs.version }}
         run: |
-          aws ecr wait image-scan-complete --repository-name ${{ env.ECR_REPOSITORY_API_POSTGRESS }} --image-id imageTag=$IMAGE_TAG
-          aws ecr describe-image-scan-findings --repository-name ${{ env.ECR_REPOSITORY_API_POSTGRESS }} --image-id imageTag=$IMAGE_TAG --output json | tee ecr_scan_result_$ECR_REPOSITORY_API_POSTGRESS.json >/dev/null
+          aws ecr wait image-scan-complete --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --registry-id $ECR_REGISTRY_ID
+          aws ecr describe-image-scan-findings --repository-name $ECR_REPOSITORY --image-id imageTag=$IMAGE_TAG --registry-id $ECR_REGISTRY_ID --output json | tee ecr_scan_result_$ECR_REPOSITORY.json >/dev/null
       - name: Archive ecr images scan results
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
           name: image_scan_results
           path: ecr_scan_*.json
-  uploads:
+  uploads-legacy:
     runs-on: ubuntu-latest
     env:
       SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
@@ -107,6 +108,33 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Deploy Uploads Scan
+        working-directory: serverless-uploads
+        run: ./deploy.sh ${{ github.event.inputs.environment }}
+  uploads-new:
+    runs-on: ubuntu-latest
+    env:
+      SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.version }}
+      - name: read .nvmrc
+        id: node_version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
+      - uses: actions/cache@v3
+        with:
+          path: serverless-uploads/**/node_modules
+          key: ${{ runner.os }}-serverless-uploads-modules-${{ hashFiles('serverless-uploads/**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-serverless-uploads-
+      - name: Configure AWS credentials (new account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.STAGING_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Deploy Uploads Scan
         working-directory: serverless-uploads
@@ -137,10 +165,10 @@ jobs:
           TF_VAR_skip_data_deployment: true
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.STAGING_RESTORE_SNAPSHOT_ID}}
           TF_VAR_postgres_deployer_registry_id: ${{secrets.STAGING_POSTGRES_DEPLOYER_ACCOUNT_ID}}
-  frontend:
+  frontend-legacy:
     needs:
       - data
-      - uploads
+      - uploads-legacy
       - scan-postgres_django
     runs-on: ubuntu-latest
     steps:
@@ -179,6 +207,45 @@ jobs:
           TF_VAR_acm_certificate_domain_ui: ${{secrets.STAGING_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
           TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.STAGING_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
           TF_VAR_use_custom_db_password_info: ${{ env.USE_CUSTOM_PASSWORD }}
+  frontend-new:
+    needs:
+      - data
+      - uploads-new
+      - scan-postgres_django
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.version }}
+      - name: Configure AWS credentials (new account)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.STAGING_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Configure Terraform Datalayer Provider Credentials
+        run: |
+          echo "TF_VAR_datalayer_aws_access_key=${{env.AWS_ACCESS_KEY_ID}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_secret_key=${{env.AWS_SECRET_ACCESS_KEY}}" >> $GITHUB_ENV
+          echo "TF_VAR_datalayer_aws_session_token=${{env.AWS_SESSION_TOKEN}}" >> $GITHUB_ENV
+      - name: Terraform setup
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.0.11
+          terraform_wrapper: false
+      - name: Deploy Frontend Layer
+        run: ./frontend_deploy.sh ${{env.APPLICATION_BUCKET}} ${{ github.event.inputs.environment }} apply application_version=${{ github.event.inputs.version }} vpc_name=${{env.VPC_NAME}} ${{ github.event.inputs.version }}
+        env:
+          VPC_NAME: ${{secrets.NEW_STAGING_VPC_NAME}}
+          OIDC_CLIENT_ID: ${{secrets.STAGING_OIDC_CLIENT_ID}}
+          OIDC_ISSUER: ${{secrets.STAGING_OIDC_ISSUER}}
+          TF_VAR_openid_discovery_url: ${{secrets.STAGING_TF_VAR_OPENID_DISCOVERY_URL}}
+          APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
+          # UI Domain can only be set in one at the time. Should currently be the legacy environment
+          # TODO: Uncomment after domain switch over.
+          # TF_VAR_acm_certificate_domain_ui: ${{secrets.STAGING_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
+          TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.STAGING_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
+          TF_VAR_use_custom_db_password_info: ${{ env.USE_CUSTOM_PASSWORD }}
+          TF_VAR_postgres_django_registry_id: ${{secrets.STAGING_POSTGRES_DJANGO_ACCOUNT_ID}}
   serverless:
     needs:
       - data
@@ -210,9 +277,11 @@ jobs:
         run: ./deploy.sh ${{ github.event.inputs.environment }}
   finalize:
     needs:
-      - uploads
+      - uploads-legacy
+      - uploads-new
       - data
-      - frontend
+      - frontend-legacy
+      - frontend-new
       - serverless
     runs-on: ubuntu-latest
     steps:

--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -1,7 +1,7 @@
 locals {
   postgres_password     = var.use_custom_db_password_info ? "/${terraform.workspace}/custom/postgres_custom_password" : "/${terraform.workspace}/postgres_password"
   postgres_user         = var.use_custom_db_user_info ? "/${terraform.workspace}/custom/postgres_custom_user" : "/${terraform.workspace}/postgres_user"
-  endpoint_api_postgres = var.acm_certificate_domain_api_postgres == "" ? "http://${aws_alb.api_postgres.dns_name}:8000" : "https://${var.acm_certificate_domain_api_postgres}"
+  endpoint_api_postgres = var.acm_certificate_domain_api_postgres == "" ? "http://${aws_alb.api_postgres.dns_name}" : "https://${var.acm_certificate_domain_api_postgres}"
   django_settings_module = {
     "prod" : "carts.settings"
   }
@@ -157,10 +157,10 @@ resource "aws_security_group_rule" "alb_api_postgres_egress" {
   security_group_id        = aws_security_group.alb_api_postgres.id
 }
 
-resource "aws_security_group_rule" "alb_api_postgres_ingress_8000" {
+resource "aws_security_group_rule" "alb_api_postgres_ingress_80" {
   type              = "ingress"
-  from_port         = 8000
-  to_port           = 8000
+  from_port         = 80
+  to_port           = 80
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.alb_api_postgres.id
@@ -219,7 +219,7 @@ resource "aws_alb_listener" "https_forward_api_postgres" {
 resource "aws_alb_listener" "http_forward_api_postgres" {
   count             = var.acm_certificate_domain_api_postgres == "" ? 1 : 0
   load_balancer_arn = aws_alb.api_postgres.id
-  port              = "8000"
+  port              = "80"
   protocol          = "HTTP"
   default_action {
     target_group_arn = aws_alb_target_group.api_postgres.id
@@ -230,7 +230,7 @@ resource "aws_alb_listener" "http_forward_api_postgres" {
 resource "aws_alb_listener" "http_to_https_redirect_api_postgres" {
   count             = var.acm_certificate_domain_api_postgres == "" ? 0 : 1
   load_balancer_arn = aws_alb.api_postgres.id
-  port              = "8000"
+  port              = "80"
   protocol          = "HTTP"
   default_action {
     target_group_arn = aws_alb_target_group.api_postgres.id

--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -39,7 +39,8 @@ data "aws_ssm_parameter" "postgres_security_group" {
 }
 
 data "aws_ecr_repository" "postgres_django" {
-  name = "postgres_django"
+  name        = "postgres_django"
+  registry_id = var.postgres_django_registry_id
 }
 
 resource "aws_ecs_task_definition" "api_postgres" {

--- a/frontend/aws/variables.tf
+++ b/frontend/aws/variables.tf
@@ -51,3 +51,9 @@ variable "use_custom_db_user_info" {
 variable "use_custom_db_password_info" {
   default = false
 }
+
+variable "postgres_django_registry_id" {
+  default     = null
+  type        = string
+  description = "The AWS Account ID where the postgres django repository is located"
+}


### PR DESCRIPTION
# Description

Alters the deployment process to deploy the frontend layer to both the legacy AWS account environments and to the new AWS accounts per environment.

Notes:
- Currently deploys dev PRs to both to help with some testing of this process. Very soon we will start deploying dev PRs to only the new dev environment.
- The new load balancers are configured to expect connections using the current domain names for the API per environment. Clearly until the DNS switch over this will have no effect, but will allow for some testing of things using curl commands with HOST headers set.
- The new cloudfront destinations are not set with a custom hostname yet. This is a limitation of Cloudfront that only 1 distribution globally can be attached to the same custom hostname. A later PR will switch the hostname from one account to the other. As that may require some manual intervention, it is being saved for later.

## How to test

This deploys. Rest need to test on merge and deployments to their respective environments.

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
