### PR TITLE
MDCT-354: Main Page Alignment issue

### DIFF
--- a/services/ui-src/src/components/layout/Header.js
+++ b/services/ui-src/src/components/layout/Header.js
@@ -78,7 +78,7 @@ class Header extends Component {
         <header className="header">
           <div className="ds-l-container">
             <div className="ds-l-row header-row">
-              <div className="site-title ds-l-col--4 ds-u-padding-x--2 ds-u-padding-top--1">
+              <div className="site-title ds-l-col--4 ds-u-padding-right--2 ds-u-padding-top--1">
                 <Link to="/" className="ds-u-display--block">
                   <img
                     id="carts-logo"

--- a/services/ui-src/src/components/sections/homepage/CMSHomepage.js
+++ b/services/ui-src/src/components/sections/homepage/CMSHomepage.js
@@ -110,7 +110,7 @@ const CMSHomepage = ({
 
   return (
     <div className="homepage ds-l-col--12">
-      <div className="ds-l-container-large">
+      <div className="homepage-filter ds-l-container-large">
         {currentUserRole !== UserRoles.BUSINESS_OWNER_REP ? (
           <>
             <div className="ds-l-row ds-u-padding-left--2">

--- a/services/ui-src/src/styles/_footer.scss
+++ b/services/ui-src/src/styles/_footer.scss
@@ -14,7 +14,11 @@
   }
 
   .adverts {
-    padding: ($padding * 4) $padding;
+    padding: ($padding * 4) $padding * 2;
+
+    @media only screen and (min-width: 544px) {
+      padding: ($padding * 4) 0;
+    }
   }
 
   .cms-logo {
@@ -93,7 +97,11 @@
   .info {
     background-color: $brand-tertiary;
     color: $white;
-    padding: ($padding * 2) $padding;
+    padding: ($padding * 2) $padding * 2;
+
+    @media only screen and (min-width: 544px) {
+      padding: ($padding * 2) 0;
+    }
 
     a,
     a:visited {

--- a/services/ui-src/src/styles/_header.scss
+++ b/services/ui-src/src/styles/_header.scss
@@ -43,6 +43,9 @@
     @media only screen and (max-width: 767px) {
       font-size: 1.6rem;
     }
+    @media only screen and (min-width: 768px) {
+      padding-left: 0;
+    }
   }
 
   #carts-logo {

--- a/services/ui-src/src/styles/_main.scss
+++ b/services/ui-src/src/styles/_main.scss
@@ -243,6 +243,14 @@ img {
 }
 
 .homepage {
+  &-filter {
+    padding: 0 16px;
+
+    @media only screen and (min-width: 544px) {
+      padding: 0;
+    }
+  }
+
   .page-title {
     margin-top: ($margin * 4);
     margin-bottom: $margin;
@@ -561,6 +569,10 @@ div[data-state="open"] .accordion-header .arrow:before {
 }
 .filter-div {
   width: 100%;
+
+  .ds-c-label {
+    margin-left: $margin * 2;
+  }
 }
 
 .help-page {


### PR DESCRIPTION
# Description

Fixes [MDCT-354](https://qmacbis.atlassian.net/browse/MDCT-354)

Fixes alignment on the main page and the Reports page. Does not fix the alignment on Get Help or the users account page intentionally. Those pages have different main content widths that were intended to be like that. Might be something we want to address going forward.

![Alignment fix](https://user-images.githubusercontent.com/19439679/175057038-a0430647-c33d-4fbf-b6e0-c7a4b574a61f.png)


## How to test

./dev local
Log in as a state user or the admin
Checkout the page in all its aligned glory (Except for the soon to be deleted CMS user note)

## Dependencies

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
