### PR TITLE
Mdct 2059 - make labels display correctly for percentage type questions

### DIFF
--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -126,6 +126,11 @@ functions:
       dynamoPrefix: ${self:custom.stage}
       seedTestData: ${self:custom.seedTestData}
     timeout: 120
+  sectionFiveCorrections:
+    handler: handlers/dataCorrections/sectionFiveCorrections.handler
+    environment:
+      dynamoPrefix: ${self:custom.stage}
+    timeout: 120
 
 resources:
   Resources:

--- a/services/ui-src/src/components/fields/CMSLegend.js
+++ b/services/ui-src/src/components/fields/CMSLegend.js
@@ -10,8 +10,7 @@ const CMSLegend = ({ hideNumber, hint, id, label, questionType }) => {
     !questionType.includes("text") &&
     !questionType.includes("mailing_address") &&
     !questionType.includes("phone_number") &&
-    !questionType.includes("email") &&
-    !questionType.includes("percentage")
+    !questionType.includes("email")
   ) {
     let legend = [];
     if (!hideNumber) legend.push(labelBits);

--- a/services/ui-src/src/components/fields/CMSLegend.test.js
+++ b/services/ui-src/src/components/fields/CMSLegend.test.js
@@ -25,7 +25,7 @@ describe("CMS Legend", () => {
     ["mailing_address", false],
     ["phone_number", false],
     ["email", false],
-    ["percentage", false],
+    ["percentage", true],
     ["radio", true],
     ["fieldset", true],
   ])(


### PR DESCRIPTION
### Description
Percentage questions weren't displaying with their labels.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2059

---
### How to test
Go to a 2022 program, section 3b, question #3: you should see: `#3. What percent of applicants screened for CHIP eligibility cannot be enrolled because they have group health plan coverage?`

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
