### PR TITLE
Mdct 2630 - allow approver and project officer roles to uncertify programs

### DIFF
--- a/services/app-api/handlers/stateStatus/get.ts
+++ b/services/app-api/handlers/stateStatus/get.ts
@@ -17,6 +17,7 @@ export const getStateStatus = handler(async (event, _context) => {
   } else if (
     user.role === AppRoles.CMS_ADMIN ||
     user.role === AppRoles.HELP_DESK ||
+    user.role === AppRoles.CMS_APPROVER ||
     user.role === AppRoles.CMS_USER
   ) {
     // Return all

--- a/services/app-api/handlers/stateStatus/update.ts
+++ b/services/app-api/handlers/stateStatus/update.ts
@@ -45,8 +45,8 @@ export const updateStateStatus = handler(async (event, _context) => {
     await dynamoDb.update(updateStateStatusparams);
   } else if (
     user.role === AppRoles.CMS_USER ||
-    AppRoles.CMS_ADMIN ||
-    AppRoles.CMS_APPROVER
+    user.role === AppRoles.CMS_ADMIN ||
+    user.role === AppRoles.CMS_APPROVER
   ) {
     /**
      * CMS_User, CMS_Admin, and CMS_Approver uncertifies a CARTS report

--- a/services/app-api/handlers/stateStatus/update.ts
+++ b/services/app-api/handlers/stateStatus/update.ts
@@ -43,9 +43,13 @@ export const updateStateStatus = handler(async (event, _context) => {
     };
 
     await dynamoDb.update(updateStateStatusparams);
-  } else if (user.role === AppRoles.CMS_USER) {
+  } else if (
+    user.role === AppRoles.CMS_USER ||
+    AppRoles.CMS_ADMIN ||
+    AppRoles.CMS_APPROVER
+  ) {
     /**
-     * CMS_User uncertifies a CARTS report
+     * CMS_User, CMS_Admin, and CMS_Approver uncertifies a CARTS report
      */
     const uncertifyReportParams = {
       TableName: process.env.stateStatusTableName!,

--- a/services/app-api/libs/authorization.ts
+++ b/services/app-api/libs/authorization.ts
@@ -140,6 +140,7 @@ export const getUserCredentialsFromJwt = (event: APIGatewayProxyEvent) => {
 export const mapIdmRoleToAppRole = (idmRole: IdmRoles) => {
   switch (idmRole) {
     case IdmRoles.APPROVER:
+      return AppRoles.CMS_APPROVER;
     case IdmRoles.HELP:
       return AppRoles.HELP_DESK;
     case IdmRoles.BUSINESS_OWNER_REP:

--- a/services/app-api/libs/tests/authorization.test.ts
+++ b/services/app-api/libs/tests/authorization.test.ts
@@ -3,6 +3,7 @@ import {
   getUserCredentialsFromJwt,
   getUserNameFromJwt,
   isAuthorized,
+  mapIdmRoleToAppRole,
   UserCredentials,
 } from "../authorization";
 import { AppRoles, IdmRoles } from "../../types";
@@ -210,6 +211,13 @@ describe("Authorization Lib", () => {
       });
       const result = getUserNameFromJwt(event);
       expect(result).toEqual("branchUser");
+    });
+  });
+
+  describe("mapIdmRoleToAppRole", () => {
+    it("should return AppRole if IdmRole exists", () => {
+      const result = mapIdmRoleToAppRole(IdmRoles.APPROVER);
+      expect(result).toEqual(AppRoles.CMS_APPROVER);
     });
   });
 });

--- a/services/app-api/types.ts
+++ b/services/app-api/types.ts
@@ -129,6 +129,7 @@ export const enum IdmRoles {
 export const enum AppRoles {
   CMS_USER = "CMS_USER", // User who can view and reject state submissions
   CMS_ADMIN = "CMS_ADMIN", // Biz Owner - View all, release forms
+  CMS_APPROVER = "CMS_APPROVER", // Approver - view and uncertify
   HELP_DESK = "HELP_DESK", // Help Desk - View all
   STATE_USER = "STATE_USER", // Enter and certifies data for a year
 }

--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -126,6 +126,11 @@ functions:
       dynamoPrefix: ${self:custom.stage}
       seedTestData: ${self:custom.seedTestData}
     timeout: 120
+  sectionFiveCorrections:
+    handler: handlers/dataCorrections/sectionFiveCorrections.handler
+    environment:
+      dynamoPrefix: ${self:custom.stage}
+    timeout: 120
 
 resources:
   Resources:

--- a/services/ui-src/src/components/layout/FormNavigation.js
+++ b/services/ui-src/src/components/layout/FormNavigation.js
@@ -31,6 +31,7 @@ const FormNavigation = (props) => {
   if (
     role !== AppRoles.CMS_ADMIN &&
     role !== AppRoles.HELP_DESK &&
+    role !== AppRoles.CMS_APPROVER &&
     role !== AppRoles.CMS_USER
   ) {
     // Add certify and submit page to items array

--- a/services/ui-src/src/components/layout/Home.js
+++ b/services/ui-src/src/components/layout/Home.js
@@ -17,6 +17,9 @@ const Home = ({ role }) => {
     case AppRoles.HELP_DESK:
       content = <CMSHome />;
       break;
+    case AppRoles.CMS_APPROVER:
+      content = <CMSHome />;
+      break;
     case AppRoles.STATE_USER:
       content = <StateHome />;
       break;

--- a/services/ui-src/src/components/layout/Home.test.js
+++ b/services/ui-src/src/components/layout/Home.test.js
@@ -38,6 +38,7 @@ describe("Home Component", () => {
     [AppRoles.CMS_USER, <CMSHome />],
     [AppRoles.CMS_ADMIN, <HomeAdmin />],
     [AppRoles.HELP_DESK, <CMSHome />],
+    [AppRoles.CMS_APPROVER, <CMSHome />],
     [AppRoles.STATE_USER, <StateHome />],
     ["", <Unauthorized />],
   ])("User role %s should see the matching homepage)", (role, expected) => {

--- a/services/ui-src/src/components/layout/Part.js
+++ b/services/ui-src/src/components/layout/Part.js
@@ -134,6 +134,7 @@ const showPartBasedOnUserType = (contextData, programData, state) => {
     programData &&
     (role === AppRoles.CMS_ADMIN ||
       role === AppRoles.HELP_DESK ||
+      role === AppRoles.CMS_APPROVER ||
       role === AppRoles.CMS_USER ||
       role === AppRoles.STATE_USER)
   ) {

--- a/services/ui-src/src/components/sections/homepage/ReportItem.js
+++ b/services/ui-src/src/components/sections/homepage/ReportItem.js
@@ -52,6 +52,12 @@ const ReportItem = ({
     window.location.reload(false);
   };
 
+  const rolesThatUncertify = [
+    AppRoles.CMS_ADMIN,
+    AppRoles.CMS_USER,
+    AppRoles.CMS_APPROVER,
+  ];
+
   return (
     <>
       {!stateUser && (
@@ -69,7 +75,7 @@ const ReportItem = ({
               {link1Text}
             </Link>
             {statusText === "Certified and Submitted" &&
-              userRole === AppRoles.CMS_USER && (
+              rolesThatUncertify.includes(userRole) && (
                 <span>
                   {" "}
                   <button

--- a/services/ui-src/src/components/sections/homepage/ReportItem.test.js
+++ b/services/ui-src/src/components/sections/homepage/ReportItem.test.js
@@ -7,6 +7,7 @@ import ReportItem from "./ReportItem";
 import { Provider } from "react-redux";
 import {
   adminUserWithMultipleReports,
+  approverUserWithMultipleReports,
   cmsUserWithMultipleReports,
   helpdeskUserWithMultipleReports,
   stateUserWithMultipleReports,
@@ -242,7 +243,7 @@ const CMSHomepageAdminAl2020Props = {
   name: "Alabama",
   year: 2020,
   statusText: "Certified and Submitted",
-  userRole: "HELP_DESK",
+  userRole: "CMS_ADMIN",
   username: "Frank States",
   lastChanged: "Mon Jun 27 2022 14:43:08 GMT-0400 (Eastern Daylight Time)",
   timeZone: "America/New_York",
@@ -253,7 +254,7 @@ const CMSHomepageAdminAL2021Props = {
   name: "Alabama",
   year: 2021,
   statusText: "In Progress",
-  userRole: "HELP_DESK",
+  userRole: "CMS_ADMIN",
   username: "al@test.com",
   lastChanged: "2021-01-04 18:28:18.524133+00",
   timeZone: "America/New_York",
@@ -319,7 +320,7 @@ describe("ReportItem viewed by an Admin User", () => {
     expect(
       report.find("div.actions.ds-l-col--auto").find("a").prop("href")
     ).toBe("/views/sections/AL/2020/00/a");
-    expect(report.find("div.actions.ds-l-col--auto").text()).not.toContain(
+    expect(report.find("div.actions.ds-l-col--auto").text()).toContain(
       "Uncertify"
     );
   });
@@ -439,6 +440,113 @@ describe("ReportItem viewed by an Help Desk User", () => {
 
   test("Certified report items  should not have basic accessibility issues", async () => {
     const { container } = render(helpdeskUserCertWrapper);
+    const stateCertResults = await axe(container);
+    expect(stateCertResults).toHaveNoViolations();
+  });
+});
+
+/**
+ *********************
+ *Approver User (help.approver@test.com)
+ *********************
+ */
+
+const approverUser = mockStore(approverUserWithMultipleReports);
+const CMSHomepageApproverAl2020Props = {
+  link1URL: "/views/sections/AL/2020/00/a",
+  name: "Alabama",
+  year: 2020,
+  statusText: "Certified and Submitted",
+  userRole: "CMS_APPROVER",
+  username: "Frank States",
+  lastChanged: "Mon Jun 27 2022 14:43:08 GMT-0400 (Eastern Daylight Time)",
+  timeZone: "America/New_York",
+};
+
+const CMSHomepageApproverAL2021Props = {
+  link1URL: "/views/sections/AL/2021/00/a",
+  name: "Alabama",
+  year: 2021,
+  statusText: "In Progress",
+  userRole: "CMS_APPROVER",
+  username: "al@test.com",
+  lastChanged: "2021-01-04 18:28:18.524133+00",
+  timeZone: "America/New_York",
+};
+
+describe("ReportItem viewed by an Admin User", () => {
+  const approverUserInProgWrapper = (
+    <Provider store={approverUser}>
+      <MemoryRouter initialEntries={["/"]}>
+        <ReportItem {...CMSHomepageApproverAL2021Props} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  const approverUserCertWrapper = (
+    <Provider store={approverUser}>
+      <MemoryRouter initialEntries={["/"]}>
+        <ReportItem {...CMSHomepageApproverAl2020Props} />
+      </MemoryRouter>
+    </Provider>
+  );
+
+  it("should render In Progress correctly", () => {
+    expect(shallow(approverUserInProgWrapper).exists()).toBe(true);
+  });
+
+  it("should render report other statuses correctly", () => {
+    expect(shallow(approverUserCertWrapper).exists()).toBe(true);
+  });
+
+  it("should render an In Progress report with passed props", () => {
+    const report = mount(approverUserInProgWrapper);
+    expect(report.find("div.name.ds-l-col--1").text()).toBe("2021");
+    expect(report.find("div.name.ds-l-col--2").text()).toBe("Alabama");
+    expect(report.find("div.status.ds-l-col--2").text()).toBe("In Progress");
+    expect(report.find("div.actions.ds-l-col--3").text()).toBe(
+      "2021-01-04 at 1:28:18 p.m. by al@test.com"
+    );
+    expect(report.find("div.actions.ds-l-col--auto").find("a").text()).toBe(
+      "View"
+    );
+    expect(
+      report.find("div.actions.ds-l-col--auto").find("a").prop("href")
+    ).toBe("/views/sections/AL/2021/00/a");
+    expect(report.find("div.actions.ds-l-col--auto").text()).not.toContain(
+      "Uncertify"
+    );
+  });
+
+  it("should render other reports statuses and time staps properly", () => {
+    const report = mount(approverUserCertWrapper);
+    expect(report.find("div.name.ds-l-col--1").text()).toBe("2020");
+    expect(report.find("div.name.ds-l-col--2").text()).toBe("Alabama");
+    expect(report.find("div.status.ds-l-col--2").text()).toBe(
+      "Certified and Submitted"
+    );
+    expect(report.find("div.actions.ds-l-col--3").text()).toBe(
+      "2022-06-27 at 2:43:08 p.m. by Frank States"
+    );
+    expect(report.find("div.actions.ds-l-col--auto").find("a").text()).toBe(
+      "View"
+    );
+    expect(
+      report.find("div.actions.ds-l-col--auto").find("a").prop("href")
+    ).toBe("/views/sections/AL/2020/00/a");
+    expect(report.find("div.actions.ds-l-col--auto").text()).toContain(
+      "Uncertify"
+    );
+  });
+
+  test("In Progress report items should not have basic accessibility issues", async () => {
+    const { container } = render(approverUserCertWrapper);
+    const stateInProgResults = await axe(container);
+    expect(stateInProgResults).toHaveNoViolations();
+  });
+
+  test("Certified report items  should not have basic accessibility issues", async () => {
+    const { container } = render(approverUserCertWrapper);
     const stateCertResults = await axe(container);
     expect(stateCertResults).toHaveNoViolations();
   });

--- a/services/ui-src/src/hooks/authHooks/userProvider.js
+++ b/services/ui-src/src/hooks/authHooks/userProvider.js
@@ -103,6 +103,7 @@ export const UserProvider = ({ children }) => {
 export const mapIdmRoleToAppRole = (idmRole) => {
   switch (idmRole) {
     case IdmRoles.APPROVER:
+      return AppRoles.CMS_APPROVER;
     case IdmRoles.HELP:
       return AppRoles.HELP_DESK;
     case IdmRoles.BUSINESS_OWNER_REP:

--- a/services/ui-src/src/store/fakeStoreExamples.js
+++ b/services/ui-src/src/store/fakeStoreExamples.js
@@ -239,7 +239,7 @@ export const adminUserWithMultipleReports = {
     currentUser: {
       username: "adminuser@test.com",
       state: {},
-      role: "HELP_DESK",
+      role: "CMS_ADMIN",
       lastname: "Admins",
       firstname: "Adam",
       email: "adminuser@test.com",
@@ -497,6 +497,69 @@ export const helpdeskUserWithMultipleReports = {
       acs_set: [],
     },
   ],
+  reportStatus: {
+    AK2021: {
+      status: "in_progress",
+      year: 2021,
+      stateCode: "AK",
+      lastChanged: "2021-01-04 18:28:18.524133+00",
+      username: "al@test.com",
+      programType: "combo",
+    },
+    AL2021: {
+      status: "in_progress",
+      year: 2021,
+      stateCode: "AL",
+      lastChanged: "2021-01-04 18:28:18.524133+00",
+      username: "al@test.com",
+      programType: "combo",
+    },
+    AL2020: {
+      status: "certified",
+      year: 2020,
+      stateCode: "AL",
+      lastChanged: "Mon Jun 27 2022 14:43:08 GMT-0400 (Eastern Daylight Time)",
+      username: "Frank States",
+      programType: "combo",
+    },
+  },
+  lastYearFormData: [],
+  lastYearTotals: {
+    calculatedTotal: false,
+  },
+};
+
+export const approverUserWithMultipleReports = {
+  formData: [],
+  save: {
+    error: false,
+    errorMessage: null,
+    lastSave: null,
+    saving: false,
+  },
+  stateUser: {
+    name: null,
+    abbr: null,
+    imageURI: null,
+    currentUser: {
+      username: "help.approver@test.com",
+      state: {},
+      role: "CMS_APPROVER",
+      lastname: "Approver",
+      firstname: "Bobby",
+      email: "help.approver@test.com",
+    },
+    localLogin: false,
+  },
+  global: {
+    formName: "CARTS FY",
+    largeTextBoxHeight: 6,
+    isFetching: false,
+    url: "/",
+    queryParams: "",
+    currentYear: 2021,
+    formYear: 2020,
+  },
   reportStatus: {
     AK2021: {
       status: "in_progress",

--- a/services/ui-src/src/types.js
+++ b/services/ui-src/src/types.js
@@ -16,6 +16,7 @@ export const AppRoles = {
   CMS_USER: "CMS_USER", // User who can view and reject state submissions
   CMS_ADMIN: "CMS_ADMIN", // Biz Owner - View all, release forms
   HELP_DESK: "HELP_DESK", // Help Desk - View all
+  CMS_APPROVER: "CMS_APPROVER", // User who can view and uncertify state submissions
   STATE_USER: "STATE_USER", // Enter and certifies data for a year
 };
 


### PR DESCRIPTION
### Description
`This PR creates a new app role called 'CMS_APPROVER' to allow for the idm roles 'APPROVER' and 'PROJECT_OFFICER' to uncertify reports along with 'BUSINESS_OWNER_REP'.  


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2630

---
### How to test
Login as an admin and generate reports. If no certified and submitted reports exist, login as a state user and submit an existing report. Then login as the users provided below and confirm that each user sees the `Uncertify` option on submitted programs and can successfully uncertify them. You can login as the state user for the corresponding state for the uncertified program to see that it is back to `in progress` and the user can edit and resubmit.

cms_user - business owner rep
`cms.user@test.com`

cms_admin - project officer
`cms.admin@tests.com`

cms_approver - approver
`help.approver@test.com`




### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
