### PR TITLE
Stop deploying to legacy aws account via github actions

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -85,15 +85,6 @@ jobs:
           key: ${{ runner.os }}-postgres_django-docker-cache-{hash}
           restore-keys: |
             ${{ runner.os }}-postgres_django-docker-cache-
-      - name: Configure AWS credentials (legacy)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Login to Amazon ECR
-        id: login-ecr-legacy
-        uses: aws-actions/amazon-ecr-login@v1
       - name: Configure AWS credentials (new account)
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -105,14 +96,12 @@ jobs:
       - name: Build, tag, and push postgres_django(frontend/api_postgres) image
         id: postgres_django_build
         env:
-          ECR_REGISTRY_LEGACY: ${{ steps.login-ecr-legacy.outputs.registry }}
           ECR_REGISTRY_NEW: ${{ steps.login-ecr-new.outputs.registry }}
           ECR_REPOSITORY: ${{env.ECR_REPOSITORY_API_POSTGRESS}}
           IMAGE_TAG: ${{env.BUILD_TAG}}
         working-directory: frontend/api_postgres
         run: |
-          docker build . -t $ECR_REGISTRY_LEGACY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY_LEGACY/$ECR_REPOSITORY:${{env.BRANCH_NAME}} -t $ECR_REGISTRY_NEW/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY_NEW/$ECR_REPOSITORY:${{env.BRANCH_NAME}}
-          docker push $ECR_REGISTRY_LEGACY/$ECR_REPOSITORY --all-tags
+          docker build . -t $ECR_REGISTRY_NEW/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY_NEW/$ECR_REPOSITORY:${{env.BRANCH_NAME}}
           docker push $ECR_REGISTRY_NEW/$ECR_REPOSITORY --all-tags
       - name: Scan postgres_django(frontend/api_postgres) Docker image
         env:
@@ -139,18 +128,6 @@ jobs:
         run: |
           docker run --rm -w /app -v $(pwd):/app node:14.4.0 /bin/bash -c "rm -rf build && npm ci && npm run build && cp env.sh .env build/"
           tar -zcvf cartsbuild.tar.gz build
-      - name: Configure AWS credentials (legacy)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Push react artifacts (legacy).
-        env:
-          IMAGE_TAG: ${{env.BUILD_TAG}}
-          APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
-        working-directory: frontend/react
-        run: aws s3 cp cartsbuild.tar.gz s3://$APPLICATION_BUCKET/artifacts/$IMAGE_TAG/cartsbuild.tar.gz
       - name: Configure AWS credentials (new account)
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -162,34 +139,6 @@ jobs:
           APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
         working-directory: frontend/react
         run: aws s3 cp cartsbuild.tar.gz s3://$APPLICATION_BUCKET/artifacts/$IMAGE_TAG/cartsbuild.tar.gz
