### PR TITLE
[MDCT-2034] Radio Buttons vs Accessibility

### DIFF
--- a/services/ui-src/src/components/fields/CMSLegend.js
+++ b/services/ui-src/src/components/fields/CMSLegend.js
@@ -19,9 +19,15 @@ const CMSLegend = ({ hideNumber, hint, id, label, questionType }) => {
 
     return (
       <>
-        <legend className="label-header">{legend.join(" ")}</legend>
+        <legend className="label-header" data-testid="question-legend">
+          {legend.join(" ")}
+        </legend>
         {hint && (
-          <div className="ds-c-field__hint" aria-label={`${label} hint`}>
+          <div
+            className="ds-c-field__hint"
+            data-testid="legend-hint"
+            aria-label={`${label} hint`}
+          >
             <Text>{hint}</Text>
           </div>
         )}

--- a/services/ui-src/src/components/fields/CMSLegend.js
+++ b/services/ui-src/src/components/fields/CMSLegend.js
@@ -13,20 +13,19 @@ const CMSLegend = ({ hideNumber, hint, id, label, questionType }) => {
     !questionType.includes("email") &&
     !questionType.includes("percentage")
   ) {
+    let legend = [];
+    if (!hideNumber) legend.push(labelBits);
+    legend.push(label);
+
     return (
-      <div>
-        {!hideNumber && <p>{labelBits}</p>}
-        {!questionType.includes("text") && (
-          <h4 className="label-header" aria-label="Label Text">
-            {label}
-          </h4>
-        )}
+      <>
+        <legend className="label-header">{legend.join(" ")}</legend>
         {hint && (
           <div className="ds-c-field__hint" aria-label={`${label} hint`}>
             <Text>{hint}</Text>
           </div>
         )}
-      </div>
+      </>
     );
   } else {
     return null;

--- a/services/ui-src/src/components/fields/CMSLegend.test.js
+++ b/services/ui-src/src/components/fields/CMSLegend.test.js
@@ -1,0 +1,66 @@
+import React from "react";
+import { shallow } from "enzyme";
+import CMSLegend from "./CMSLegend";
+import { Provider } from "react-redux";
+import configureMockStore from "redux-mock-store";
+import { screen, render } from "@testing-library/react";
+
+const legend = <CMSLegend questionType="radio" />;
+const mockStore = configureMockStore();
+const store = mockStore({});
+const buildLegend = (legendProps) => {
+  return (
+    <Provider store={store}>
+      <CMSLegend {...legendProps} />
+    </Provider>
+  );
+};
+describe("CMS Legend", () => {
+  it("should render correctly", () => {
+    expect(shallow(legend).exists()).toBe(true);
+  });
+
+  it.each([
+    ["text", false],
+    ["mailing_address", false],
+    ["phone_number", false],
+    ["email", false],
+    ["percentage", false],
+    ["radio", true],
+    ["fieldset", true],
+  ])(
+    "Question type %s should show or hide legend, and allow hints if rendered",
+    (questionType, expected) => {
+      render(
+        buildLegend({
+          hideNumber: false,
+          hint: "hint",
+          id: "2022-0-1-1a",
+          label: "Label",
+          questionType: questionType,
+        })
+      );
+      const legend = screen.queryByTestId("question-legend");
+      if (expected) {
+        expect(legend).not.toBeNull();
+        let hint = screen.getByTestId("legend-hint");
+        expect(hint).not.toBeNull();
+      } else {
+        expect(legend).toBeNull();
+      }
+    }
+  );
+
+  it("Hint should hide when not provided", () => {
+    render(
+      buildLegend({
+        hideNumber: false,
+        id: "2022-0-1-1a",
+        label: "Label",
+        questionType: "radio",
+      })
+    );
+    const hint = screen.queryByTestId("legend-hint");
+    expect(hint).toBeNull();
+  });
+});

--- a/services/ui-src/src/components/fields/Checkbox.js
+++ b/services/ui-src/src/components/fields/Checkbox.js
@@ -42,7 +42,7 @@ const Checkbox = ({ onChange, question, ...props }) => {
     }
   );
 
-  return <fieldset className="ds-c-fieldset">{radioButttonList}</fieldset>;
+  return <div className="ds-c-fieldset">{radioButttonList}</div>;
 };
 Checkbox.propTypes = {
   onChange: PropTypes.func.isRequired,

--- a/services/ui-src/src/components/fields/Question.js
+++ b/services/ui-src/src/components/fields/Question.js
@@ -50,12 +50,9 @@ const questionTypes = new Map([
   ["text_small", TextSmall],
 ]);
 
-const Container = ({ question, children }) =>
-  question.type === "fieldset" ? (
-    <>{children}</>
-  ) : (
-    <fieldset className="ds-c-fieldset">{children}</fieldset>
-  );
+const Container = ({ children }) => (
+  <fieldset className="ds-c-fieldset">{children}</fieldset>
+);
 Container.propTypes = {
   question: PropTypes.object.isRequired,
   children: PropTypes.node.isRequired,

--- a/services/ui-src/src/components/fields/Radio.js
+++ b/services/ui-src/src/components/fields/Radio.js
@@ -49,7 +49,7 @@ const Radio = ({ onChange, onClick, question, ...props }) => {
     );
   });
 
-  return <fieldset className="ds-c-fieldset">{radioButttonList}</fieldset>;
+  return <div className="ds-c-fieldset">{radioButttonList}</div>;
 };
 Radio.propTypes = {
   onChange: PropTypes.func.isRequired,

--- a/services/ui-src/src/components/fields/SkipText.js
+++ b/services/ui-src/src/components/fields/SkipText.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Alert } from "@cmsgov/design-system";
 
 const SkipText = ({ question: { skip_text: skipText } }) => (
-  <Alert autoFocus>
+  <Alert>
     <p className="ds-c-alert__text">{skipText}</p>
   </Alert>
 );

