### PR TITLE
Added fix for PDFs to show all text in a Textarea in V3 (#3344)

### DIFF
--- a/services/ui-src/src/components/fields/Text.js
+++ b/services/ui-src/src/components/fields/Text.js
@@ -83,15 +83,20 @@ const Text = ({ question, state, ...props }) => {
           {question.hint}
         </p>
       )}
-      <TextField
-        id={question.id}
-        value={
-          prevYearValue || (question.answer && question.answer.entry) || ""
-        }
-        type="text"
-        {...props}
-        disabled={prevYearDisabled || !!props.disabled}
-      />
+      <div className="non-print-textarea">
+        <TextField
+          id={question.id}
+          value={
+            prevYearValue || (question.answer && question.answer.entry) || ""
+          }
+          type="text"
+          {...props}
+          disabled={prevYearDisabled || !!props.disabled}
+        />
+      </div>
+      <p className="print-text-area">
+        {prevYearValue || (question.answer && question.answer.entry) || ""}
+      </p>
     </>
   );
 };

--- a/services/ui-src/src/styles/_form.scss
+++ b/services/ui-src/src/styles/_form.scss
@@ -486,3 +486,7 @@
     display: block;
   }
 }
+
+.print-text-area {
+  display: none;
+}

--- a/services/ui-src/src/styles/_print.scss
+++ b/services/ui-src/src/styles/_print.scss
@@ -5,7 +5,8 @@
 .print-all {
   .ds-c-alert,
   .form-footer,
-  .page-info {
+  .page-info,
+  .non-print-textarea {
     display: none;
   }
   .print-only,
@@ -38,10 +39,17 @@
       margin: 0 2.2rem 1.2rem 2.2rem;
     }
   }
+
+  .print-text-area {
+    display: block;
+    padding: 10px;
+    border: black solid 1px;
+  }
 }
 
 @media print {
-  .no-print {
+  .no-print,
+  .non-print-textarea {
     display: none !important;
   }
   .action-buttons,
@@ -114,5 +122,11 @@
   }
   .question {
     break-inside: avoid;
+  }
+
+  .print-text-area {
+    display: block;
+    padding: 10px;
+    border: black solid 1px;
   }
 }


### PR DESCRIPTION
# Description
Brought in logic from v2 that correctly prints all text in a text area 

## How to test
Print either single page or all pages with textboxes with content that overflows the view

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
