### PR TITLE
[MDCT-2116] Loading CHIPS Enrollment counts

### DIFF
--- a/services/app-api/handlers/enrollmentCounts/get.ts
+++ b/services/app-api/handlers/enrollmentCounts/get.ts
@@ -29,21 +29,20 @@ export const getEnrollmentCounts = handler(async (event, _context) => {
     };
     const currentYearQuery = await dynamoDb.query(currentParams);
     if (currentYearQuery.Items) {
-      counts.concat(currentYearQuery.Items);
+      counts.push(...currentYearQuery.Items);
     }
-
     // Provide past year values as fallback
     const pastYear = parseInt(year) - 1;
     const pastParams = {
       TableName: process.env.stageEnrollmentCountsTableName!,
       KeyConditionExpression: "pk = :pk",
       ExpressionAttributeValues: {
-        ":pk": `${state}-${pastYear - 1}`,
+        ":pk": `${state}-${pastYear}`,
       },
     };
     const pastYearQuery = await dynamoDb.query(pastParams);
     if (pastYearQuery.Items) {
-      counts.concat(currentYearQuery.Items);
+      counts.push(...pastYearQuery.Items);
     }
   }
   return counts;

--- a/services/app-api/handlers/enrollmentCounts/tests/get.test.ts
+++ b/services/app-api/handlers/enrollmentCounts/tests/get.test.ts
@@ -10,7 +10,30 @@ jest.mock("../../../libs/dynamodb-lib", () => ({
   __esModule: true,
   default: {
     get: jest.fn(),
-    query: jest.fn().mockReturnValue({ Items: [] }),
+    query: jest.fn().mockReturnValue({
+      Items: [
+        {
+          pk: "AL-2022",
+          entryKey: "separate_chip-1",
+          indexToUpdate: 1,
+          stateId: "AL",
+          typeOfEnrollment: "Separate CHIP",
+          enrollmentCount: 5,
+          filterId: "2022-02",
+          yearToModify: "2022",
+        },
+        {
+          pk: "AL-2021",
+          entryKey: "separate_chip-2",
+          indexToUpdate: 2,
+          stateId: "AL",
+          typeOfEnrollment: "Separate CHIP",
+          enrollmentCount: 5,
+          filterId: "2021-02",
+          yearToModify: "2021",
+        },
+      ],
+    }),
   },
 }));
 
@@ -51,6 +74,8 @@ describe("Test Get Enrollment Count Handlers", () => {
         ":pk": "AL-2022",
       },
     });
+    const body = JSON.parse(res.body);
+    expect(body.length).toEqual(4); // get should be called 2x to populate
   });
 
   test("fetching enrollment counts without state and year throws error", async () => {

--- a/services/database/data/seed-local/seed-stg-enrollment-counts.json
+++ b/services/database/data/seed-local/seed-stg-enrollment-counts.json
@@ -30,6 +30,16 @@
     "yearToModify": "2022"
   },
   {
+    "pk": "AL-2021",
+    "entryKey": "medicaid_exp_chip-2",
+    "indexToUpdate": 2,
+    "stateId": "AL",
+    "typeOfEnrollment": "Medicaid Expansion CHIP",
+    "enrollmentCount": 3,
+    "filterId": "2021-02",
+    "yearToModify": "2021"
+  },
+  {
     "pk": "AL-2022",
     "entryKey": "medicaid_exp_chip-2",
     "indexToUpdate": 2,
@@ -48,6 +58,16 @@
     "enrollmentCount": 5,
     "filterId": "2022-02",
     "yearToModify": "2022"
+  },
+  {
+    "pk": "AL-2021",
+    "entryKey": "separate_chip-2",
+    "indexToUpdate": 2,
+    "stateId": "AL",
+    "typeOfEnrollment": "Separate CHIP",
+    "enrollmentCount": 5,
+    "filterId": "2021-02",
+    "yearToModify": "2021"
   },
   {
     "pk": "AL-2022",

--- a/services/database/data/seed-local/seed-stg-enrollment-counts.json
+++ b/services/database/data/seed-local/seed-stg-enrollment-counts.json
@@ -16,7 +16,7 @@
     "stateId": "AK",
     "typeOfEnrollment": "Medicaid Expansion CHIP",
     "enrollmentCount": 123,
-    "filterId": "2021-02",
+    "filterId": "2022-02",
     "yearToModify": "2022"
   },
   {
@@ -46,7 +46,7 @@
     "stateId": "AL",
     "typeOfEnrollment": "Medicaid Expansion CHIP",
     "enrollmentCount": 333,
-    "filterId": "2021-02",
+    "filterId": "2022-02",
     "yearToModify": "2022"
   },
   {
@@ -76,7 +76,7 @@
     "stateId": "AL",
     "typeOfEnrollment": "Separate CHIP",
     "enrollmentCount": 123,
-    "filterId": "2021-02",
+    "filterId": "2022-02",
     "yearToModify": "2022"
   }
 ]

