### PR TITLE
Re-Apply rules: don't allow unclean downloads

### DIFF
--- a/frontend/aws/s3_uploads.tf
+++ b/frontend/aws/s3_uploads.tf
@@ -55,7 +55,7 @@ resource "aws_s3_bucket_policy" "b" {
     Statement = concat([
       {
         Sid       = "MustBeClean"
-        Effect    = "Allow"
+        Effect    = "Deny"
         Principal = "*"
         Action = [
           "s3:GetObject"


### PR DESCRIPTION
# Description
This never actually released to any envs with the Allow flag, it was all managed directly in the console for porting files. Change the rule back to its initial state.

## How to test
App deploys again

## Dependencies
N/A

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
