### PR TITLE
MDCT-48: Submit and Uncertify E2E Test

### DIFF
--- a/services/ui-src/src/components/sections/homepage/ReportItem.js
+++ b/services/ui-src/src/components/sections/homepage/ReportItem.js
@@ -112,7 +112,11 @@ const ReportItem = ({
           <div className="status ds-l-col--2">{statusText}</div>
           <div className="actions ds-l-col--3">{lastEditedNote}</div>
           <div className="actions ds-l-col--1">
-            <Link to={link1URL} target={anchorTarget}>
+            <Link
+              to={link1URL}
+              target={anchorTarget}
+              data-testid="report-action-button"
+            >
               {link1Text}
             </Link>
           </div>

--- a/tests/cypress/cypress.json
+++ b/tests/cypress/cypress.json
@@ -16,9 +16,11 @@
   "defaultCommandTimeout": 15000,
   "types": ["cypress", "cypress-axe"],
   "env": {
-    "STATE_USER_EMAIL": "stateuser1@test.com",
+    "STATE_USER_EMAIL": "stateuser2@test.com",
     "STATE_USER_PASSWORD": "p@55W0rd!",
     "ADMIN_USER_EMAIL": "cms.admin@test.com",
-    "ADMIN_USER_PASSWORD": "p@55W0rd!"
+    "ADMIN_USER_PASSWORD": "p@55W0rd!",
+    "REVIEWER_EMAIL": "cms.user@test.com",
+    "REVIEWER_PASSWORD": "p@55W0rd!"
   }
 }

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -21,6 +21,11 @@ const adminUser = {
   password: Cypress.env("ADMIN_USER_PASSWORD"),
 };
 
+const reviewer = {
+  email: Cypress.env("REVIEWER_EMAIL"),
+  password: Cypress.env("REVIEWER_PASSWORD"),
+};
+
 Cypress.Commands.add("authenticate", (userType, userCredentials) => {
   let credentials = {};
   if (userType && userCredentials) {
@@ -36,6 +41,9 @@ Cypress.Commands.add("authenticate", (userType, userCredentials) => {
         break;
       case "stateUser":
         credentials = stateUser;
+        break;
+      case "reviewer":
+        credentials = reviewer;
         break;
       default:
         throw new Error("Provided userType not recognized.");

--- a/tests/cypress/tests/integration/submitAndUncertify.spec.js
+++ b/tests/cypress/tests/integration/submitAndUncertify.spec.js
@@ -15,9 +15,9 @@ describe("CARTS Submit and Uncertify Integration Tests", () => {
     cy.authenticate("stateUser");
 
     // certify and submit report
-    cy.get(actionButton).contains("Edit").click();
+    cy.get(actionButton).should("be.visible").contains("Edit").click();
     cy.contains("Certify and Submit").click();
-    cy.get(certifySubmitButton).click();
+    cy.get(certifySubmitButton).should("be.visible").click();
     cy.get("button").contains("Confirm Certify and Submit").click();
     cy.get("button").contains("Return Home").click();
 
@@ -29,7 +29,11 @@ describe("CARTS Submit and Uncertify Integration Tests", () => {
     cy.authenticate("reviewer");
 
     // uncertify report
-    cy.get(uncertifyButton).first().contains("Uncertify").click();
+    cy.get(uncertifyButton)
+      .first()
+      .should("be.visible")
+      .contains("Uncertify")
+      .click();
     cy.get("button").contains("Yes, Uncertify").click();
 
     // log back out

--- a/tests/cypress/tests/integration/submitAndUncertify.spec.js
+++ b/tests/cypress/tests/integration/submitAndUncertify.spec.js
@@ -1,0 +1,45 @@
+// element selectors
+const logoutButton = "[data-testid='header-menu-option-log-out']";
+const headerDropdownMenu = "[data-testid='headerDropDownMenu']";
+const actionButton = "[data-testid='report-action-button']";
+const certifySubmitButton = "[data-testid='certifySubmit']";
+const uncertifyButton = "[data-testid='uncertifyButton']";
+
+describe("CARTS Submit and Uncertify Integration Tests", () => {
+  before(() => {
+    cy.visit("/");
+  });
+
+  it("Should submit form as a State User", () => {
+    // log in as State User
+    cy.authenticate("stateUser");
+
+    // certify and submit report
+    cy.get(actionButton).contains("Edit").click();
+    cy.contains("Certify and Submit").click();
+    cy.get(certifySubmitButton).click();
+    cy.get("button").contains("Confirm Certify and Submit").click();
+    cy.get("button").contains("Return Home").click();
+
+    // log out
+    cy.get(headerDropdownMenu).click();
+    cy.get(logoutButton).click();
+
+    // log in as CMS User (Reviewer)
+    cy.authenticate("reviewer");
+
+    // uncertify report
+    cy.get(uncertifyButton).first().contains("Uncertify").click();
+    cy.get("button").contains("Yes, Uncertify").click();
+
+    // log back out
+    cy.get(headerDropdownMenu).click();
+    cy.get(logoutButton).click();
+
+    // log back in as State User
+    cy.authenticate("stateUser");
+
+    // the report should be "In Progress" again
+    cy.get(actionButton).contains("Edit").should("be.visible");
+  });
+});

--- a/tests/cypress/tests/integration/submitAndUncertify.spec.js
+++ b/tests/cypress/tests/integration/submitAndUncertify.spec.js
@@ -15,7 +15,10 @@ describe("CARTS Submit and Uncertify Integration Tests", () => {
     cy.authenticate("stateUser");
 
     // certify and submit report
-    cy.get(actionButton).should("be.visible").contains("Edit").click();
+    cy.get(actionButton, { timeout: 30000 })
+      .should("be.visible")
+      .contains("Edit")
+      .click();
     cy.contains("Certify and Submit").click();
     cy.get(certifySubmitButton).should("be.visible").click();
     cy.get("button").contains("Confirm Certify and Submit").click();

--- a/tests/cypress/tests/integration/submitAndUncertify.spec.js
+++ b/tests/cypress/tests/integration/submitAndUncertify.spec.js
@@ -15,12 +15,9 @@ describe("CARTS Submit and Uncertify Integration Tests", () => {
     cy.authenticate("stateUser");
 
     // certify and submit report
-    cy.get(actionButton, { timeout: 30000 })
-      .should("be.visible")
-      .contains("Edit")
-      .click();
+    cy.get(actionButton, { timeout: 30000 }).contains("Edit").click();
     cy.contains("Certify and Submit").click();
-    cy.get(certifySubmitButton).should("be.visible").click();
+    cy.get(certifySubmitButton).click();
     cy.get("button").contains("Confirm Certify and Submit").click();
     cy.get("button").contains("Return Home").click();
 
@@ -32,11 +29,7 @@ describe("CARTS Submit and Uncertify Integration Tests", () => {
     cy.authenticate("reviewer");
 
     // uncertify report
-    cy.get(uncertifyButton)
-      .first()
-      .should("be.visible")
-      .contains("Uncertify")
-      .click();
+    cy.get(uncertifyButton).first().contains("Uncertify").click();
     cy.get("button").contains("Yes, Uncertify").click();
 
     // log back out


### PR DESCRIPTION
# Description

Closes [MDCT-48](https://qmacbis.atlassian.net/browse/MDCT-48).

Adding an integration test for this flow:
- State User logs in
- Certifies and submits a report
- State User logs out
- CMS Reviewer logs in
- CMS Reviewer un-certifies that report

## How to test

Run `yarn test` and see the magic ✨ 

## Dependencies

N/A

# Get it done

N/A

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
