### PR TITLE
Mdct 2555 - SubmitAndUncertify Integration test 

### DIFF
--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -126,6 +126,11 @@ functions:
       dynamoPrefix: ${self:custom.stage}
       seedTestData: ${self:custom.seedTestData}
     timeout: 120
+  sectionFiveCorrections:
+    handler: handlers/dataCorrections/sectionFiveCorrections.handler
+    environment:
+      dynamoPrefix: ${self:custom.stage}
+    timeout: 120
 
 resources:
   Resources:

--- a/tests/cypress/tests/integration/submitAndUncertify.spec.js
+++ b/tests/cypress/tests/integration/submitAndUncertify.spec.js
@@ -10,7 +10,12 @@ describe("CARTS Submit and Uncertify Integration Tests", () => {
     cy.visit("/");
   });
 
-  it("Should submit form as a State User", () => {
+  it("Should submit form as a State User and uncertify as a Reviewer", () => {
+    // generate the forms
+    cy.authenticate("adminUser");
+    cy.get(headerDropdownMenu).click();
+    cy.get(logoutButton).click();
+
     // log in as State User
     cy.authenticate("stateUser");
 


### PR DESCRIPTION
### Description
SubmitAndUncertify Integration test gets stuck. The test needs to keep forms available for state user to edit.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2555

---
### How to test
It should just pass


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