-  uploads-legacy:
-    needs:
-      - prevalidate
-    runs-on: ubuntu-latest
-    env:
-      SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
-    steps:
-      - uses: actions/checkout@v3
-      - name: read .nvmrc
-        id: node_version
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: serverless-uploads/**/node_modules
-          key: ${{ runner.os }}-serverless-uploads-modules-${{ hashFiles('serverless-uploads/**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-serverless-uploads-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Deploy Uploads Scan
-        working-directory: serverless-uploads
-        run: ./deploy.sh ${{env.BRANCH_NAME}}
   uploads-new:
     needs:
       - prevalidate
@@ -240,45 +189,6 @@ jobs:
           VPC_NAME: ${{secrets.NEW_DEV_VPC }}
           APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.DEV_RESTORE_SNAPSHOT_ID}}
-  frontend-legacy:
-    needs:
-      - prevalidate
-      - data
-      - uploads-legacy
-      - build-react
-      - build-push-scan-postgres_django
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Configure datalayer AWS credentials (new account)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure Terraform Datalayer Provider Credentials
-        run: |
-          echo "TF_VAR_datalayer_aws_access_key=${{env.AWS_ACCESS_KEY_ID}}" >> $GITHUB_ENV
-          echo "TF_VAR_datalayer_aws_secret_key=${{env.AWS_SECRET_ACCESS_KEY}}" >> $GITHUB_ENV
-          echo "TF_VAR_datalayer_aws_session_token=${{env.AWS_SESSION_TOKEN}}" >> $GITHUB_ENV
-      - name: Configure frontend AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Terraform setup
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.0.11
-          terraform_wrapper: false
-      - name: Deploy Frontend Layer
-        run: ./frontend_deploy.sh ${{env.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}} ${{env.BUILD_TAG}}
-        env:
-          VPC_NAME: ${{secrets.DEV_VPC_NAME}}
-          OIDC_CLIENT_ID: ${{secrets.MASTER_OIDC_CLIENT_ID}}
-          OIDC_ISSUER: ${{secrets.MASTER_OIDC_ISSUER}}
-          TF_VAR_openid_discovery_url: ${{secrets.MASTER_TF_VAR_OPENID_DISCOVERY_URL}}
-          APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
   frontend-new:
     needs:
       - prevalidate

--- a/.github/workflows/dev-destroy.yml
+++ b/.github/workflows/dev-destroy.yml
@@ -19,48 +19,6 @@ env:
   ECR_REPOSITORY_API_POSTGRESS: "postgres_django"
 
 jobs:
-  destroy-frontend-legacy:
-    # Protected branches should be designated as such in the GitHub UI.
-    # So, a protected branch should never have this workflow run, since the branch should never be deleted.
-    # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
-    # This is a list of branch names that are commonly used for protected branches/environments.
-    # Add/remove names from this list as appropriate.
-    if: |
-      github.event.ref_type == 'branch' &&
-      !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref) &&
-      startsWith(github.event.ref,'dev-')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Configure datalayer AWS credentials (new account)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure Terraform Datalayer Provider Credentials
-        run: |
-          echo "TF_VAR_datalayer_aws_access_key=${{env.AWS_ACCESS_KEY_ID}}" >> $GITHUB_ENV
-          echo "TF_VAR_datalayer_aws_secret_key=${{env.AWS_SECRET_ACCESS_KEY}}" >> $GITHUB_ENV
-          echo "TF_VAR_datalayer_aws_session_token=${{env.AWS_SESSION_TOKEN}}" >> $GITHUB_ENV
-      - name: Configure frontend AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Terraform setup
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.0.11
-          terraform_wrapper: false
-      - name: Destroy frontend
-        run: ./frontend_destroy.sh ${{env.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} destroy application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}} ${{env.BUILD_TAG}}
-        env:
-          VPC_NAME: ${{secrets.DEV_VPC_NAME}}
-          OIDC_CLIENT_ID: ${{secrets.MASTER_OIDC_CLIENT_ID}}
-          OIDC_ISSUER: ${{secrets.MASTER_OIDC_ISSUER}}
-          TF_VAR_openid_discovery_url: ${{secrets.MASTER_TF_VAR_OPENID_DISCOVERY_URL}}
-          APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
   destroy-frontend-new:
     # Protected branches should be designated as such in the GitHub UI.
     # So, a protected branch should never have this workflow run, since the branch should never be deleted.
@@ -105,14 +63,12 @@ jobs:
     # Add/remove names from this list as appropriate.
     if: |
       always() &&
-      (needs.destroy-frontend-legacy.result == 'success' || needs.destroy-frontend-legacy.result == 'skipped') &&
       (needs.destroy-frontend-new.result == 'success' || needs.destroy-frontend-new.result == 'skipped') &&
       github.event.ref_type == 'branch' &&
       !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref) &&
       startsWith(github.event.ref,'dev-')
     runs-on: ubuntu-latest
     needs:
-      - destroy-frontend-legacy
       - destroy-frontend-new
     steps:
       - uses: actions/checkout@v3
@@ -132,42 +88,6 @@ jobs:
           VPC_NAME: ${{secrets.NEW_DEV_VPC}}
           APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.DEV_RESTORE_SNAPSHOT_ID}}
