### PR TITLE
tech debt: update workflows to avoid deprecations

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Dependabotbot Gather Metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.0
+        uses: dependabot/fetch-metadata@v1
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,17 +44,14 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
-      - name: read .nvmrc
-        id: node_version
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
-      - uses: actions/cache@v2
+          node-version-file: ".nvmrc"
+      - uses: actions/cache@v3
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}
@@ -65,7 +62,7 @@ jobs:
         run: ./test-unit.sh
       - name: publish test coverage to code climate
         if: env.CODE_CLIMATE_ID != ''
-        uses: paambaati/codeclimate-action@v2.7.5
+        uses: paambaati/codeclimate-action@v5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}
         with:
@@ -85,7 +82,7 @@ jobs:
       - id: endpoint
         run: |
           APPLICATION_ENDPOINT=$(./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name)
-          echo ::set-output name=application_endpoint::$APPLICATION_ENDPOINT
+          echo "application_endpoint=$APPLICATION_ENDPOINT" >> $GITHUB_OUTPUT
           echo "## Application Endpoint" >> $GITHUB_STEP_SUMMARY
           echo "<$APPLICATION_ENDPOINT>" >> $GITHUB_STEP_SUMMARY
         working-directory: services

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -40,7 +40,7 @@ jobs:
           AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}

--- a/.github/workflows/git-secrets.yaml
+++ b/.github/workflows/git-secrets.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Run gitlakes docker
+      - name: Run gitleaks docker
         uses: docker://zricethezav/gitleaks
         with:
           args: detect --source /github/workspace/ --no-git --verbose

--- a/.github/workflows/git-secrets.yaml
+++ b/.github/workflows/git-secrets.yaml
@@ -4,8 +4,8 @@ jobs:
   gitleaks-scan:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Run gitlakes docker	    
-      uses: docker://zricethezav/gitleaks
-      with:
-        args: detect --source /github/workspace/ --no-git --verbose
+      - uses: actions/checkout@v3
+      - name: Run gitlakes docker
+        uses: docker://zricethezav/gitleaks
+        with:
+          args: detect --source /github/workspace/ --no-git --verbose

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pre-commit/action@v2.0.2
+      - uses: pre-commit/action@v3.0.0
   jest-frontend:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version-file: ".nvmrc"
       - name: Prepare for Jest (frontend)
         run: yarn install --frozen-lockfile
         working-directory: ./services/ui-src
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version-file: ".nvmrc"
       - name: Prepare for Jest (backend)
         run: yarn install --frozen-lockfile
         working-directory: ./services/app-api

--- a/.github/workflows/scan_security-hub-jira-integration.yml
+++ b/.github/workflows/scan_security-hub-jira-integration.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: ${{ secrets.PRODUCTION_SYNC_OIDC_ROLE }}

--- a/.github/workflows/scan_snyk-jira-integration.yml
+++ b/.github/workflows/scan_snyk-jira-integration.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Snyk and Run Snyk test
         run: |
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name == 'schedule'
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Snyk and Run Snyk test
         run: |


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Updated action versions and `set-output` command

case for update: [example previous deploy run](https://github.com/Enterprise-CMCS/macpro-mdct-carts/actions/runs/6300380326) that has the warnings

docs:
[set-output update](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
[aws-configure-credentials readme](https://github.com/aws-actions/configure-aws-credentials) – no breaking changes between 1 and 4. ("By default, your account ID will not be masked in workflow logs. This was changed from being masked by default in the previous version. AWS does not consider account IDs as sensitive information, so this change reflects that stance." Let me know if you want to mask this still and I'll add that option)
[cache readme](https://github.com/actions/cache) – no breaking changes with v3
[codeclimate action changelog](https://github.com/paambaati/codeclimate-action/releases) – breaking changes not relevant to us
[node version action](https://github.com/actions/setup-node) – update allows us to read from .nvmrc natively
[pre-commit/action changelog](https://github.com/pre-commit/action/releases) – doesn't specifically call out a fix but the warnings were resolved by upgrading
[actions/checkout changelog](https://github.com/actions/checkout/releases/tag/v3.0.0) – v3 uses node 16 which will be deprecated soon but doesn't have a warning for now, and keeps it up to date with our other checkouts@v3
[dependabot/fetch-metadata action changelog](https://github.com/dependabot/fetch-metadata/releases) – specifically v1.5.0 removes deprecated set-output so by changing to @v1 it will automatically use latest version


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-none

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
See [deploy step](https://github.com/Enterprise-CMCS/macpro-mdct-carts/actions/runs/6302056446?pr=139467) in this PR has no warnings

and other workflows as well

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---
