### PR TITLE
[MDCT-2913][MDCT-2917][MDCT-2919] Sections 3 b, d, e

### DIFF
--- a/services/database/data/seed/seed-section-base-2023.json
+++ b/services/database/data/seed/seed-section-base-2023.json
@@ -2502,7 +2502,7 @@
                       {
                         "id": "2023-03-b-01-04",
                         "type": "radio",
-                        "label": "If you have a Separate CHIP program, do you require individuals to be uninsured for a minimum amount of time before enrollment (“the waiting period”)?",
+                        "label": "Does the state implement a waiting period in its separate CHIP?",
                         "answer": {
                           "entry": null,
                           "options": [
@@ -6809,7 +6809,7 @@
           },
           {
             "id": "2023-03-d",
-            "text": "States can choose whether or not to require cost sharing in their CHIP program. Cost sharing includes payments such as enrollment fees, premiums, deductibles, coinsurance, and copayments.",
+            "text": "States can choose to require cost sharing in their CHIP program. Cost sharing includes payments such as enrollment fees, premiums, deductibles, coinsurance, and copayments.",
             "type": "subsection",
             "parts": [
               {
@@ -7088,7 +7088,7 @@
                   }
                 ],
                 "context_data": {
-                  "skip_text": "This section only applies to states with a Separate CHIP program. Skip to the next section.",
+                  "skip_text": "This section only applies to states with a separate CHIP program. Skip to the next section.",
                   "show_if_state_program_type_in": ["separate_chip", "combo"]
                 }
               }
@@ -7265,7 +7265,7 @@
                   {
                     "id": "2023-03-e-02-07",
                     "type": "integer",
-                    "label": "How many children were enrolled in the premium assistance program on average each month in FFY 2022?",
+                    "label": "How many children were enrolled in the premium assistance program on average each month in FFY 2023?",
                     "answer": {
                       "entry": null
                     }
@@ -7403,7 +7403,7 @@
                   {
                     "id": "2023-03-e-02-15",
                     "type": "text_multiline",
-                    "label": "What challenges did you experience with your premium assistance program in FFY 2022?",
+                    "label": "What challenges did you experience with your premium assistance program in FFY 2023?",
                     "answer": {
                       "entry": null
                     }
@@ -7411,7 +7411,7 @@
                   {
                     "id": "2023-03-e-02-16",
                     "type": "text_multiline",
-                    "label": "What accomplishments did you experience with your premium assistance program in FFY 2022?",
+                    "label": "What accomplishments did you experience with your premium assistance program in FFY 2023?",
                     "answer": {
                       "entry": null
                     }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Content changes for the related tickets. Only catch is setting up shouldDisplay for the blue banner locally. Change screenshotted:
![image](https://github.com/Enterprise-CMCS/macpro-mdct-carts/assets/6362494/3cfb2fd6-f833-4bbe-8405-d571b51b971a)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2913
MDCT-2917
MDCT-2919

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Compare ticket requests to diff and run local.
If determined to setup the should display, you can either put a return false at the top of shouldDisplay.js, or set the state and user program type to something not in the list and attempt to reload.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