-  destroy-serverless-legacy-account:
-    # Protected branches should be designated as such in the GitHub UI.
-    # So, a protected branch should never have this workflow run, since the branch should never be deleted.
-    # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
-    # This is a list of branch names that are commonly used for protected branches/environments.
-    # Add/remove names from this list as appropriate.
-    if: |
-      always() &&
-      (needs.destroy-data.result == 'success' || needs.destroy-data.result == 'skipped') &&
-      github.event.ref_type == 'branch' &&
-      !contains(fromJson('["master", "main", "staging", "production", "prod"]'), github.event.ref)
-    runs-on: ubuntu-latest
-    needs:
-      - destroy-data
-    steps:
-      - uses: actions/checkout@v3
-      - name: read .nvmrc
-        id: node_version
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: serverless/**/node_modules
-          key: ${{ runner.os }}-serverless-modules-${{ hashFiles('serverless/**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-serverless-modules-
-      - name: Configure AWS credentials (legacy account)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Destroy serverless
-        working-directory: serverless
-        run: ./destroy.sh ${{env.BRANCH_NAME}}
   destroy-serverless-new-account:
     # Protected branches should be designated as such in the GitHub UI.
     # So, a protected branch should never have this workflow run, since the branch should never be deleted.

--- a/.github/workflows/master-deploy.yml
+++ b/.github/workflows/master-deploy.yml
@@ -91,15 +91,6 @@ jobs:
           key: ${{ runner.os }}-postgres_django-docker-cache-{hash}
           restore-keys: |
             ${{ runner.os }}-postgres_django-docker-cache-
-      - name: Configure AWS credentials (legacy)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Login to Amazon ECR
-        id: login-ecr-legacy
-        uses: aws-actions/amazon-ecr-login@v1
       - name: Configure AWS credentials (new account)
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -111,14 +102,12 @@ jobs:
       - name: Build, tag, and push postgres_django(frontend/api_postgres) image
         id: postgres_django_build
         env:
-          ECR_REGISTRY_LEGACY: ${{ steps.login-ecr-legacy.outputs.registry }}
           ECR_REGISTRY_NEW: ${{ steps.login-ecr-new.outputs.registry }}
           ECR_REPOSITORY: ${{env.ECR_REPOSITORY_API_POSTGRESS}}
           IMAGE_TAG: ${{ needs.build-info.outputs.build_tag }}
         working-directory: frontend/api_postgres
         run: |
-          docker build . -t $ECR_REGISTRY_LEGACY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY_LEGACY/$ECR_REPOSITORY:${{env.BRANCH_NAME}} -t $ECR_REGISTRY_NEW/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY_NEW/$ECR_REPOSITORY:${{env.BRANCH_NAME}}
-          docker push $ECR_REGISTRY_LEGACY/$ECR_REPOSITORY --all-tags
+          docker build . -t $ECR_REGISTRY_NEW/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY_NEW/$ECR_REPOSITORY:${{env.BRANCH_NAME}}
           docker push $ECR_REGISTRY_NEW/$ECR_REPOSITORY --all-tags
       - name: Scan postgres_django(frontend/api_postgres) Docker image
         env:
@@ -145,18 +134,6 @@ jobs:
         run: |
           docker run --rm -w /app -v $(pwd):/app node:14.4.0 /bin/bash -c "rm -rf build && npm ci && npm run build && cp env.sh .env build/"
           tar -zcvf cartsbuild.tar.gz build
-      - name: Configure AWS credentials (legacy)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Push react artifacts (legacy).
-        env:
-          IMAGE_TAG: ${{ needs.build-info.outputs.build_tag }}
-          APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
-        working-directory: frontend/react
-        run: aws s3 cp cartsbuild.tar.gz s3://$APPLICATION_BUCKET/artifacts/$IMAGE_TAG/cartsbuild.tar.gz
       - name: Configure AWS credentials (new account)
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -168,34 +145,6 @@ jobs:
           APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
         working-directory: frontend/react
         run: aws s3 cp cartsbuild.tar.gz s3://$APPLICATION_BUCKET/artifacts/$IMAGE_TAG/cartsbuild.tar.gz
-  uploads-legacy:
-    needs:
-      - build-info
-    runs-on: ubuntu-latest
-    env:
-      SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
-    steps:
-      - uses: actions/checkout@v3
-      - name: read .nvmrc
-        id: node_version
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: serverless-uploads/**/node_modules
-          key: ${{ runner.os }}-serverless-uploads-modules-${{ hashFiles('serverless-uploads/**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-serverless-uploads-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Deploy Uploads Scan
-        working-directory: serverless-uploads
-        run: ./deploy.sh ${{env.BRANCH_NAME}}
   uploads-new:
     needs:
       - build-info
@@ -249,50 +198,6 @@ jobs:
           TF_VAR_skip_data_deployment: true
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.MASTER_RESTORE_SNAPSHOT_ID}}
           TF_VAR_postgres_deployer_registry_id: ${{secrets.MASTER_POSTGRES_DEPLOYER_ACCOUNT_ID}}
-  frontend-legacy:
-    needs:
-      - build-info
-      - data
-      - uploads-legacy
-      - build-react
-      - build-push-scan-postgres_django
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Configure datalayer AWS credentials (new account)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ secrets.DEV_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure Terraform Datalayer Provider Credentials
-        run: |
-          echo "TF_VAR_datalayer_aws_access_key=${{env.AWS_ACCESS_KEY_ID}}" >> $GITHUB_ENV
-          echo "TF_VAR_datalayer_aws_secret_key=${{env.AWS_SECRET_ACCESS_KEY}}" >> $GITHUB_ENV
-          echo "TF_VAR_datalayer_aws_session_token=${{env.AWS_SESSION_TOKEN}}" >> $GITHUB_ENV
-      - name: Configure frontend AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Terraform setup
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.0.11
-          terraform_wrapper: false
-      - name: Deploy Frontend Layer
-        run: ./frontend_deploy.sh ${{env.APPLICATION_BUCKET}} ${{env.BRANCH_NAME}} apply application_version=${{env.BUILD_TAG}} vpc_name=${{env.VPC_NAME}} ${{env.BUILD_TAG}}
-        env:
-          BUILD_TAG: ${{ needs.build-info.outputs.build_tag }}
-          VPC_NAME: ${{secrets.DEV_VPC_NAME}}
-          OIDC_CLIENT_ID: ${{secrets.MASTER_OIDC_CLIENT_ID}}
-          OIDC_ISSUER: ${{secrets.MASTER_OIDC_ISSUER}}
-          TF_VAR_openid_discovery_url: ${{secrets.MASTER_TF_VAR_OPENID_DISCOVERY_URL}}
-          APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
-          # UI Domain can only be set in one at the time. Should currently be the new environment
-          # TF_VAR_acm_certificate_domain_ui: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
-          TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.MASTER_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
-          TF_VAR_use_custom_db_password_info: ${{ env.USE_CUSTOM_PASSWORD }}
   frontend-new:
     needs:
       - build-info
@@ -300,7 +205,6 @@ jobs:
       - uploads-new
       - build-react
       - build-push-scan-postgres_django
-      - frontend-legacy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -360,10 +264,8 @@ jobs:
         run: ./deploy.sh ${{env.BRANCH_NAME}}
   finalize:
     needs:
-      - uploads-legacy
       - uploads-new
       - data
-      - frontend-legacy
       - frontend-new
       - serverless
       - build-info

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -84,34 +84,6 @@ jobs:
         with:
           name: image_scan_results
           path: ecr_scan_*.json
-  uploads-legacy:
-    runs-on: ubuntu-latest
-    env:
-      SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.inputs.version }}
-      - name: read .nvmrc
-        id: node_version
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: serverless-uploads/**/node_modules
-          key: ${{ runner.os }}-serverless-uploads-modules-${{ hashFiles('serverless-uploads/**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-serverless-uploads-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Deploy Uploads Scan
-        working-directory: serverless-uploads
-        run: ./deploy.sh ${{ github.event.inputs.environment }}
   uploads-new:
     runs-on: ubuntu-latest
     env:
@@ -165,55 +137,11 @@ jobs:
           TF_VAR_skip_data_deployment: true
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.PROD_RESTORE_SNAPSHOT_ID}}
           TF_VAR_postgres_deployer_registry_id: ${{secrets.PROD_POSTGRES_DEPLOYER_ACCOUNT_ID}}
-  frontend-legacy:
-    needs:
-      - data
-      - uploads-legacy
-      - scan-postgres_django
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.inputs.version }}
-      - name: Configure datalayer AWS credentials (new account)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ secrets.PROD_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure Terraform Datalayer Provider Credentials
-        run: |
-          echo "TF_VAR_datalayer_aws_access_key=${{env.AWS_ACCESS_KEY_ID}}" >> $GITHUB_ENV
-          echo "TF_VAR_datalayer_aws_secret_key=${{env.AWS_SECRET_ACCESS_KEY}}" >> $GITHUB_ENV
-          echo "TF_VAR_datalayer_aws_session_token=${{env.AWS_SESSION_TOKEN}}" >> $GITHUB_ENV
-      - name: Configure frontend AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Terraform setup
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.0.11
-          terraform_wrapper: false
-      - name: Deploy Frontend Layer
-        run: ./frontend_deploy.sh ${{env.APPLICATION_BUCKET}} ${{ github.event.inputs.environment }} apply application_version=${{ github.event.inputs.version }} vpc_name=${{env.VPC_NAME}} ${{ github.event.inputs.version }}
-        env:
-          VPC_NAME: ${{secrets.PROD_VPC_NAME}}
-          OIDC_CLIENT_ID: ${{secrets.PROD_OIDC_CLIENT_ID}}
-          OIDC_ISSUER: ${{secrets.PROD_OIDC_ISSUER}}
-          TF_VAR_openid_discovery_url: ${{secrets.PROD_TF_VAR_OPENID_DISCOVERY_URL}}
-          APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
-          # UI Domain can only be set in one at the time. Should currently be the new environment
-          # TF_VAR_acm_certificate_domain_ui: ${{secrets.PROD_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
-          TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.PROD_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
-          TF_VAR_use_custom_db_password_info: ${{ env.USE_CUSTOM_PASSWORD }}
   frontend-new:
     needs:
       - data
       - uploads-new
       - scan-postgres_django
-      - frontend-legacy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -277,10 +205,8 @@ jobs:
         run: ./deploy.sh ${{ github.event.inputs.environment }}
   finalize:
     needs:
-      - uploads-legacy
       - uploads-new
       - data
-      - frontend-legacy
       - frontend-new
       - serverless
     runs-on: ubuntu-latest

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -84,34 +84,6 @@ jobs:
         with:
           name: image_scan_results
           path: ecr_scan_*.json
-  uploads-legacy:
-    runs-on: ubuntu-latest
-    env:
-      SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.inputs.version }}
-      - name: read .nvmrc
-        id: node_version
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: serverless-uploads/**/node_modules
-          key: ${{ runner.os }}-serverless-uploads-modules-${{ hashFiles('serverless-uploads/**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-serverless-uploads-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Deploy Uploads Scan
-        working-directory: serverless-uploads
-        run: ./deploy.sh ${{ github.event.inputs.environment }}
   uploads-new:
     runs-on: ubuntu-latest
     env:
@@ -165,55 +137,11 @@ jobs:
           TF_VAR_skip_data_deployment: true
           TF_VAR_postgres_restore_snapshot_id: ${{secrets.STAGING_RESTORE_SNAPSHOT_ID}}
           TF_VAR_postgres_deployer_registry_id: ${{secrets.STAGING_POSTGRES_DEPLOYER_ACCOUNT_ID}}
-  frontend-legacy:
-    needs:
-      - data
-      - uploads-legacy
-      - scan-postgres_django
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.inputs.version }}
-      - name: Configure datalayer AWS credentials (new account)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ secrets.STAGING_NEW_AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Configure Terraform Datalayer Provider Credentials
-        run: |
-          echo "TF_VAR_datalayer_aws_access_key=${{env.AWS_ACCESS_KEY_ID}}" >> $GITHUB_ENV
-          echo "TF_VAR_datalayer_aws_secret_key=${{env.AWS_SECRET_ACCESS_KEY}}" >> $GITHUB_ENV
-          echo "TF_VAR_datalayer_aws_session_token=${{env.AWS_SESSION_TOKEN}}" >> $GITHUB_ENV
-      - name: Configure frontend AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Terraform setup
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.0.11
-          terraform_wrapper: false
-      - name: Deploy Frontend Layer
-        run: ./frontend_deploy.sh ${{env.APPLICATION_BUCKET}} ${{ github.event.inputs.environment }} apply application_version=${{ github.event.inputs.version }} vpc_name=${{env.VPC_NAME}} ${{ github.event.inputs.version }}
-        env:
-          VPC_NAME: ${{secrets.STAGING_VPC_NAME}}
-          OIDC_CLIENT_ID: ${{secrets.STAGING_OIDC_CLIENT_ID}}
-          OIDC_ISSUER: ${{secrets.STAGING_OIDC_ISSUER}}
-          TF_VAR_openid_discovery_url: ${{secrets.STAGING_TF_VAR_OPENID_DISCOVERY_URL}}
-          APPLICATION_BUCKET: ${{secrets.APPLICATION_BUCKET}}
-          # UI Domain can only be set in one at the time. Should currently be the new environment
-          # TF_VAR_acm_certificate_domain_ui: ${{secrets.STAGING_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
-          TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.STAGING_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
-          TF_VAR_use_custom_db_password_info: ${{ env.USE_CUSTOM_PASSWORD }}
   frontend-new:
     needs:
       - data
       - uploads-new
       - scan-postgres_django
-      - frontend-legacy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -277,10 +205,8 @@ jobs:
         run: ./deploy.sh ${{ github.event.inputs.environment }}
   finalize:
     needs:
-      - uploads-legacy
       - uploads-new
       - data
-      - frontend-legacy
       - frontend-new
       - serverless
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

With DNS traffic no longer resolving to the old legacy environment, we do not need to build for that environment anymore and can remove the CI/CD tasks related to building and deploying to that environment.

Terraform code is being left alone for now until after we tear down the old infrastructure, as the terraform code will be needed for that.

## How to test

Tested via this branch deploying to only the new environment.

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
