### PR TITLE
MDCT-2912: FFY2023 Content Changes for Section 2 + Seeding ACS Data from FFY2022

### DIFF
--- a/services/database/data/seed/seed-acs-2022.json
+++ b/services/database/data/seed/seed-acs-2022.json
@@ -1,0 +1,418 @@
+[
+  {
+    "stateId": "US",
+    "year": 2022,
+    "numberUninsured": 1866000,
+    "numberUninsuredMoe": 42000,
+    "percentUninsured": 2.5,
+    "percentUninsuredMoe": 0.1
+  },
+  {
+    "stateId": "AL",
+    "year": 2022,
+    "numberUninsured": 22000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 1.9,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "AK",
+    "year": 2022,
+    "numberUninsured": 4000,
+    "numberUninsuredMoe": 2000,
+    "percentUninsured": 2.3,
+    "percentUninsuredMoe": 0.9
+  },
+  {
+    "stateId": "AZ",
+    "year": 2022,
+    "numberUninsured": 76000,
+    "numberUninsuredMoe": 8000,
+    "percentUninsured": 4.6,
+    "percentUninsuredMoe": 0.5
+  },
+  {
+    "stateId": "AR",
+    "year": 2022,
+    "numberUninsured": 25000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 3.4,
+    "percentUninsuredMoe": 0.7
+  },
+  {
+    "stateId": "CA",
+    "year": 2022,
+    "numberUninsured": 128000,
+    "numberUninsuredMoe": 11000,
+    "percentUninsured": 1.5,
+    "percentUninsuredMoe": 0.1
+  },
+  {
+    "stateId": "CO",
+    "year": 2022,
+    "numberUninsured": 25000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 2.0,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "CT",
+    "year": 2022,
+    "numberUninsured": 9000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 1.2,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "DE",
+    "year": 2022,
+    "numberUninsured": 2000,
+    "numberUninsuredMoe": 1000,
+    "percentUninsured": 1.1,
+    "percentUninsuredMoe": 0.6
+  },
+  {
+    "stateId": "DC",
+    "year": 2022,
+    "numberUninsured": 1000,
+    "numberUninsuredMoe": 1000,
+    "percentUninsured": 0.6,
+    "percentUninsuredMoe": 0.5
+  },
+  {
+    "stateId": "FL",
+    "year": 2022,
+    "numberUninsured": 158000,
+    "numberUninsuredMoe": 13000,
+    "percentUninsured": 3.6,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "GA",
+    "year": 2022,
+    "numberUninsured": 85000,
+    "numberUninsuredMoe": 9000,
+    "percentUninsured": 3.3,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "HI",
+    "year": 2022,
+    "numberUninsured": 4000,
+    "numberUninsuredMoe": 1000,
+    "percentUninsured": 1.3,
+    "percentUninsuredMoe": 0.5
+  },
+  {
+    "stateId": "ID",
+    "year": 2022,
+    "numberUninsured": 13000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 2.7,
+    "percentUninsuredMoe": 0.6
+  },
+  {
+    "stateId": "IL",
+    "year": 2022,
+    "numberUninsured": 43000,
+    "numberUninsuredMoe": 6000,
+    "percentUninsured": 1.5,
+    "percentUninsuredMoe": 0.2
+  },
+  {
+    "stateId": "IN",
+    "year": 2022,
+    "numberUninsured": 37000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 2.3,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "IA",
+    "year": 2022,
+    "numberUninsured": 11000,
+    "numberUninsuredMoe": 2000,
+    "percentUninsured": 1.5,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "KS",
+    "year": 2022,
+    "numberUninsured": 19000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 2.6,
+    "percentUninsuredMoe": 0.5
+  },
+  {
+    "stateId": "KY",
+    "year": 2022,
+    "numberUninsured": 24000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 2.4,
+    "percentUninsuredMoe": 0.5
+  },
+  {
+    "stateId": "LA",
+    "year": 2022,
+    "numberUninsured": 21000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 2.4,
+    "percentUninsuredMoe": 0.5
+  },
+  {
+    "stateId": "ME",
+    "year": 2022,
+    "numberUninsured": 5000,
+    "numberUninsuredMoe": 2000,
+    "percentUninsured": 2.2,
+    "percentUninsuredMoe": 0.9
+  },
+  {
+    "stateId": "MD",
+    "year": 2022,
+    "numberUninsured": 29000,
+    "numberUninsuredMoe": 6000,
+    "percentUninsured": 2.1,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "MA",
+    "year": 2022,
+    "numberUninsured": 6000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 0.5,
+    "percentUninsuredMoe": 0.2
+  },
+  {
+    "stateId": "MI",
+    "year": 2022,
+    "numberUninsured": 26000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 1.2,
+    "percentUninsuredMoe": 0.2
+  },
+  {
+    "stateId": "MN",
+    "year": 2022,
+    "numberUninsured": 18000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 1.3,
+    "percentUninsuredMoe": 0.2
+  },
+  {
+    "stateId": "MS",
+    "year": 2022,
+    "numberUninsured": 20000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 2.9,
+    "percentUninsuredMoe": 0.6
+  },
+  {
+    "stateId": "MO",
+    "year": 2022,
+    "numberUninsured": 42000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 3.0,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "MT",
+    "year": 2022,
+    "numberUninsured": 9000,
+    "numberUninsuredMoe": 2000,
+    "percentUninsured": 3.7,
+    "percentUninsuredMoe": 0.9
+  },
+  {
+    "stateId": "NE",
+    "year": 2022,
+    "numberUninsured": 9000,
+    "numberUninsuredMoe": 2000,
+    "percentUninsured": 1.8,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "NV",
+    "year": 2022,
+    "numberUninsured": 24000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 3.4,
+    "percentUninsuredMoe": 0.6
+  },
+  {
+    "stateId": "NH",
+    "year": 2022,
+    "numberUninsured": 3000,
+    "numberUninsuredMoe": 1000,
+    "percentUninsured": 1.2,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "NJ",
+    "year": 2022,
+    "numberUninsured": 39000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 1.9,
+    "percentUninsuredMoe": 0.2
+  },
+  {
+    "stateId": "NM",
+    "year": 2022,
+    "numberUninsured": 10000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 2.2,
+    "percentUninsuredMoe": 0.6
+  },
+  {
+    "stateId": "NY",
+    "year": 2022,
+    "numberUninsured": 51000,
+    "numberUninsuredMoe": 6000,
+    "percentUninsured": 1.2,
+    "percentUninsuredMoe": 0.2
+  },
+  {
+    "stateId": "NC",
+    "year": 2022,
+    "numberUninsured": 59000,
+    "numberUninsuredMoe": 6000,
+    "percentUninsured": 2.5,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "ND",
+    "year": 2022,
+    "numberUninsured": 4000,
+    "numberUninsuredMoe": 2000,
+    "percentUninsured": 2.3,
+    "percentUninsuredMoe": 0.9
+  },
+  {
+    "stateId": "OH",
+    "year": 2022,
+    "numberUninsured": 53000,
+    "numberUninsuredMoe": 6000,
+    "percentUninsured": 2.0,
+    "percentUninsuredMoe": 0.2
+  },
+  {
+    "stateId": "OK",
+    "year": 2022,
+    "numberUninsured": 35000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 3.6,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "OR",
+    "year": 2022,
+    "numberUninsured": 11000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 1.3,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "PA",
+    "year": 2022,
+    "numberUninsured": 63000,
+    "numberUninsuredMoe": 8000,
+    "percentUninsured": 2.3,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "RI",
+    "year": 2022,
+    "numberUninsured": 1000,
+    "numberUninsuredMoe": 1000,
+    "percentUninsured": 0.7,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "SC",
+    "year": 2022,
+    "numberUninsured": 31000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 2.7,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "SD",
+    "year": 2022,
+    "numberUninsured": 7000,
+    "numberUninsuredMoe": 1000,
+    "percentUninsured": 3.3,
+    "percentUninsuredMoe": 0.6
+  },
+  {
+    "stateId": "TN",
+    "year": 2022,
+    "numberUninsured": 42000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 2.7,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "TX",
+    "year": 2022,
+    "numberUninsured": 447000,
+    "numberUninsuredMoe": 22000,
+    "percentUninsured": 5.8,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "UT",
+    "year": 2022,
+    "numberUninsured": 26000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 2.7,
+    "percentUninsuredMoe": 0.6
+  },
+  {
+    "stateId": "VT",
+    "year": 2022,
+    "numberUninsured": 26000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 5.8,
+    "percentUninsuredMoe": 0.6
+  },
+  {
+    "stateId": "VA",
+    "year": 2022,
+    "numberUninsured": 31000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 1.6,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "WA",
+    "year": 2022,
+    "numberUninsured": 17000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 1.0,
+    "percentUninsuredMoe": 0.2
+  },
+  {
+    "stateId": "WV",
+    "year": 2022,
+    "numberUninsured": 4000,
+    "numberUninsuredMoe": 1000,
+    "percentUninsured": 1.0,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "WI",
+    "year": 2022,
+    "numberUninsured": 28000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 2.2,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "WY",
+    "year": 2022,
+    "numberUninsured": 6000,
+    "numberUninsuredMoe": 2000,
+    "percentUninsured": 4.1,
+    "percentUninsuredMoe": 1.5
+  }
+]

