### PR TITLE
[MDCT-2036] Missing ACS Data in <= 2021 Forms

### DIFF
--- a/services/ui-src/src/util/synthesize.js
+++ b/services/ui-src/src/util/synthesize.js
@@ -215,6 +215,13 @@ const lookupFMAP = (state, fy) => {
   return "";
 };
 
+const snakeToCamel = (str) =>
+  str
+    .toLowerCase()
+    .replace(/([-_][a-z])/g, (group) =>
+      group.toUpperCase().replace("-", "").replace("_", "")
+    );
+
 /**
  * Retrieve acsSet from state and return for individual state.
  *
@@ -225,6 +232,11 @@ const lookupFMAP = (state, fy) => {
  */
 const lookupAcs = (state, { ffy, acsProperty }) => {
   let returnValue = "Not Available";
+  // Support prior lookup syntax in form lookups
+  const acsPropQuery = acsProperty.includes("_")
+    ? snakeToCamel(acsProperty)
+    : acsProperty;
+
   // if allStatesData and stateUser are available
   if (state.allStatesData && state.stateUser) {
     const windowPathName = window.location.pathname;
@@ -250,7 +262,7 @@ const lookupAcs = (state, { ffy, acsProperty }) => {
 
     // If acs exists, return the value from the object
     if (acs) {
-      returnValue = Number(`${acs[acsProperty]}`).toLocaleString();
+      returnValue = Number(`${acs[acsPropQuery]}`).toLocaleString();
       if (acsProperty.includes("percent")) {
         returnValue += "%";
       }

--- a/services/ui-src/src/util/synthesize.test.js
+++ b/services/ui-src/src/util/synthesize.test.js
@@ -3,6 +3,36 @@
 import synthesize from "../util/synthesize";
 
 const state = {
+  allStatesData: [
+    {
+      name: "Alabama",
+      programNames: {},
+      programType: "combo",
+      code: "AL",
+      fmapSet: [],
+      acsSet: [
+        {
+          percentUninsured: "2.1",
+          numberUninsuredMoe: 4000,
+          year: 2021,
+          percentUninsuredMoe: "0.3",
+          stateId: "AL",
+          numberUninsured: 27000,
+        },
+        {
+          percentUninsured: "3.1",
+          numberUninsuredMoe: 5000,
+          year: 2020,
+          percentUninsuredMoe: "0.3",
+          stateId: "AL",
+          numberUninsured: 28000,
+        },
+      ],
+    },
+  ],
+  stateUser: {
+    abbr: "AL",
+  },
   items: [
     {
       id: "item0",
@@ -350,6 +380,85 @@ describe("value synthesization utility", () => {
       );
 
       expect(out).toEqual({ contents: 1.6 });
+    });
+  });
+
+  describe("handles ACS Data", () => {
+    it("handles a lookup for a ffy and property", () => {
+      const out = synthesize(
+        {
+          lookupAcs: {
+            ffy: 2021,
+            acsProperty: "numberUninsured",
+          },
+        },
+        state
+      );
+      expect(out).toEqual({ contents: ["27,000"] });
+    });
+
+    it("returns results for properties in other cases", () => {
+      const out = synthesize(
+        {
+          lookupAcs: {
+            ffy: 2021,
+            acsProperty: "number_uninsured",
+          },
+        },
+        state
+      );
+      expect(out).toEqual({ contents: ["27,000"] });
+    });
+
+    it("returns 'Not Available' when no data found", () => {
+      const out = synthesize(
+        {
+          lookupAcs: {
+            ffy: 2555,
+            acsProperty: "cyborgsCreated",
+          },
+        },
+        state
+      );
+      expect(out).toEqual({ contents: ["Not Available"] });
+      const outCompare = synthesize(
+        {
+          compareACS: {
+            ffy1: 2555,
+            ffy2: 1900,
+            acsProperty: "cyborgsCreated",
+          },
+        },
+        state
+      );
+      expect(outCompare).toEqual({ contents: ["Not Available"] });
+    });
+
+    it("formats percents on lookup", () => {
+      const out = synthesize(
+        {
+          lookupAcs: {
+            ffy: 2021,
+            acsProperty: "percentUninsured",
+          },
+        },
+        state
+      );
+      expect(out).toEqual({ contents: ["2.1%"] });
+    });
+
+    it("compares two ffys", () => {
+      const out = synthesize(
+        {
+          compareACS: {
+            ffy1: 2021,
+            ffy2: 2020,
+            acsProperty: "numberUninsured",
+          },
+        },
+        state
+      );
+      expect(out).toEqual({ contents: ["3.70%"] });
     });
   });
 });


### PR DESCRIPTION
# Description
2021 Forms and earlier have snake case acs lookup props. We can support that syntax easily, rather than a sweeping data fix. This just checks if the param is snake case before doing the lookup, and adjusts it.

## How to test
To test this locally you'll either need to modify the casing on the acsLookup calls in section 2, part to

## Dependencies

Please spell out any dependencies for this change -- ex -- requires an install / update / migration etc

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
