### PR TITLE
[MDCT-297] Chips Seds data - calculate missing values

### DIFF
--- a/services/database/seed-section-base.json
+++ b/services/database/seed-section-base.json
@@ -1635,24 +1635,20 @@
                             "lookupChipEnrollments": {
                               "ffy": "2022",
                               "enrollmentType": "Medicaid Expansion CHIP",
-                              "index": 1,
-                              "valueType": "number"
+                              "index": 1
                             }
                           },
                           {
                             "lookupChipEnrollments": {
                               "ffy": "2022",
                               "enrollmentType": "Medicaid Expansion CHIP",
-                              "index": 2,
-                              "valueType": "number"
+                              "index": 2
                             }
                           },
                           {
-                            "lookupChipEnrollments": {
+                            "compareChipEnrollements": {
                               "ffy": "2022",
-                              "enrollmentType": "Medicaid Expansion CHIP",
-                              "index": 3,
-                              "valueType": "percent"
+                              "enrollmentType": "Medicaid Expansion CHIP"
                             }
                           }
                         ],
@@ -1664,24 +1660,20 @@
                             "lookupChipEnrollments": {
                               "ffy": "2022",
                               "enrollmentType": "Separate CHIP",
-                              "index": 1,
-                              "valueType": "number"
+                              "index": 1
                             }
                           },
                           {
                             "lookupChipEnrollments": {
                               "ffy": "2022",
                               "enrollmentType": "Separate CHIP",
-                              "index": 2,
-                              "valueType": "number"
+                              "index": 2
                             }
                           },
                           {
-                            "lookupChipEnrollments": {
+                            "compareChipEnrollements": {
                               "ffy": "2022",
-                              "enrollmentType": "Separate CHIP",
-                              "index": 3,
-                              "valueType": "percent"
+                              "enrollmentType": "Separate CHIP"
                             }
                           }
                         ]

--- a/services/database/seed-stg-enrollment-counts.json
+++ b/services/database/seed-stg-enrollment-counts.json
@@ -20,16 +20,6 @@
     "yearToModify": "2022"
   },
   {
-    "pk": "AK-2022",
-    "entryKey": "medicaid_exp_chip-3",
-    "indexToUpdate": 3,
-    "stateId": "AK",
-    "typeOfEnrollment": "Medicaid Expansion CHIP",
-    "enrollmentCount": 123,
-    "filterId": "2022-02",
-    "yearToModify": "2022"
-  },
-  {
     "pk": "AL-2022",
     "entryKey": "medicaid_exp_chip-1",
     "indexToUpdate": 1,
@@ -51,16 +41,6 @@
   },
   {
     "pk": "AL-2022",
-    "entryKey": "medicaid_exp_chip-3",
-    "indexToUpdate": 3,
-    "stateId": "AL",
-    "typeOfEnrollment": "Medicaid Expansion CHIP",
-    "enrollmentCount": 5,
-    "filterId": "2022-02",
-    "yearToModify": "2022"
-  },
-  {
-    "pk": "AL-2022",
     "entryKey": "separate_chip-1",
     "indexToUpdate": 1,
     "stateId": "AL",
@@ -77,16 +57,6 @@
     "typeOfEnrollment": "Separate CHIP",
     "enrollmentCount": 123,
     "filterId": "2021-02",
-    "yearToModify": "2022"
-  },
-  {
-    "pk": "AL-2022",
-    "entryKey": "separate_chip-3",
-    "indexToUpdate": 3,
-    "stateId": "AL",
-    "typeOfEnrollment": "Separate CHIP",
-    "enrollmentCount": 4,
-    "filterId": "2022-02",
     "yearToModify": "2022"
   }
 ]

--- a/services/ui-src/src/util/shouldDisplay.js
+++ b/services/ui-src/src/util/shouldDisplay.js
@@ -1,6 +1,10 @@
 import { AppRoles } from "../types";
 import jsonpath from "./jsonpath";
