### PR TITLE
MDCT-2285: Modify destroy script to change order of ops

### DIFF
--- a/destroy.sh
+++ b/destroy.sh
@@ -109,12 +109,6 @@ do
   aws s3 rm s3://$i/ --recursive
 done
 
-# Trigger a delete for each cloudformation stack
-for i in "${stackList[@]}"
-do
-  echo $i
-  aws cloudformation delete-stack --stack-name $i
-done
 # Delete Client Certificates associated with a branch
 certToDestroy=$(aws apigateway get-client-certificates\
     | grep \"app-api-${stage}\" -B 2 \
@@ -130,3 +124,10 @@ do
     | grep -o '"clientCertificateId": "[^"]*' \
     | grep -o '[^"]*$' || true) 
 done 
+
+# Trigger a delete for each cloudformation stack
+for i in "${stackList[@]}"
+do
+  echo $i
+  aws cloudformation delete-stack --stack-name $i
+done

--- a/destroy.sh
+++ b/destroy.sh
@@ -113,8 +113,6 @@ echo "Removing certificate from stage"
 
 restApiId=$(aws apigateway get-rest-apis | jq -r '.[] | .[] |  select(.name=="fix-destroy-issues-app-api") | .id|tostring')
 
-echo $restApiId
-
 aws apigateway update-stage \
   --rest-api-id $restApiId \
   --stage-name $stage \

--- a/destroy.sh
+++ b/destroy.sh
@@ -109,6 +109,27 @@ do
   aws s3 rm s3://$i/ --recursive
 done
 
+echo "Removing certificate from stage"
+
+restApiId=$(aws apigateway get-rest-apis | jq -r '.[] | .[] |  select(.name=="fix-destroy-issues-app-api") | .id|tostring')
+
+echo $restApiId
+
+aws apigateway update-stage \
+  --rest-api-id $restApiId \
+  --stage-name $stage \
+  --patch-operations op=replace,path=/clientCertificateId,value="" \
+  &> /dev/null
+
+echo "Removed certificate from stage"
+
+# Trigger a delete for each cloudformation stack
+for i in "${stackList[@]}"
+do
+  echo "Triggered stack deletion for stack: ' $i
+  aws cloudformation delete-stack --stack-name $i
+done
+
 # Delete Client Certificates associated with a branch
 certToDestroy=$(aws apigateway get-client-certificates\
     | grep \"app-api-${stage}\" -B 2 \
@@ -124,10 +145,3 @@ do
     | grep -o '"clientCertificateId": "[^"]*' \
     | grep -o '[^"]*$' || true) 
 done 
-
-# Trigger a delete for each cloudformation stack
-for i in "${stackList[@]}"
-do
-  echo $i
-  aws cloudformation delete-stack --stack-name $i
-done


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Problem was that AWS client certificates are associated directly with a specific stage in an API gateway not via an AWS resource, just an entry in a configuration field. The plugin that is creating/managing our client certs doesn’t implement a “on delete” behavior, so I changed our destroy script to first dis-associate the cert, then delete it, then delete all of the stacks.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2285

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
n/a

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
