### PR TITLE
Create test users for exclusive Cypress use

### DIFF
--- a/services/ui-auth/libs/users.json
+++ b/services/ui-auth/libs/users.json
@@ -376,5 +376,59 @@
         "Value": "mdctcarts-approver"
       }
     ]
+  },
+  {
+    "username": "cypressstateuser@test.com",
+    "attributes": [
+      {
+          "Name": "email",
+          "Value": "cypressstateuser@test.com"
+      },
+      {
+          "Name": "given_name",
+          "Value": "CypressAutomatedIntegrationTests"
+      },
+      {
+          "Name": "family_name",
+          "Value": "State"
+      },
+      {
+          "Name": "email_verified",
+          "Value": "true"
+      },
+      {
+          "Name": "custom:cms_roles",
+          "Value": "mdctcarts-state-user"
+      },
+      {
+          "Name": "custom:cms_state",
+          "Value": "DC"
+      }
+    ]
+  },
+  {
+    "username": "cypressadminuser@test.com",
+    "attributes": [
+      {
+          "Name": "email",
+          "Value": "cypressadminuser@test.com"
+      },
+      {
+          "Name": "given_name",
+          "Value": "CypressAutomatedIntegrationTests"
+      },
+      {
+          "Name": "family_name",
+          "Value": "Admin"
+      },
+      {
+          "Name": "email_verified",
+          "Value": "true"
+      },
+      {
+          "Name": "custom:cms_roles",
+          "Value": "mdctcarts-project-officer"
+      }
+    ]
   }
 ]

--- a/tests/cypress/cypress.config.js
+++ b/tests/cypress/cypress.config.js
@@ -14,8 +14,8 @@ module.exports = defineConfig({
   downloadsFolder: "downloads",
   types: ["cypress", "cypress-axe"],
   env: {
-    STATE_USER_EMAIL: "stateuser2@test.com",
-    ADMIN_USER_EMAIL: "cms.admin@test.com",
+    STATE_USER_EMAIL: "cypressstateuser@test.com",
+    ADMIN_USER_EMAIL: "cypressadminuser@test.com",
   },
   e2e: {
     baseUrl: "http://localhost:3000/",


### PR DESCRIPTION
### Description
Two new test users - one admin, one DC state user - for Cypress to log in as. This will prevent any kind of contention on the usual test users, and theoretically make automated test activity easier to identify.

### Related ticket(s)
MDCT-2806

---
### How to test
Will the cypress tests on this branch pass?

### Important updates
None, for manual testing.

---
### Author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
