### PR TITLE
Move jsonpath-plus to dependencies

### DIFF
--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -20,7 +20,6 @@
     "@types/jest": "^27.4.0",
     "aws-lambda": "^1.0.7",
     "jest": "^27.4.7",
-    "jsonpath-plus": "^5.1.0",
     "serverless-associate-waf": "^1.2.1",
     "serverless-plugin-typescript": "^2.1.0",
     "ts-jest": "^27.1.3",
@@ -30,6 +29,7 @@
     "aws-jwt-verify": "^3.1.0",
     "aws4": "^1.11.0",
     "axios": "^0.27.2",
+    "jsonpath-plus": "^5.1.0",
     "jsonschema": "^1.4.1",
     "jwt-decode": "^3.1.2",
     "uuid": "^7.0.3"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
I foolishly [put jsonpath-plus in devDependencies](https://github.com/Enterprise-CMCS/macpro-mdct-carts/pull/139460/files#diff-176116eaad8a02297192e3a2c242b670c88b7db79d2393a4625c0ea6f37fdbb8) instead of dependencies so it failed in the AWS environment

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2933

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[Deployed environment](https://d2mptsphuu2kz5.cloudfront.net) works (form edits save successfully)

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---