### PR TITLE
lock django-filter to prior version, new version expects recent django

### DIFF
--- a/frontend/api_postgres/requirements.txt
+++ b/frontend/api_postgres/requirements.txt
@@ -4,7 +4,7 @@ psycopg2-binary==2.8.3
 djangorestframework
 markdown
 django-json-widget
-django-filter
+django-filter==21.1
 django-cors-headers==3.11.0
 jsonschema==4.4.0
 jsonpath_ng


### PR DESCRIPTION
# Description

lock django-filter to prior version (21.1), new version (22.1) expects django 3.2, we're on 2.2.27.
This is causing failing deployments.

https://pyup.io/changelogs/django-filter/


## How to test
Let's hope we deploy correctly


# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
