### PR TITLE
skip test that was skipped before

### DIFF
--- a/tests/cypress/cypress.config.js
+++ b/tests/cypress/cypress.config.js
@@ -21,6 +21,7 @@ module.exports = defineConfig({
     baseUrl: "http://localhost:3000/",
     specPattern: "**/*.spec.js",
     supportFile: "support/index.js",
+    excludeSpecPattern: "**/filterReports.spec.js",
     async setupNodeEvents(on, config) {
       await preprocessor.addCucumberPreprocessorPlugin(on, config);
       on("file:preprocessor", browserify.default(config));


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Tried [fixing this test](https://github.com/Enterprise-CMCS/macpro-mdct-carts/pull/139477) but didn't have much luck then I realized this was skipped before the cypress update (see `ignoreTestFiles` in the [old cypress.json](https://github.com/Enterprise-CMCS/macpro-mdct-carts/pull/139465/files#diff-c8befb97501c0e10836c9cb31c5082bede8c8b832aa1f9615b6f6021c347a8c7)) so let's continue skipping it for now while we figure out better tests in a [separate ticket](https://qmacbis.atlassian.net/jira/software/c/projects/MDCT/boards/232?selectedIssue=MDCT-2806)

Will "fix" our woes with the e2e tests [failing in main](https://github.com/Enterprise-CMCS/macpro-mdct-carts/actions/runs/6382753480/job/17322282446) and val

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2806 kinda

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
In cypress.config.ts modify `baseUrl` to point at `https://mdctcartsdev.cms.gov` and run the test suite in ci mode

`"CYPRESS_ADMIN_USER_PASSWORD=pw CYPRESS_STATE_USER_PASSWORD=pwQ yarn test:ci"` (replacing pw with the carts test user password)

Verify they all pass and filterReports is skipped

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
---