### PR TITLE
MDCT-138: Enable Cross Account Copy of Uploads Bucket Objects

### DIFF
--- a/frontend/aws/ecs_task_api_postgres.tf
+++ b/frontend/aws/ecs_task_api_postgres.tf
@@ -377,6 +377,7 @@ data "aws_caller_identity" "current" {}
 
 locals {
   account_id        = data.aws_caller_identity.current.account_id
+  new_account_id    = data.aws_caller_identity.datalayer.account_id # Data Layer is always in new account now
   is_legacy_account = local.account_id == "730373213083"
 }
 


### PR DESCRIPTION
# Description

To allow syncing the uploads bucket from the legacy account to the new account, this modifies the legacy account bucket policy to grant the new account (the account with the data layer).

Closes [MDCT-138](https://qmacbis.atlassian.net/browse/MDCT-138)

## How to test

This was deployed out. I uploaded 3 files to the upload bucket created in the legacy account. 

<img width="987" alt="image" src="https://user-images.githubusercontent.com/121035/173708940-d19bd1d4-79a3-4caf-b65e-766831b56a2f.png">


I then run an aws sync using credentials for the new dev account.

```
aws s3 sync s3://cartscms-uploads-dev-s3cp s3://carts-uploads-dev-s3cp
```

I then confirmed the s3 objects were put into the new account uploads bucket.

<img width="954" alt="image" src="https://user-images.githubusercontent.com/121035/173708864-7f351636-1893-4f88-ace4-507cb65b93da.png">


## Dependencies

Please spell out any dependencies for this change -- ex -- requires an install / update / migration etc

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
