### PR TITLE
Fix Failing Destroy Branch

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -19,7 +19,8 @@ jobs:
     # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
     # This is a list of branch names that are commonly used for protected branches/environments.
     # Add/remove names from this list as appropriate.
-    if: github.event.ref_type == 'branch' && !contains(fromJson('["main", "master", "val", "production"]'), github.event.ref)
+    # Names include current v3 branches (main/val/production) and v2 branches in an effort to protect any preserved resources like saved databases
+    if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "main", "staging", "val", "production", "prod"]'), github.event.ref)
     runs-on: ubuntu-latest
     steps:
       - name: set branch_name
@@ -50,4 +51,5 @@ jobs:
           repo: cmsgov/cms-bigmac
           token: ${{ secrets.AUTOMATION_ACCESS_TOKEN }}
           inputs: '{ "topics": "mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.config,mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.offsets,mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.status"}'
+          ref: refs/heads/master # Otherwise workflow-dispatch tries to operate off of our default name
       - run: ./destroy.sh $STAGE_PREFIX$branch_name


### PR DESCRIPTION
# Description
[workflow-dispatch](https://github.com/benc-uk/workflow-dispatch) is used to trigger cleanup of topics that may have been created of a branch in the bigmac repo. Changing our default branch broke this integration, the plugin needs to know what branch to target if it is different than the default branch of the originating repo.

## How to test
Let it run on a deleted branch

## Dependencies
None

# Get it done
Once merged and deleted, this should run, hopefully successfully.

## Code authors checklist

- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [ ] Necessary analytics were added, or no new analytics were required
- [ ] I have made corresponding changes to the documentation

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
