### PR TITLE
Fix av definition downloads

### DIFF
--- a/serverless-uploads/services/uploads/src/clamav.js
+++ b/serverless-uploads/services/uploads/src/clamav.js
@@ -93,7 +93,6 @@ async function uploadAVDefinitions() {
           Bucket: constants.CLAMAV_BUCKET_NAME,
           Key: `${constants.PATH_TO_AV_DEFINITIONS}/${filenameToUpload}`,
           Body: fs.createReadStream(path.join("/tmp/", filenameToUpload)),
-          ACL: "public-read",
         };
 
         S3.putObject(options, function (err, data) {


### PR DESCRIPTION
# Description

AV definitions were attempting to be put into S3 with a public acl, which is is both not allowed by our account policies, but is also not needed.

This removes the public-read acl setting on the objects, allowing them to use the default private acl instead.

## How to test

After this deployed, I confirmed both that the branch specific av definitions bucket got the updated definitions and that when I dropped a file into the
branch specific uploads bucket that the file was eventually scanned and marked clean by the scanning lambda.

## Dependencies

none.

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
