### PR TITLE
lastChanged on section

### DIFF
--- a/services/app-api/handlers/formTemplates/post.ts
+++ b/services/app-api/handlers/formTemplates/post.ts
@@ -38,6 +38,7 @@ export const post = handler(async (event, _context) => {
   // Copy out report string and populate state data
   const forms = [];
   const stateStatuses = [];
+  const creationTime = new Date().toString();
   for (const state of queuedStates) {
     for (const section of baseSections) {
       state;
@@ -47,6 +48,7 @@ export const post = handler(async (event, _context) => {
       sectionObj.year = yearNumber;
       sectionObj.stateId = state.code;
       sectionObj.contents.section.state = state.code;
+      sectionObj.lastChanged = creationTime;
 
       // Section 0 Special Case - Program Type should be read from State
       if (sectionObj.sectionId === 0) {
@@ -60,6 +62,7 @@ export const post = handler(async (event, _context) => {
       year: yearNumber,
       programType: state.programType,
       status: "not_started",
+      lastChanged: creationTime,
     });
   }
 

--- a/services/app-api/handlers/section/tests/update.test.ts
+++ b/services/app-api/handlers/section/tests/update.test.ts
@@ -51,6 +51,7 @@ describe("Test Update Sections Handler", () => {
       1,
       {
         contents: { test: "test" },
+        lastChanged: new Date().toString(),
       },
       "post"
     );

--- a/services/app-api/handlers/section/update.ts
+++ b/services/app-api/handlers/section/update.ts
@@ -21,7 +21,6 @@ export const updateSections = handler(async (event, _context) => {
 
   const user = getUserCredentialsFromJwt(event);
   const { year, state } = event.pathParameters;
-
   // only state users can update reports associated with their assigned state
   if (
     (user.role === AppRoles.STATE_USER && user.state !== state) ||
@@ -42,6 +41,7 @@ export const updateSections = handler(async (event, _context) => {
   }
 
   // Update each of the Sections for the report associated with the given year and state
+  const lastChanged = new Date().toString();
   for (let section = 0; section < reportData.length; section++) {
     const params = {
       TableName: process.env.sectionTableName!,
@@ -52,6 +52,7 @@ export const updateSections = handler(async (event, _context) => {
       ...convertToDynamoExpression(
         {
           contents: reportData[section].contents,
+          lastChanged: lastChanged,
         },
         "post"
       ),
@@ -75,23 +76,23 @@ export const updateSections = handler(async (event, _context) => {
 
   const queryValue = await dynamoDb.query(params);
   const stateStatus = queryValue.Items![0] as StateStatus;
+  const moveToInProgress =
+    queryValue.Items && stateStatus.status === "not_started";
 
-  if (queryValue.Items && stateStatus.status === "not_started") {
-    const params = {
-      TableName: process.env.stateStatusTableName!,
-      Key: {
-        stateId: state,
-        year: parseInt(year),
+  const statusParams = {
+    TableName: process.env.stateStatusTableName!,
+    Key: {
+      stateId: state,
+      year: parseInt(year),
+    },
+    ...convertToDynamoExpression(
+      {
+        status: moveToInProgress ? "in_progress" : stateStatus.status,
+        lastChanged: lastChanged,
       },
-      ...convertToDynamoExpression(
-        {
-          status: "in_progress",
-          lastChanged: new Date().toString(),
-        },
-        "post"
-      ),
-    };
+      "post"
+    ),
+  };
 
-    await dynamoDb.update(params);
-  }
+  await dynamoDb.update(statusParams);
 });

--- a/services/database/handlers/dataMigration/tables/section.js
+++ b/services/database/handlers/dataMigration/tables/section.js
@@ -1,4 +1,4 @@
-const query = `select contents->'section'->'state' as "stateId", contents->'section'->'year' as year, contents->'section'->'ordinal' as "sectionId", contents
+const query = `select contents->'section'->'state' as "stateId", contents->'section'->'year' as year, contents->'section'->'ordinal' as "sectionId", modified_on as "lastChanged", contents
 from carts_api_section`;
 
 const migration = {
@@ -7,6 +7,7 @@ const migration = {
   transform: (rows) => {
     rows.map((row) => {
       row.pk = `${row.stateId}-${row.year}`;
+      row.lastChanged = row.lastChanged?.toString();
     });
     return rows;
   },


### PR DESCRIPTION
# Description
Downstream there is a use case for tracking the lastChanged time on a per-section basis. Added a timestamp for that.

Update the time to be marked on creation for status, and roll up modification times to status on all updates.

## How to test
You should see a new field on the section, and the dashboard page timestamps should update accurately on interaction with the sections.

## Dependencies
None

# Get it done
Merge it, and let the Dataconnect team know as it goes through each env

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
