### PR TITLE
Fix api gatway certs

### DIFF
--- a/destroy.sh
+++ b/destroy.sh
@@ -115,3 +115,18 @@ do
   echo $i
   aws cloudformation delete-stack --stack-name $i
 done
+# Delete Client Certificates associated with a branch
+certToDestroy=$(aws apigateway get-client-certificates\
+    | grep \"app-api-${stage}\" -B 2 \
+    | grep -o '"clientCertificateId": "[^"]*' \
+    | grep -o '[^"]*$')
+
+until [ -z $certToDestroy ];
+do 
+  aws apigateway delete-client-certificate --client-certificate-id $certToDestroy || true
+  sleep 10
+  certToDestroy=$(aws apigateway get-client-certificates\
+    | grep \"app-api-${stage}\" -B 2 \
+    | grep -o '"clientCertificateId": "[^"]*' \
+    | grep -o '[^"]*$' || true) 
+done 


### PR DESCRIPTION
# Description
Added a few lines in our destory scripts to delete api gateways so we don't hit our limit when creating new environements. 

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
