### PR TITLE
[MDCT-2042]: Make dropdown checkbox options accessible

### DIFF
--- a/services/ui-src/src/components/fields/DropdownOption.js
+++ b/services/ui-src/src/components/fields/DropdownOption.js
@@ -1,0 +1,33 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+/*
+ * modified default component from react-multi-select-component
+ * (see here: https://rb.gy/7ibfx)
+ *
+ * the primary modification is the removal of the tabIndex attribute
+ */
+
+export const DropdownOption = ({ checked, option, onClick, disabled }) => (
+  <div className={`item-renderer ${disabled ? "disabled" : ""}`}>
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={onClick}
+      disabled={disabled}
+    />
+    <span>{option.label}</span>
+  </div>
+);
+
+DropdownOption.propTypes = {
+  checked: PropTypes.bool.isRequired,
+  option: PropTypes.shape({
+    value: PropTypes.any.isRequired,
+    label: PropTypes.string.isRequired,
+    key: PropTypes.string,
+    disabled: PropTypes.bool,
+  }).isRequired,
+  onClick: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};

--- a/services/ui-src/src/components/sections/homepage/CMSHomepage.js
+++ b/services/ui-src/src/components/sections/homepage/CMSHomepage.js
@@ -6,6 +6,7 @@ import ReportItem from "./ReportItem";
 import { selectFormStatuses, selectYears } from "../../../store/selectors";
 import { Button } from "@cmsgov/design-system";
 import { MultiSelect } from "react-multi-select-component";
+import { DropdownOption } from "../../fields/DropdownOption";
 import { STATUS_MAPPING, AppRoles } from "../../../types";
 
 const CMSHomepage = ({
@@ -134,6 +135,7 @@ const CMSHomepage = ({
                       labelledBy={"State"}
                       hasSelectAll={false}
                       overrideStrings={{ selectSomeItems: "State" }}
+                      ItemRenderer={DropdownOption}
                     />
                   </div>
                   <div
@@ -147,6 +149,7 @@ const CMSHomepage = ({
                       labelledBy={"Year"}
                       hasSelectAll={false}
                       overrideStrings={{ selectSomeItems: "Year" }}
+                      ItemRenderer={DropdownOption}
                     />
                   </div>
                   <div
@@ -160,6 +163,7 @@ const CMSHomepage = ({
                       labelledBy="Status"
                       hasSelectAll={false}
                       overrideStrings={{ selectSomeItems: "Status" }}
+                      ItemRenderer={DropdownOption}
                     />
                   </div>
                   <div>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The default behavior of a third-party library (react-multi-select-component) was disallowing tabbing through dropdown checkbox options. The solution was to utilize the component's  exposed `ItemRenderer` prop to provide a custom component to render for each dropdown option. In this case, the component to be provided is the exact same as the default component but one major change: it does not set `tabIndex={-1}`, which allows users to tab to the dropdown checkbox options. Really this just involved:
1. Copying over the [default option component](https://github.com/hc-oss/react-multi-select-component/blob/master/src/select-panel/default-item.tsx)
2. Converting from TS to JS + PropTypes (sigh)
3. Removing the `tabIndex` property

Here's a video of it in action:

https://github.com/Enterprise-CMCS/macpro-mdct-carts/assets/27705928/5eff3413-c0cd-4ac9-b2a0-25c726382b44

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2042

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Pull down `m2042-a11yed-droppies` and run locally
2. Sign in as admin user
3. Test that users can tab through the dropdown checkbox options with `Tab`, select/unselect options with `Space`, unselect dropdowns with `Esc`, etc.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] ~~I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary~~
- [x] ~~I have updated relevant documentation, if necessary~~
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