--- a/services/database/data/seed/seed-acs-2022.json
+++ b/services/database/data/seed/seed-acs-2022.json
@@ -162,10 +162,10 @@
   {
     "stateId": "ME",
     "year": 2022,
-    "numberUninsured": 1000,
-    "numberUninsuredMoe": 0,
-    "percentUninsured": 0.4,
-    "percentUninsuredMoe": 0.3
+    "numberUninsured": 5000,
+    "numberUninsuredMoe": 2000,
+    "percentUninsured": 2.2,
+    "percentUninsuredMoe": 0.9
   },
   {
     "stateId": "MD",
@@ -370,10 +370,10 @@
   {
     "stateId": "VT",
     "year": 2022,
-    "numberUninsured": 26000,
-    "numberUninsuredMoe": 5000,
-    "percentUninsured": 5.8,
-    "percentUninsuredMoe": 0.6
+    "numberUninsured": 1000,
+    "numberUninsuredMoe": 0,
+    "percentUninsured": 0.4,
+    "percentUninsuredMoe": 0.3
   },
   {
     "stateId": "VA",

--- a/services/database/data/seed/seed-acs-2022.json
+++ b/services/database/data/seed/seed-acs-2022.json
@@ -155,17 +155,17 @@
     "stateId": "LA",
     "year": 2022,
     "numberUninsured": 21000,
-    "numberUninsuredMoe": 5000,
-    "percentUninsured": 2.4,
-    "percentUninsuredMoe": 0.5
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 1.9,
+    "percentUninsuredMoe": 0.3
   },
   {
     "stateId": "ME",
     "year": 2022,
-    "numberUninsured": 5000,
-    "numberUninsuredMoe": 2000,
-    "percentUninsured": 2.2,
-    "percentUninsuredMoe": 0.9
+    "numberUninsured": 1000,
+    "numberUninsuredMoe": 0,
+    "percentUninsured": 0.4,
+    "percentUninsuredMoe": 0.3
   },
   {
     "stateId": "MD",

--- a/services/database/data/seed/seed-section-base-2023.json
+++ b/services/database/data/seed/seed-section-base-2023.json
@@ -2066,8 +2066,8 @@
                         [
                           {
                             "compareACS": {
-                              "ffy1": "2019",
-                              "ffy2": "2021",
+                              "ffy1": "2021",
+                              "ffy2": "2022",
                               "acsProperty": "percentUninsured"
                             }
                           }

--- a/services/database/data/seed/seed-section-base-2023.json
+++ b/services/database/data/seed/seed-section-base-2023.json
@@ -2852,7 +2852,7 @@
                 "questions": [
                   {
                     "id": "2023-03-c-02-01",
-                    "hint": "Don’t include applicants being considered for redetermination — these data will be collected in Part 3.",
+                    "hint": "Don’t include applicants who are being considered for redetermination — these data will be collected in Part 3.",
                     "type": "integer",
                     "label": "How many applicants were denied CHIP coverage in FFY 2022?",
                     "answer": {
@@ -3510,7 +3510,7 @@
                 "title": "Tracking a CHIP cohort over 18 months",
                 "questions": [
                   {
-                    "hint": "Children should be in age groups based on their age at the start of the cohort, when they’re identified as newly enrolled in January, February, or March of 2022. For example, if a child is four years old when they’re newly enrolled, they should continue to be reported in the “ages 1-5” group at 6 months, 12 months, and 18 months later.\n\nThe oldest children in the cohort must be no older than 16 years (and 0 months) to ensure they don’t age out of the program at the end of the 18-month tracking period. That means children in the “ages 13-16” group who are newly enrolled in January 2022 must be born after January 2006. Similarly, children who are newly enrolled in February 2022 must be born after February 2006, and children newly enrolled in March 2022 must be born after March 2006.",
+                    "hint": "Children should be in age groups based on their age at the start of the cohort, when they’re identified as newly enrolled in January, February, or March of 2022. For example, if a child is four years old at the start of the cohort, they should continue to be reported in the “ages 1-5” group at 6 months, 12 months, and 18 months later as well.\n\nThe oldest children in the cohort must be no older than 16 years (and 0 months) to ensure they don’t age out of the program at the end of the 18-month tracking period. That means children in the “ages 13-16” group who are newly enrolled in January 2022 must be born after January 2006. Similarly, children who are newly enrolled in February 2022 must be born after February 2006, and children newly enrolled in March 2022 must be born after March 2006.",
                     "type": "fieldset",
                     "label": "Helpful hints on age groups",
                     "questions": []

--- a/services/database/data/seed/seed-section-base-2023.json
+++ b/services/database/data/seed/seed-section-base-2023.json
@@ -1698,7 +1698,7 @@
                   {
                     "id": "2023-02-a-01-01",
                     "type": "text_multiline",
-                    "label": "If you had more than a 3% percent change from last year, what are some possible reasons why your enrollment numbers changed?",
+                    "label": "The percent change column in the table above calculates the rate of growth in enrollment over the previous federal fiscal year by subtracting the previous fiscal year enrollment total from the current fiscal year enrollment total (B - A), and dividing that by the previous fiscal year total (A). If you had more than a 3% percent change from last year, what are some possible reasons why your enrollment numbers changed?",
                     "answer": {
                       "entry": null
                     },
@@ -1734,7 +1734,7 @@
               },
               {
                 "id": "2023-02-a-02",
-                "text": "This table is pre-filled with data on uninsured children (age 18 and under) who are below 200% of the Federal Poverty Level (FPL) based on annual estimates from the American Community Survey. Due to the impacts of the COVID-19 PHE on collection of ACS data, the Census Bureau did not release standard one-year ACS estimates in 2020 and that row is intentionally left blank.",
+                "text": "This table is pre-filled with data on uninsured children (age 18 and under) who are below 200% of the Federal Poverty Level (FPL) based on annual estimates from the American Community Survey (ACS).",
                 "type": "part",
                 "title": "Number of Uninsured Children in Your State",
                 "questions": [
@@ -2006,6 +2006,35 @@
                               "acsProperty": "percentUninsuredMoe"
                             }
                           }
+                        ],
+                        [
+                          {
+                            "contents": "2022"
+                          },
+                          {
+                            "lookupAcs": {
+                              "ffy": "2022",
+                              "acsProperty": "numberUninsured"
+                            }
+                          },
+                          {
+                            "lookupAcs": {
+                              "ffy": "2022",
+                              "acsProperty": "numberUninsuredMoe"
+                            }
+                          },
+                          {
+                            "lookupAcs": {
+                              "ffy": "2022",
+                              "acsProperty": "percentUninsured"
+                            }
+                          },
+                          {
+                            "lookupAcs": {
+                              "ffy": "2022",
+                              "acsProperty": "percentUninsuredMoe"
+                            }
+                          }
                         ]
                       ],
                       "headers": [
@@ -2046,7 +2075,7 @@
                       ],
                       "headers": [
                         {
-                          "contents": "Percent change between 2019 and 2021"
+                          "contents": "Percent change between 2021 and 2022"
                         }
                       ]
                     },
@@ -2090,7 +2119,7 @@
                   {
                     "id": "2023-02-a-02-02",
                     "type": "radio",
-                    "label": "Are there any reasons why the American Community Survey estimates wouldn’t be a precise representation of the actual number of uninsured children in your state?",
+                    "label": "Are there any reasons why the ACS estimates wouldn’t be a precise representation of the actual number of uninsured children in your state?",
                     "answer": {
                       "entry": null,
                       "options": [

--- a/services/database/handlers/seed/tables/acs-2022.js
+++ b/services/database/handlers/seed/tables/acs-2022.js
@@ -1,0 +1,8 @@
+const seed = {
+  name: "ACS 2022",
+  data: require("../../../data/seed/seed-acs-2022.json"),
+  tableNameBuilder: (stage) => `${stage}-acs`,
+  keys: ["stateId", "year"],
+};
+
+module.exports = seed;

--- a/services/database/handlers/seed/tables/index.js
+++ b/services/database/handlers/seed/tables/index.js
@@ -1,5 +1,6 @@
 const tables = [
   require("./acs-2021"),
+  require("./acs-2022"),
   require("./fmap"),
   require("./sectionBase"),
 ];

--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -45,7 +45,11 @@ custom:
         sources:
           - table: ${self:custom.acsTableName}
             sources:
-              [./data/seed-local/seed-acs.json, ./data/seed/seed-acs-2021.json]
+              [
+                ./data/seed-local/seed-acs.json,
+                ./data/seed/seed-acs-2021.json,
+                ./data/seed/seed-acs-2022.json,
+              ]
           - table: ${self:custom.fmapTableName}
             sources: [./data/seed-local/seed-fmap.json]
           - table: ${self:custom.stateTableName}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Updated verbiage and content for Section 2 of the CARTS form (FFY2023), and seeding ACS data for the table in `Part 2` of that section.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2912
MDCT-2949

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as cms.admin@test.com
- Generate form base templates for both 2022 and 2023
- Log in as stateuser2@test.com
- Navigate to the 2023 form, Section 2

Verify that the content in red (on the ticket) matches the content in the form

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
