### PR TITLE
Disable migration, and release v2 sec group

### DIFF
--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -44,7 +44,8 @@ custom:
       domain:
         sources:
           - table: ${self:custom.acsTableName}
-            sources: [./data/seed-local/seed-acs.json, ./data/seed/seed-acs-2021.json]
+            sources:
+              [./data/seed-local/seed-acs.json, ./data/seed/seed-acs-2021.json]
           - table: ${self:custom.fmapTableName}
             sources: [./data/seed-local/seed-fmap.json]
           - table: ${self:custom.stateTableName}
@@ -57,13 +58,15 @@ custom:
             sources: [./data/seed/seed-section-base.json]
           - table: ${self:custom.stageEnrollmentCountsTableName}
             sources: [./data/seed-local/seed-stg-enrollment-counts.json]
-  dataMigrationEnabled: ${env:runV2DataMigration, ssm:/configuration/${self:custom.stage}/runV2DataMigration, "false"}
-  dataMigrationEnvMap:
-    production: prod
-    val: staging
-    main: master
-    default: master
-  dataMigrationEnv: ${self:custom.dataMigrationEnvMap.${self:custom.stage}, self:custom.dataMigrationEnvMap.default}
+  # Disabling migration handler to unattach from v2 security group for teardown. Remove this and dataMigration folder in future
+  # dataMigrationEnabled: ${env:runV2DataMigration, ssm:/configuration/${self:custom.stage}/runV2DataMigration, "false"}
+  # dataMigrationEnvMap:
+  #   production: prod
+  #   val: staging
+  #   main: master
+  #   default: master
+  # dataMigrationEnv: ${self:custom.dataMigrationEnvMap.${self:custom.stage}, self:custom.dataMigrationEnvMap.default}
+  dataMigrationEnabled: false
   scripts:
     hooks:
       deploy:finalize: |
@@ -102,20 +105,21 @@ provider:
           Resource: "*"
 
 functions:
-  dataMigration:
-    handler: handlers/dataMigration/dataMigration.handler
-    environment:
-      postgresDb: ${env:postgresDatabase, ssm:/${self:custom.dataMigrationEnv}/postgres_db}
-      postgresHost: ${env:postgresHost, ssm:/${self:custom.dataMigrationEnv}/postgres_host}
-      postgresUser: ${env:postgresUser, ssm:/${self:custom.dataMigrationEnv}/postgres_user}
-      postgresPassword: ${env:postgresPassword, ssm:/${self:custom.dataMigrationEnv}/custom/postgres_custom_password, ssm:/${self:custom.dataMigrationEnv}/postgres_password}
-      dynamoPrefix: ${self:custom.stage}
-    timeout: 120
-    vpc:
-      securityGroupIds:
-        - ${env:runV2DataMigration, ssm:/configuration/${self:custom.stage}/migrationSecurityGroup, ssm:/configuration/default/migrationSecurityGroup}
-      subnetIds:
-        - ${env:runV2DataMigration, ssm:/configuration/${self:custom.stage}/migrationSubnet, ssm:/configuration/default/migrationSubnet}
+  # Disabling migration handler to unattach from v2 security group for teardown. Remove this and dataMigration folder in future
+  # dataMigration:
+  #   handler: handlers/dataMigration/dataMigration.handler
+  #   environment:
+  #     postgresDb: ${env:postgresDatabase, ssm:/${self:custom.dataMigrationEnv}/postgres_db}
+  #     postgresHost: ${env:postgresHost, ssm:/${self:custom.dataMigrationEnv}/postgres_host}
+  #     postgresUser: ${env:postgresUser, ssm:/${self:custom.dataMigrationEnv}/postgres_user}
+  #     postgresPassword: ${env:postgresPassword, ssm:/${self:custom.dataMigrationEnv}/custom/postgres_custom_password, ssm:/${self:custom.dataMigrationEnv}/postgres_password}
+  #     dynamoPrefix: ${self:custom.stage}
+  #   timeout: 120
+  #   vpc:
+  #     securityGroupIds:
+  #       - ${env:runV2DataMigration, ssm:/configuration/${self:custom.stage}/migrationSecurityGroup, ssm:/configuration/default/migrationSecurityGroup}
+  #     subnetIds:
+  #       - ${env:runV2DataMigration, ssm:/configuration/${self:custom.stage}/migrationSubnet, ssm:/configuration/default/migrationSubnet}
   seed:
     handler: handlers/seed/seed.handler
     environment:


### PR DESCRIPTION
# Description
We're in the process of tearing down v2, but v3's migration handler reference some of those connections for accessing the database.

Commenting out that integration for now, just so we keep the code on hand in case we need it for recovery from v2 tables, but we'll need to setup new security groups if we ever need that.


## How to test
This branch deploys just fine.

## Dependencies
None

# Get it done
Once this is merged into main and deployed, proceed with dev v2 teardown.

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