-import { compareACS, lookupChipEnrollments } from "./synthesize";
+import {
+  compareACS,
+  lookupChipEnrollments,
+  compareChipEnrollements,
+} from "./synthesize";
 
 /**
  * This function determines whether a radio's conditional subquestion should hide
@@ -65,6 +69,10 @@ const hideIfTableValue = (state, hideIfTableValueInfo) => {
         } else if (item.lookupChipEnrollments) {
           computedRow.push(
             lookupChipEnrollments(state, item.lookupChipEnrollments)
+          );
+        } else if (item.compareChipEnrollements) {
+          computedRow.push(
+            compareChipEnrollements(state, item.compareChipEnrollements)
           );
         } else {
           // Let non-computed entries pass through with the other data transparently

--- a/services/ui-src/src/util/synthesize.js
+++ b/services/ui-src/src/util/synthesize.js
@@ -322,7 +322,7 @@ export const lookupChipEnrollments = (
         enrollment.typeOfEnrollment === enrollmentType
     );
     if (targetValue) {
-      returnValue = targetValue.enrollmentCount;
+      returnValue = targetValue.enrollmentCount.toLocaleString();
     }
   }
   return returnValue;
@@ -351,7 +351,8 @@ export const compareChipEnrollements = (state, { ffy, enrollmentType }) => {
         ((newCount.enrollmentCount - oldCount.enrollmentCount) /
           oldCount.enrollmentCount) *
         100;
-      returnValue = Math.round(returnValue * 1000) / 1000 + "%";
+      returnValue =
+        (Math.round(returnValue * 1000) / 1000).toLocaleString() + "%";
     }
   }
   return returnValue;

--- a/services/ui-src/src/util/synthesize.js
+++ b/services/ui-src/src/util/synthesize.js
@@ -308,7 +308,7 @@ export const compareACS = (state, { ffy1, ffy2, acsProperty }) => {
 
 export const lookupChipEnrollments = (
   state,
-  { ffy, enrollmentType, index, valueType }
+  { ffy, enrollmentType, index }
 ) => {
   let returnValue = "Not Available";
   if (
@@ -323,7 +323,35 @@ export const lookupChipEnrollments = (
     );
     if (targetValue) {
       returnValue = targetValue.enrollmentCount;
-      if (valueType === "percent") returnValue += "%";
+    }
+  }
+  return returnValue;
+};
+
+export const compareChipEnrollements = (state, { ffy, enrollmentType }) => {
+  let returnValue = "Not Available";
+  if (
+    state.enrollmentCounts &&
+    state.enrollmentCounts.chipEnrollments.length > 0
+  ) {
+    const oldCount = state.enrollmentCounts.chipEnrollments.find(
+      (enrollment) =>
+        enrollment.yearToModify === ffy &&
+        enrollment.indexToUpdate === 1 &&
+        enrollment.typeOfEnrollment === enrollmentType
+    );
+    const newCount = state.enrollmentCounts.chipEnrollments.find(
+      (enrollment) =>
+        enrollment.yearToModify === ffy &&
+        enrollment.indexToUpdate === 2 &&
+        enrollment.typeOfEnrollment === enrollmentType
+    );
+    if (oldCount && newCount && oldCount.enrollmentCounts !== 0) {
+      returnValue =
+        ((newCount.enrollmentCount - oldCount.enrollmentCount) /
+          oldCount.enrollmentCount) *
+        100;
+      returnValue = Math.round(returnValue * 1000) / 1000 + "%";
     }
   }
   return returnValue;
@@ -349,6 +377,12 @@ const synthesizeValue = (value, state) => {
   if (value.lookupChipEnrollments) {
     return {
       contents: [lookupChipEnrollments(state, value.lookupChipEnrollments)],
+    };
+  }
+
+  if (value.compareChipEnrollements) {
+    return {
+      contents: [compareChipEnrollements(state, value.compareChipEnrollements)],
     };
   }
 


### PR DESCRIPTION
# Description

Made a bad assumption that column 3 was provided in the seds chip data. It was added as part of the trigger comparing the two other indexes. This should handle the calculation and simplify the form a little. The generated format matched the previous calculation and display of 3 decimals if necessary.

## How to test

Run it locally, generate new forms, check that the 2022 item is populated for Alabama.

## Dependencies

None

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
