### PR TITLE
MDCT-355: Remove CMS User note

### DIFF
--- a/services/ui-src/src/components/layout/HomeAdmin.js
+++ b/services/ui-src/src/components/layout/HomeAdmin.js
@@ -24,9 +24,6 @@ const AdminHome = () => {
                 CHIP Annual Reporting Template System (CARTS)
               </h1>
             </div>
-            <div className="page-info">
-              <div className="edit-info">admin</div>
-            </div>
             <div className="ds-l-row">
               <ul>
                 <li>

--- a/services/ui-src/src/components/sections/homepage/CMSHomepage.js
+++ b/services/ui-src/src/components/sections/homepage/CMSHomepage.js
@@ -112,16 +112,11 @@ const CMSHomepage = ({
     <div className="homepage ds-l-col--12">
       <div className="ds-l-container-large">
         {currentUserRole !== UserRoles.BUSINESS_OWNER_REP ? (
-          <>
-            <div className="ds-l-row ds-u-padding-left--2">
-              <h1 className="page-title ds-u-margin-bottom--0">
-                CHIP Annual Reporting Template System (CARTS)
-              </h1>
-            </div>
-            <div className="page-info ds-u-padding-left--2">
-              <div className="edit-info">CMS user</div>
-            </div>
-          </>
+          <div className="ds-l-row ds-u-padding-left--2">
+            <h1 className="page-title ds-u-margin-bottom--0">
+              CHIP Annual Reporting Template System (CARTS)
+            </h1>
+          </div>
         ) : null}
         <div className="ds-l-row">
           <div className="reports ds-l-col--12">


### PR DESCRIPTION
# Description

Fixes [MDCT-355](https://qmacbis.atlassian.net/browse/MDCT-355)

Hated seeing the CMS User note? So did the rest of the world. It's done, kapeesh? It won't be bothering us no more. 

![Screen Shot 2022-06-22 at 11 17 19 AM](https://user-images.githubusercontent.com/19439679/175067404-c0a2642d-3a09-4cdb-a222-efae16830a60.png)


## How to test

./dev local
Log in
See that the main page is filled with only the most effective wording now known to man.

## Dependencies

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
