### PR TITLE
Support V2 custom db password setting

### DIFF
--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -98,7 +98,7 @@ functions:
       postgresDb: ${env:postgresDatabase, ssm:/${self:custom.dataMigrationEnv}/postgres_db}
       postgresHost: ${env:postgresHost, ssm:/${self:custom.dataMigrationEnv}/postgres_host}
       postgresUser: ${env:postgresUser, ssm:/${self:custom.dataMigrationEnv}/postgres_user}
-      postgresPassword: ${env:postgresPassword, ssm:/${self:custom.dataMigrationEnv}/postgres_password}
+      postgresPassword: ${env:postgresPassword, ssm:/${self:custom.dataMigrationEnv}/custom/postgres_custom_password, ssm:/${self:custom.dataMigrationEnv}/postgres_password}
       dynamoPrefix: ${self:custom.stage}
     timeout: 120
     vpc:


### PR DESCRIPTION
# Description

For password rotation, the V2 data layer has a optional custom password parameter that is used during the rotation. To ensure that the migration handler still works after rotation, we need to include that in the variable resolution list.

## How to test

Successful deployment to main after merge.

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
