### PR TITLE
[MDCT-2137] -  Range Component, Add/Remove Row fix

### DIFF
--- a/services/ui-src/src/components/fields/Ranges.js
+++ b/services/ui-src/src/components/fields/Ranges.js
@@ -221,12 +221,22 @@ const Ranges = ({ onChange, question, ...props }) => {
       )}
 
       {values.length < max || max === 0 ? (
-        <Button onClick={addRow} type="button" variation="primary" {...props}>
+        <Button
+          onClick={addRow}
+          type="button"
+          variation="primary"
+          disabled={props.disabled}
+        >
           Add another? <FontAwesomeIcon icon={faPlus} />
         </Button>
       ) : null}
       {values.length > min || min === 0 ? (
-        <Button onClick={removeRow} type="button" variation="primary">
+        <Button
+          onClick={removeRow}
+          type="button"
+          variation="primary"
+          disabled={props.disabled}
+        >
           Remove Last Entry <FontAwesomeIcon icon={faMinusCircle} />
         </Button>
       ) : null}


### PR DESCRIPTION
# Description

[Ticket](https://qmacbis.atlassian.net/jira/software/c/projects/MDCT/boards/232).

Users are unable to add more rows ("Add Another") to their premiums in section 1, part 2.
![image](https://user-images.githubusercontent.com/6362494/204341445-cbd432ff-168e-4ae4-b31a-2d85f8599065.png)

The {...props} were being added to the add row button, which allowed it to properly display disabled, from a previous fix, but was accidentally clobbering the button's onClick() function.

Removed the spreading of props arbitrarily, and explicitly add disabled.

The only items with values on that props being passed through is name (which probably won't be referenced ever as a form button) and disabled.
![image](https://user-images.githubusercontent.com/6362494/204341394-f897ec19-1929-4b03-8a98-7c8d19d022ff.png)

## How to test

1. Check the button works. Spin it up as a state user, go to section 1, part 2, and play with the Add and remove buttons.
2. Verify Disabled still tracks (and now works on remove). Go to a submitted survey and check the same section. You shouldn't have the ability to click the buttons.

## Dependencies

N/A

# Get it done
Try to get a quick turnaround for users submitting this year's data

## Code authors checklist

- [x] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
