### PR TITLE
V2: Remove custom domain from prod deploy

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -170,7 +170,7 @@ jobs:
           OIDC_ISSUER: ${{secrets.PROD_OIDC_ISSUER}}
           TF_VAR_openid_discovery_url: ${{secrets.PROD_TF_VAR_OPENID_DISCOVERY_URL}}
           APPLICATION_BUCKET: ${{secrets.NEW_APPLICATION_BUCKET}}
-          TF_VAR_acm_certificate_domain_ui: ${{secrets.PROD_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
+          # TF_VAR_acm_certificate_domain_ui: ${{secrets.PROD_TF_VAR_ACM_CERTIFICATE_DOMAIN_UI}}
           TF_VAR_acm_certificate_domain_api_postgres: ${{secrets.PROD_TF_VAR_ACM_CERTIFICATE_DOMAIN_API_POSTGRES}}
           TF_VAR_use_custom_db_password_info: ${{ env.USE_CUSTOM_PASSWORD }}
           TF_VAR_postgres_django_registry_id: ${{secrets.PROD_POSTGRES_DJANGO_ACCOUNT_ID}}


### PR DESCRIPTION
# Description
Remove the relationship to the domain from the deploy step, so that the next time we run deploy it will release its hold on that env.

## How to test
Run deploy, watch mdctcarts.cms.gov throw errors.

## Dependencies
N/A

# Get it done
Once the DNS change is live:
* Run this deploy step
* Remove the GitHub Secret of the same name (else GitHub actions will think that value can't be used in v3 deploy)
* Add the related cert arm and domain SSM params for v3
* Run the latest v3 release step.

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
