### PR TITLE
[MDCT-297] Display "-" instead of Infinity when prior year is 0

### DIFF
--- a/services/ui-src/src/actions/initial.js
+++ b/services/ui-src/src/actions/initial.js
@@ -196,7 +196,6 @@ export const loadEnrollmentCounts = ({ stateCode, selectedYear }) => {
 };
 
 export const loadUser = (user) => async (dispatch) => {
-  console.log(user);
   const { email, given_name, family_name, userRole, state } = user;
   const flattenedUser = {
     username: email,

--- a/services/ui-src/src/util/synthesize.js
+++ b/services/ui-src/src/util/synthesize.js
@@ -346,7 +346,8 @@ export const compareChipEnrollements = (state, { ffy, enrollmentType }) => {
         enrollment.indexToUpdate === 2 &&
         enrollment.typeOfEnrollment === enrollmentType
     );
-    if (oldCount && newCount && oldCount.enrollmentCounts !== 0) {
+    if (oldCount && newCount) {
+      if (oldCount.enrollmentCount === 0) return "-";
       returnValue =
         ((newCount.enrollmentCount - oldCount.enrollmentCount) /
           oldCount.enrollmentCount) *


### PR DESCRIPTION
# Description

Small bugfix for displaying infinity when the prior year data is 0.

## How to test

Prep the seeded data with a 0 before viewing section 2.

## Dependencies

N/A

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
