### PR TITLE
Switch dev ui domain to new aws environment

### DIFF
--- a/.github/workflows/master-deploy.yml
+++ b/.github/workflows/master-deploy.yml
@@ -289,7 +289,8 @@ jobs:
           OIDC_ISSUER: ${{secrets.MASTER_OIDC_ISSUER}}
           TF_VAR_openid_discovery_url: ${{secrets.MASTER_TF_VAR_OPENID_DISCOVERY_URL}}
           APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
-          TF_VAR_acm_certificate_domain_ui: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
+          # UI Domain can only be set in one at the time. Should currently be the new environment
+          # TF_VAR_acm_certificate_domain_ui: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
           TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
           TF_VAR_use_custom_db_password_info: ${{ env.USE_CUSTOM_PASSWORD }}
   frontend-new:
@@ -299,6 +300,7 @@ jobs:
       - uploads-new
       - build-react
       - build-push-scan-postgres_django
+      - frontend-legacy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -326,9 +328,7 @@ jobs:
           OIDC_ISSUER: ${{secrets.MASTER_OIDC_ISSUER}}
           TF_VAR_openid_discovery_url: ${{secrets.MASTER_TF_VAR_OPENID_DISCOVERY_URL}}
           APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
-          # UI Domain can only be set in one at the time. Should currently be the legacy environment
-          # TODO: Uncomment after domain switch over.
-          # TF_VAR_acm_certificate_domain_ui: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
+          TF_VAR_acm_certificate_domain_ui: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
           TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
           TF_VAR_use_custom_db_password_info: ${{ env.USE_CUSTOM_PASSWORD }}
   serverless:


### PR DESCRIPTION
# Description

Public DNS records have been updated for the dev url to point to the new environments cloudfront distro. For cloufront to know to resolve this to the new distrobution, we need to change the UI domain setting to the new environment.

## How to test

Needs merge to test. Serves as test for val and prod, which will be in later PRs and DNS requests.

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
