### PR TITLE
[MDCT-2918][MDCT-2915][MDCT-2916] Field Validation Changes

### DIFF
--- a/services/database/data/seed/seed-section-base-2023.json
+++ b/services/database/data/seed/seed-section-base-2023.json
@@ -7283,7 +7283,7 @@
                       },
                       {
                         "id": "2023-03-e-02-09",
-                        "type": "money",
+                        "type": "text",
                         "label": "What’s the average monthly contribution the employer pays towards coverage of a child?",
                         "answer": {
                           "entry": null
@@ -7291,7 +7291,7 @@
                       },
                       {
                         "id": "2023-03-e-02-10",
-                        "type": "money",
+                        "type": "text",
                         "label": "What’s the average monthly contribution the employee pays towards coverage of a child?",
                         "answer": {
                           "entry": null

--- a/services/ui-src/src/components/fields/Integer.js
+++ b/services/ui-src/src/components/fields/Integer.js
@@ -40,7 +40,7 @@ const Integer = ({ onChange, question, prevYear, ...props }) => {
       />
     );
   }
-
+  const renderAnswer = (val) => (val || Number.isInteger(val) ? val : ""); // may attempt to rerender string on page load, so both val || isInteger
   return (
     <TextField
       className="ds-c-input"
@@ -50,7 +50,7 @@ const Integer = ({ onChange, question, prevYear, ...props }) => {
       name={question.id}
       numeric
       onChange={change}
-      value={prevYear ? prevYear.value : answer || ""}
+      value={prevYear ? prevYear.value : renderAnswer(answer)}
       {...props}
     />
   );

--- a/services/ui-src/src/components/fields/Integer.test.js
+++ b/services/ui-src/src/components/fields/Integer.test.js
@@ -1,0 +1,76 @@
+import React from "react";
+import { Provider } from "react-redux";
+import configureMockStore from "redux-mock-store";
+import { shallow, mount } from "enzyme";
+import Integer from "./Integer";
+import { screen, render, fireEvent } from "@testing-library/react";
+
+const mockStore = configureMockStore();
+const store = mockStore({ lastYearTotals: { 2022: [] } });
+const buildInteger = (intProps) => {
+  return (
+    <Provider store={store}>
+      <Integer onChange={() => {}} {...intProps} />
+    </Provider>
+  );
+};
+describe("<Integer />", () => {
+  it("should render correctly", () => {
+    const props = { question: { id: "2023-00-a-01-01", answer: 1 } };
+    expect(shallow(buildInteger(props)).exists()).toBe(true);
+  });
+
+  it("should render Previous Year data correctly", () => {
+    const props = { question: { id: "2023-00-a-01-01", answer: { entry: 0 } } };
+    expect(mount(buildInteger(props)).exists()).toBe(true);
+  });
+
+  it("should render an Integer", () => {
+    const props = {
+      question: {
+        id: "2023-00-a-01-01",
+        label: "How many lightbulbs does it take to change a man?",
+        answer: { entry: 123 },
+      },
+    };
+    render(buildInteger(props));
+    expect(screen.getByDisplayValue("123")).toBeInTheDocument();
+
+    props.question.answer.entry = 0;
+    render(buildInteger(props));
+    expect(screen.getByDisplayValue("0")).toBeInTheDocument();
+  });
+
+  it("should update new numbers", () => {
+    const props = {
+      question: {
+        id: "2023-00-a-01-01",
+        label: "How many lightbulbs does it take to change a man?",
+        answer: { entry: 123 },
+      },
+    };
+
+    render(buildInteger(props));
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: 234 } });
+    expect(screen.getByDisplayValue("234")).toBeInTheDocument();
+  });
+
+  it("should filter out non-numbers", () => {
+    const props = {
+      question: {
+        id: "2023-00-a-01-01",
+        label: "How many lightbulbs does it take to change a man?",
+        answer: { entry: "hope" },
+      },
+    };
+
+    render(buildInteger(props));
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "raw text" } });
+    expect(screen.queryByDisplayValue("raw text")).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
2 changes for field validations.

1. Integer fields allow 0 when entered, this takes care of two of the tickets. The integer field was only rendering truthy values, but still saving anything, so you could enter 0, not see it, reload and see it. 

Requests were both for 3C in the following fields but applies globally:

<img width="856" alt="image" src="https://github.com/Enterprise-CMCS/macpro-mdct-carts/assets/6362494/fc0020f5-087a-43aa-820f-643a7052f2fc">

<img width="891" alt="image" src="https://github.com/Enterprise-CMCS/macpro-mdct-carts/assets/6362494/33f84d94-d51a-4093-acde-45294d0910d2">

2. Update 3E, 9 & 10 to text fields.
<img width="812" alt="image" src="https://github.com/Enterprise-CMCS/macpro-mdct-carts/assets/6362494/6a13c63f-da47-42cc-9710-8d860f227951">





### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2918 - new field type
MDCT-2915 & MDCT-2916 - ints with 0

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Go to the above sections and try it out

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