--- a/services/ui-src/src/util/synthesize.js
+++ b/services/ui-src/src/util/synthesize.js
@@ -327,12 +327,21 @@ export const lookupChipEnrollments = (
     state.enrollmentCounts &&
     state.enrollmentCounts.chipEnrollments.length > 0
   ) {
-    const targetValue = state.enrollmentCounts.chipEnrollments.find(
+    let targetValue = state.enrollmentCounts.chipEnrollments.find(
       (enrollment) =>
-        enrollment.yearToModify === ffy &&
+        enrollment.yearToModify == ffy &&
         enrollment.indexToUpdate === index &&
         enrollment.typeOfEnrollment === enrollmentType
     );
+    // Lookup the primary stat for the past year if missing
+    if (!targetValue && index == 1) {
+      targetValue = state.enrollmentCounts.chipEnrollments.find(
+        (enrollment) =>
+          enrollment.yearToModify == ffy - 1 &&
+          enrollment.indexToUpdate === index + 1 &&
+          enrollment.typeOfEnrollment === enrollmentType
+      );
+    }
     if (targetValue) {
       returnValue = targetValue.enrollmentCount.toLocaleString();
     }
@@ -349,13 +358,13 @@ export const compareChipEnrollements = (state, { ffy, enrollmentType }) => {
     // Retrieve Values
     let oldCount = state.enrollmentCounts.chipEnrollments.find(
       (enrollment) =>
-        enrollment.yearToModify === ffy &&
+        enrollment.yearToModify == ffy &&
         enrollment.indexToUpdate === 1 &&
         enrollment.typeOfEnrollment === enrollmentType
     );
     const newCount = state.enrollmentCounts.chipEnrollments.find(
       (enrollment) =>
-        enrollment.yearToModify === ffy &&
+        enrollment.yearToModify == ffy &&
         enrollment.indexToUpdate === 2 &&
         enrollment.typeOfEnrollment === enrollmentType
     );
@@ -366,7 +375,7 @@ export const compareChipEnrollements = (state, { ffy, enrollmentType }) => {
        */
       oldCount = state.enrollmentCounts.chipEnrollments.find(
         (enrollment) =>
-          enrollment.yearToModify === ffy - 1 &&
+          enrollment.yearToModify == ffy - 1 &&
           enrollment.indexToUpdate === 2 &&
           enrollment.typeOfEnrollment === enrollmentType
       );

--- a/services/ui-src/src/util/synthesize.test.js
+++ b/services/ui-src/src/util/synthesize.test.js
@@ -67,6 +67,57 @@ const state = {
       answer: { entry: "abc" },
     },
   ],
+  enrollmentCounts: {
+    chipEnrollments: [
+      {
+        pk: "AL-2022",
+        entryKey: "medicaid_exp_chip-1",
+        indexToUpdate: 1,
+        stateId: "AL",
+        typeOfEnrollment: "Medicaid Expansion CHIP",
+        enrollmentCount: 301,
+        filterId: "2022-02",
+        yearToModify: "2022",
+      },
+      {
+        pk: "AL-2022",
+        entryKey: "medicaid_exp_chip-2",
+        indexToUpdate: 2,
+        stateId: "AL",
+        typeOfEnrollment: "Medicaid Expansion CHIP",
+        enrollmentCount: 333,
+        filterId: "2022-02",
+        yearToModify: "2022",
+      },
+    ],
+  },
+};
+
+const fallbackChipState = {
+  enrollmentCounts: {
+    chipEnrollments: [
+      {
+        pk: "AL-2021",
+        entryKey: "medicaid_exp_chip-2",
+        indexToUpdate: 2,
+        stateId: "AL",
+        typeOfEnrollment: "Medicaid Expansion CHIP",
+        enrollmentCount: 301,
+        filterId: "2021-02",
+        yearToModify: "2021",
+      },
+      {
+        pk: "AL-2022",
+        entryKey: "medicaid_exp_chip-2",
+        indexToUpdate: 2,
+        stateId: "AL",
+        typeOfEnrollment: "Medicaid Expansion CHIP",
+        enrollmentCount: 333,
+        filterId: "2022-02",
+        yearToModify: "2022",
+      },
+    ],
+  },
 };
 
 describe("value synthesization utility", () => {
@@ -459,6 +510,72 @@ describe("value synthesization utility", () => {
         state
       );
       expect(out).toEqual({ contents: ["3.70%"] });
+    });
+  });
+
+  describe("handles CHIPS Enrollment Data", () => {
+    it("performs a lookup for a given year", () => {
+      const out = synthesize(
+        {
+          lookupChipEnrollments: {
+            ffy: 2022,
+            enrollmentType: "Medicaid Expansion CHIP",
+            index: 2,
+          },
+        },
+        state
+      );
+      expect(out).toEqual({ contents: ["333"] });
+    });
+    it("performs a lookup for a past years data if current year does not provide it", () => {
+      const out = synthesize(
+        {
+          lookupChipEnrollments: {
+            ffy: 2022,
+            enrollmentType: "Medicaid Expansion CHIP",
+            index: 1,
+          },
+        },
+        fallbackChipState
+      );
+      expect(out).toEqual({ contents: ["301"] });
+    });
+    it("performs a comparison between two years", () => {
+      const out = synthesize(
+        {
+          compareChipEnrollements: {
+            ffy: 2022,
+            enrollmentType: "Medicaid Expansion CHIP",
+          },
+        },
+        state
+      );
+      expect(out).toEqual({ contents: ["10.631%"] });
+    });
+
+    it("performs a comparison between two years and is able to fall back to past data", () => {
+      const out = synthesize(
+        {
+          compareChipEnrollements: {
+            ffy: 2022,
+            enrollmentType: "Medicaid Expansion CHIP",
+          },
+        },
+        fallbackChipState
+      );
+      expect(out).toEqual({ contents: ["10.631%"] });
+    });
+    it("returns Not Available when data is missing", () => {
+      const out = synthesize(
+        {
+          compareChipEnrollements: {
+            ffy: 2050,
+            enrollmentType: "Medicaid Expansion CHIP",
+          },
+        },
+        state
+      );
+      expect(out).toEqual({ contents: ["Not Available"] });
     });
   });
 });


### PR DESCRIPTION
# Description
[Ticket Here](https://qmacbis.atlassian.net/browse/MDCT-2116)

CHIPS data is successfully saved into the system, but was not being loaded into the section 2 enrollment count table.
The getEnrollmentCounts endpoint has been fixed to return the results for a given year and its prior year.

synthesize.js
*  Updated to use enrollments counts from prior years if the current year's results don't include information about the past year. (Index 1 in the table is the past year).
* Added unit for the enrollment counts, since we now have the jsonschema stuff not blowing up the file


## How to test
* Run locally. 2022 and 2021 enrollment counts are staged for AL.
* Login as admin >  Generate 2022 forms > Nav to AL 2022, Section 2
* The enrollment counts table should be populated.
* Using DynamoDB Admin, remove the AL-2022 entries with index 1. This is the past year data. 
* Refresh the page, The synthesize process should be able to populate the relevant AL-2021 entries for that column when it is missing.

## Dependencies
N/A

# Get it done
Get it out through the envs quickly so users have a better day.

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
