### PR TITLE
MDCT-376: Delete kafka mgmt topics on destroy #2993

### DIFF
--- a/.github/workflows/dev-destroy.yml
+++ b/.github/workflows/dev-destroy.yml
@@ -203,3 +203,14 @@ jobs:
       - name: Destroy serverless
         working-directory: serverless
         run: ./destroy.sh ${{env.BRANCH_NAME}}
+      - name: Delete topics from bigmac
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Delete Topics
+          repo: cmsgov/cms-bigmac
+          token: ${{ secrets.BIGMAC_PERSONAL_ACCESS_TOKEN }}
+          inputs: '{ "topics": 
+              "mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.config",
+              "mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.offsets",
+              "mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.status"
+            }'

--- a/.github/workflows/dev-destroy.yml
+++ b/.github/workflows/dev-destroy.yml
@@ -209,8 +209,8 @@ jobs:
           workflow: Delete Topics
           repo: cmsgov/cms-bigmac
           token: ${{ secrets.AUTOMATION_ACCESS_TOKEN }}
-          inputs: '{ "topics": 
-              "mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.config",
-              "mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.offsets",
-              "mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.status"
+          inputs: '{ "topics":
+            "mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.config",
+            "mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.offsets",
+            "mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.status"
             }'

--- a/.github/workflows/dev-destroy.yml
+++ b/.github/workflows/dev-destroy.yml
@@ -208,7 +208,7 @@ jobs:
         with:
           workflow: Delete Topics
           repo: cmsgov/cms-bigmac
-          token: ${{ secrets.BIGMAC_PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.AUTOMATION_ACCESS_TOKEN }}
           inputs: '{ "topics": 
               "mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.config",
               "mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.offsets",


### PR DESCRIPTION
# Description

Reopened the branch with a shorter name, so as to not fail the deploy steps

Per [MDCT-376](https://qmacbis.atlassian.net/browse/MDCT-376), delete all "mgmt.connect" queues when tearing down resources.

The 3 listed topics should get cleaned up.
## How to test

I guess merge and let this branch do its thing, or manually spin up and destroy other resources based on this new

## Dependencies

Nothing new to install.

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
