### PR TITLE
[MDCT-2914] 3C - Not readonly & Prior year info

### DIFF
--- a/services/database/data/seed/seed-section-base-2023.json
+++ b/services/database/data/seed/seed-section-base-2023.json
@@ -4158,8 +4158,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -4197,8 +4196,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4206,8 +4204,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4215,8 +4212,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4224,8 +4220,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -4258,8 +4253,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -4297,8 +4291,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4306,8 +4299,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4315,8 +4307,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4324,8 +4315,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -4358,8 +4348,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -4397,8 +4386,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4406,8 +4394,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4415,8 +4402,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4424,8 +4410,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -4459,8 +4444,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -4498,8 +4482,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4507,8 +4490,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4516,8 +4498,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4525,8 +4506,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -4559,8 +4539,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -4598,8 +4577,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4607,8 +4585,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4616,8 +4593,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4625,8 +4601,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -4666,8 +4641,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -4705,8 +4679,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4714,8 +4687,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4723,8 +4695,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4732,8 +4703,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -4766,8 +4736,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -4805,8 +4774,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4814,8 +4782,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4823,8 +4790,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4832,8 +4798,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -4866,8 +4831,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -4905,8 +4869,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4914,8 +4877,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4923,8 +4885,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -4932,8 +4893,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -4967,8 +4927,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -5006,8 +4965,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -5015,8 +4973,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -5024,8 +4981,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -5033,8 +4989,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -5106,8 +5061,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -5115,8 +5069,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -5124,8 +5077,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -5133,8 +5085,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -5862,8 +5813,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -5871,8 +5821,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -5880,8 +5829,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -5889,8 +5837,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -5962,8 +5909,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -5971,8 +5917,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -5980,8 +5925,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -5989,8 +5933,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -6062,8 +6005,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6071,8 +6013,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6080,8 +6021,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6089,8 +6029,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -6163,8 +6102,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6172,8 +6110,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6181,8 +6118,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6190,8 +6126,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -6263,8 +6198,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6272,8 +6206,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6281,8 +6214,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6290,8 +6222,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -6370,8 +6301,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6379,8 +6309,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6388,8 +6317,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6397,8 +6325,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -6470,8 +6397,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6479,8 +6405,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6488,8 +6413,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6497,8 +6421,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -6570,8 +6493,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6579,8 +6501,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6588,8 +6509,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6597,8 +6517,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -6671,8 +6590,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6680,8 +6598,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6689,8 +6606,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6698,8 +6614,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],
@@ -6771,8 +6686,7 @@
                             "type": "integer",
                             "label": "Ages 0-1",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6780,8 +6694,7 @@
                             "type": "integer",
                             "label": "Ages 1-5",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6789,8 +6702,7 @@
                             "type": "integer",
                             "label": "Ages 6-12",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           },
                           {
@@ -6798,8 +6710,7 @@
                             "type": "integer",
                             "label": "Ages 13-16",
                             "answer": {
-                              "entry": null,
-                              "readonly": true
+                              "entry": null
                             }
                           }
                         ],