--- a/services/ui-src/src/components/fields/SkipText.test.js
+++ b/services/ui-src/src/components/fields/SkipText.test.js
@@ -1,0 +1,21 @@
+import React from "react";
+
+import { shallow } from "enzyme";
+import { axe } from "jest-axe";
+import SkipText from "./SkipText";
+
+const wrapper = <SkipText question={{ skip_text: "Render text" }} />;
+
+describe("<SkipText />", () => {
+  it("should render correctly", () => {
+    expect(shallow(wrapper).exists()).toBe(true);
+  });
+});
+
+describe("Test <SkipText /> accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    const card = shallow(wrapper);
+    const results = await axe(card.html());
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/services/ui-src/src/components/layout/Part.js
+++ b/services/ui-src/src/components/layout/Part.js
@@ -49,7 +49,7 @@ const Part = ({
   } else {
     if (contextData) {
       innards = (
-        <Alert autoFocus>
+        <Alert>
           <div className="ds-c-alert__text">
             {contextData.skip_text ? <p>{contextData.skip_text}</p> : null}
           </div>

--- a/services/ui-src/src/components/layout/Part.js
+++ b/services/ui-src/src/components/layout/Part.js
@@ -39,10 +39,15 @@ const Part = ({
   if (show) {
     innards = (
       <>
-        {text ? <Text>{text}</Text> : null}
+        {text ? <Text data-testid="part-text">{text}</Text> : null}
 
         {questions.map((question) => (
-          <Question key={question.id} question={question} tableTitle={title} />
+          <Question
+            key={question.id}
+            question={question}
+            tableTitle={title}
+            data-testid="part-question"
+          />
         ))}
       </>
     );
@@ -50,7 +55,7 @@ const Part = ({
     if (contextData) {
       innards = (
         <Alert>
-          <div className="ds-c-alert__text">
+          <div className="ds-c-alert__text" data-testid="part-alert">
             {contextData.skip_text ? <p>{contextData.skip_text}</p> : null}
           </div>
         </Alert>
@@ -59,15 +64,15 @@ const Part = ({
   }
 
   return (
-    <div id={partId}>
+    <div id={partId} data-testid="part">
       {title &&
         (nestedSubsectionTitle ? (
-          <h4 className="h4-pdf-bookmark">
+          <h4 className="h4-pdf-bookmark" data-testid="part-sub-header">
             {+section !== 0 && partNumber && `Part ${partNumber}: `}
             {title}
           </h4>
         ) : (
-          <h3 className="h3-pdf-bookmark">
+          <h3 className="h3-pdf-bookmark" data-testid="part-header">
             {+section !== 0 && partNumber && `Part ${partNumber}: `}
             {title}
           </h3>

--- a/services/ui-src/src/components/layout/Part.test.js
+++ b/services/ui-src/src/components/layout/Part.test.js
@@ -1,0 +1,133 @@
+import React from "react";
+import { shallow } from "enzyme";
+import configureMockStore from "redux-mock-store";
+import { Provider } from "react-redux";
+import { screen, render } from "@testing-library/react";
+import Part from "./Part";
+import { AppRoles } from "../../types";
+
+jest.mock("../fields/Question.js", () => () => {
+  const MockName = "default-question";
+  return <MockName data-testid="part-question" />;
+});
+const mockStore = configureMockStore();
+const store = mockStore({
+  allStatesData: [],
+  stateUser: {
+    currentUser: {
+      role: AppRoles.CMS_ADMIN,
+    },
+  },
+  reportStatus: {
+    status: "certified",
+    AL2020: {
+      status: "certified",
+      username: "my_user@name.com",
+      lastChanged: new Date(),
+    },
+  },
+  formData: [
+    {
+      pk: "AL-2020",
+      sectionId: 0,
+      year: 2020,
+      contents: {
+        section: {
+          id: "2020-00",
+          ordinal: 0,
+          title: "my section",
+          subsections: [
+            {
+              type: "subsection",
+              parts: [
+                {
+                  id: "2020-00-a-01",
+                  text: "We already have some information about your state from our records. If any information is incorrect, please contact the [mdct_help@cms.hhs.gov](mailto:mdct_help@cms.hhs.gov).",
+                  type: "part",
+                  title: "Welcome!",
+                  questions: [
+                    {
+                      id: "2020-00-a-01-01",
+                      type: "text",
+                      label: "State or territory name:",
+                      answer: {
+                        entry: "Alabama",
+                        readonly: true,
+                        prepopulated: true,
+                      },
+                    },
+                  ],
+                },
+                {
+                  id: "2020-00-a-01",
+                  text: "We already have some information about your state from our records. If any information is incorrect, please contact the [mdct_help@cms.hhs.gov](mailto:mdct_help@cms.hhs.gov).",
+                  type: "part",
+                  title: "Welcome!",
+                  questions: [
+                    {
+                      id: "2020-00-a-01-01",
+                      type: "text",
+                      label: "State or territory name:",
+                      answer: {
+                        entry: "Alabama",
+                        readonly: true,
+                        prepopulated: true,
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: "2020-00-a",
+              title: "my title",
+            },
+          ],
+          context_data: {},
+        },
+      },
+      stateId: "AL",
+    },
+  ],
+  global: {
+    isFetching: false,
+  },
+});
+const buildPart = (partId, nestedSubsectionTitle = false) => {
+  return (
+    <Provider store={store}>
+      <Part partId={partId} nestedSubsectionTitle={nestedSubsectionTitle} />
+    </Provider>
+  );
+};
+
+describe("Part Component", () => {
+  it("should render correctly", () => {
+    expect(shallow(buildPart("2020-00")).exists()).toBe(true);
+  });
+
+  it("renders text and any questions provided", () => {
+    render(buildPart("2020-00-a-01"));
+    const part = screen.getByTestId("part");
+    expect(part).toHaveTextContent("information about your state");
+    const question = screen.getByTestId("part-question");
+    expect(question).not.toBeNull();
+  });
+
+  it("conditionally renders a title", () => {
+    render(buildPart("2020-00-a"));
+    const title = screen.getByTestId("part-header");
+    expect(title).toHaveTextContent("my title");
+  });
+
+  it("subtitles rendered if appropriate as a nested subsection", () => {
+    render(buildPart("2020-00-a-01", true));
+    const title = screen.getByTestId("part-sub-header");
+    expect(title).toHaveTextContent("Welcome!");
+  });
+
+  it("When no title is provided, no header is renderd", () => {
+    render(buildPart("2020-00-a-02"));
+    const title = screen.queryByTestId("part-header");
+    screen.conta;
+    expect(title).toBeNull;
+  });
+});

--- a/services/ui-src/src/components/sections/GetHelp.js
+++ b/services/ui-src/src/components/sections/GetHelp.js
@@ -7,7 +7,7 @@ const GetHelp = () => {
   return (
     <main className="help-page ds-l-container">
       <div className="ds-l-col--12">
-        <Alert autoFocus heading="Informative status">
+        <Alert heading="Informative status">
           <p className="ds-c-alert__text">
             Lorem ipsum dolor sit link text, consectetur adipiscing elit, sed do
             eiusmod.


### PR DESCRIPTION
# Description
A couple issues around radio buttons popped up in the app:

### Radio buttons should include the question when using a screenreader
A couple changes to clean this up
* Radio buttons are fieldsets, they need legends
* This mixes up all questions, when nested, so all questions need to be fieldsets. Which means they get legends too.

This actually simplifies some of the code in practice.
 
### Some radio buttons are not keyboard navigable
Resulted from all <Alert> components having the autofocus property, which destroyed focus as they rendered and unrendered. These should only be on Error alerts, not the nice little information blurbs that appear when you have portions of the report skipped.

## How to test
Turn on screenreader, navigate some radio buttons.

## Dependencies
N/A

# Get it done

Now that the PR is open this is what happens next

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
