### PR TITLE
Disable carts-bigmac-streams on dev branches

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -11,8 +11,12 @@ services=(
   'ui'
   'ui-auth'
   'ui-src'
-  'carts-bigmac-streams'
 )
+
+# Only deploy resources for kafka ingestion in real envs
+if [[ "$stage" == "main" || "$stage" == "val" || "$stage" == "production" ]]; then
+  services+=('carts-bigmac-streams')
+fi
 
 install_deps() {
   if [ "$CI" == "true" ]; then # If we're in a CI system


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Flag the entry for the carts-bigmac-streams service in the deploy.sh by branch. We don't need the resources listening for seds updates on dev branches.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2463

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
The most recent deploy action logs should be missing the carts-bigmac streams in its deployed stack. Ctrl + F for "deploying" to skip through the deployed stacks.

After merging, dev's deployment log should still contain that stack.

You can test this locally by adding 
```
echo ${services[*]}
exit 1
```
after the updated code and running deploy.sh with any branch name you would like to test. It will output the considered branches for deployment given that branch name.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