--- a/services/ui-src/src/components/fields/DataGrid.js
+++ b/services/ui-src/src/components/fields/DataGrid.js
@@ -29,22 +29,30 @@ const DataGrid = ({ question, lastYearFormData }) => {
     // Even years get inputs, odd years get previous year data
     const shouldGetPriorYear = splitID[0] % 2;
 
+    // Custom handling for -03-c-05 and -03-c-06
     if (
       shouldGetPriorYear &&
       splitID[1] === "03" &&
       splitID[2] === "c" &&
-      splitID[3] === "06" &&
+      (splitID[3] === "05" || splitID[3] === "06") &&
       parseInt(splitID[4]) > 2 &&
       parseInt(splitID[4]) < 10
     ) {
       // Set year to last year
       splitID[0] = parseInt(splitID[0]) - 1;
       splitID.pop();
+
       const fieldsetId = splitID.join("-");
+      const partIndex = parseInt(splitID[3]) - 1;
 
       let prevYearValue =
         parseInt(
-          getValueFromLastYear(lastYearFormData[3], fieldsetId, questionId, 5)
+          getValueFromLastYear(
+            lastYearFormData[3],
+            fieldsetId,
+            questionId,
+            partIndex
+          )
         ) || "";
       const itemId = item.id.slice(0, -2);
 

--- a/services/ui-src/src/components/fields/DataGrid.js
+++ b/services/ui-src/src/components/fields/DataGrid.js
@@ -72,7 +72,7 @@ const DataGrid = ({ question, lastYearFormData }) => {
       const temp = questionsToSet.push({
         hideNumber: true,
         question: item,
-        prevYear: { value: prevYearValue, disabled: true },
+        prevYear: { value: prevYearValue },
       });
 
       // Set cumulative array of questions to local state
@@ -94,12 +94,12 @@ const DataGrid = ({ question, lastYearFormData }) => {
   };
 
   // Takes in a section, fieldset ID, and item id to determine which value matches from larger data set
-  const getValueFromLastYear = (data, fieldsetId, itemId, partNumber) => {
+  const getValueFromLastYear = (data, fieldsetId, itemId, partIndex) => {
     let lastYearAnswer;
 
     // Get questions from last years JSON
     const questions =
-      data.contents.section.subsections[2].parts[partNumber].questions;
+      data.contents.section.subsections[2].parts[partIndex].questions;
 
     // Filter down to specific question
     let matchingQuestion = questions.filter(

--- a/services/ui-src/src/components/fields/Integer.js
+++ b/services/ui-src/src/components/fields/Integer.js
@@ -50,7 +50,7 @@ const Integer = ({ onChange, question, prevYear, ...props }) => {
       name={question.id}
       numeric
       onChange={change}
-      value={prevYear ? prevYear.value : renderAnswer(answer)}
+      value={answer != null ? renderAnswer(answer) : prevYear && prevYear.value}
       {...props}
     />
   );

--- a/services/ui-src/src/components/fields/Text.js
+++ b/services/ui-src/src/components/fields/Text.js
@@ -1,75 +1,58 @@
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { TextField } from "@cmsgov/design-system";
-import axios from "../../authenticatedAxios";
 import { connect } from "react-redux";
 import { generateQuestionNumber } from "../utils/helperFunctions";
 
-const Text = ({ question, state, ...props }) => {
+const Text = ({ question, state, lastYearFormData, ...props }) => {
   const [prevYearValue, setPrevYearValue] = useState();
-  const [prevYearDisabled, setPrevYearDisabled] = useState();
+
+  const getPrevYearValue = async () => {
+    // Create array from id
+    const splitID = question.id.split("-");
+
+    // Even years get inputs, odd years get previous year data
+    const shouldGetPriorYear = splitID[0] % 2;
+
+    // If question is Part 6, section 3c, question 9
+    if (
+      shouldGetPriorYear &&
+      splitID[1] === "03" &&
+      splitID[2] === "c" &&
+      (splitID[3] === "05" || splitID[3] === "06") &&
+      splitID[4] === "09"
+    ) {
+      // Set year to last year
+      const lastYear = parseInt(splitID[0]) - 1;
+      splitID[0] = lastYear;
+      const fieldsetId = splitID.join("-");
+      const partIndex = parseInt(splitID[3]) - 1;
+
+      let value =
+        getValueFromLastYear(lastYearFormData[3], fieldsetId, partIndex) || "";
+      setPrevYearValue(value);
+    }
+  };
+
+  const getValueFromLastYear = (data, fieldsetId, partIndex) => {
+    let lastYearAnswer;
+    // Get questions from last years JSON
+    const questions =
+      data.contents.section.subsections[2].parts[partIndex].questions;
+    // Derive matching question
+    let matchingQuestion = questions.filter(
+      (question) => fieldsetId === question?.id
+    );
+
+    // Always use first item in array
+    if (matchingQuestion[0]) {
+      lastYearAnswer = matchingQuestion[0].answer.entry;
+    }
+
+    return lastYearAnswer ?? "";
+  };
 
   useEffect(() => {
-    const getPrevYearValue = async () => {
-      // Create array from id
-      const splitID = question.id.split("-");
-
-      // Even years get inputs, odd years get previous year data
-      const shouldGetPriorYear = splitID[0] % 2;
-
-      // If question is Part 6, section 3c, question 9
-      if (
-        shouldGetPriorYear &&
-        splitID[1] === "03" &&
-        splitID[2] === "c" &&
-        splitID[3] === "06" &&
-        splitID[4] === "09"
-      ) {
-        // Set year to last year
-        const lastYear = parseInt(splitID[0]) - 1;
-        splitID[0] = lastYear;
-        const fieldsetId = splitID.join("-");
-
-        if (state) {
-          try {
-            await axios
-              .get(`/api/v1/sections/${lastYear}/${state.toUpperCase()}/3`)
-              .then((data) => {
-                // getDataFromLastYear(fieldsetId);
-                if (data) {
-                  let value =
-                    getValueFromLastYear(data.data, fieldsetId) ||
-                    "No Value from Last Year";
-                  setPrevYearDisabled(true);
-                  setPrevYearValue(value);
-                }
-              });
-          } catch (e) {
-            setPrevYearDisabled(true);
-            setPrevYearValue(null);
-          }
-        }
-      }
-    };
-
-    const getValueFromLastYear = (data, fieldsetId) => {
-      let lastYearAnswer;
-      // Get questions from last years JSON
-      const questions = data.contents.section.subsections[2].parts[5].questions;
-
-      // Derive matching question
-      let matchingQuestion = questions.filter(
-        (question) => fieldsetId === question?.id
-      );
-
-      // Always use first item in array
-      if (matchingQuestion[0]) {
-        lastYearAnswer = matchingQuestion[0].answer.entry;
-      }
-
-      return lastYearAnswer ?? "";
-    };
-
     getPrevYearValue().then();
   }, [state]);
 
@@ -90,15 +73,15 @@ const Text = ({ question, state, ...props }) => {
           }`}
           id={question.id}
           value={
-            prevYearValue || (question.answer && question.answer.entry) || ""
+            (question.answer && question.answer.entry) || prevYearValue || ""
           }
           type="text"
           {...props}
-          disabled={prevYearDisabled || !!props.disabled}
+          disabled={!!props.disabled}
         />
       </div>
       <p className="print-text-area">
-        {prevYearValue || (question.answer && question.answer.entry) || ""}
+        {(question.answer && question.answer.entry) || prevYearValue || ""}
       </p>
     </>
   );
@@ -107,10 +90,15 @@ Text.propTypes = {
   question: PropTypes.object.isRequired,
   state: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
+  year: PropTypes.number.isRequired,
+  lastYearFormData: PropTypes.object.isRequired,
 };
 
 const mapState = (state) => ({
   state: state.formData[0].contents?.section?.state,
+  year: state.formData[0].contents.section.year,
+  lastYearFormData: state.lastYearFormData,
+  lastYearTotals: state.lastYearTotals,
 });
 
 export default connect(mapState)(Text);


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Feedback from CARTS folks caught some extra changes for 3C.

Part 5 & 6
- Read data from 2022 (was not working in Part 5)
- Current year answers should not be read only in the 2 year cycle
- Functional Change: Answers from prior year should not be readonly, and should be editable.
- Question 9 in part 5 & 6 should also pull through (🐛) 
  - When Question 9 is empty, no string should be populated. Functionality was broken and not happening, but restoring it started bringing a placeholder string through. Removed.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2914

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Spin up 2022 and 2023. 
- Fill out the grids in part 5 and 6
- Go to 2023. New year should be editable
- Past year should be populated and editable

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
