### PR TITLE
Persistent Spinner on Print

### DIFF
--- a/services/ui-src/src/components/sections/Print.js
+++ b/services/ui-src/src/components/sections/Print.js
@@ -109,8 +109,12 @@ const Print = ({ currentUser, state, name }) => {
       dispatch({ type: "CONTENT_FETCHING_FINISHED" });
     };
 
-    // Call async function to load data
-    retrieveUserData();
+    //NOTE: Every time setAuthTimeout is called, it causes the useEffect to re-run even after data is retrieved
+    if(!formData.length){
+      // Call async function to load data
+      retrieveUserData();
+    }
+
   }, [currentUser]);
 
   const sections = [];


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The spinner would run over and over on the print page even after the data has loaded. Current fix is adding a conditional check to see if the form data has loaded before trying to pull again.

Flow of the loop is:
Print -> useEffect -> retrieveUserData-> SetAuthTimeout -> Print -> useEffect ->  retrieveUserData-> SetAuthTimeout -> (and so on)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2060

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Go to print page
2) Wait about 30 seconds to 1 minute
3) If loader only runs once, it's fixed


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N / A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
