### PR TITLE
Treat cost sharing as an offset in table 5.1

### DIFF
--- a/services/database/data/seed/seed-section-base-2023.json
+++ b/services/database/data/seed/seed-section-base-2023.json
@@ -10427,31 +10427,37 @@
                             "contents": "Total benefit costs"
                           },
                           {
-                            "actions": ["sum"],
+                            "actions": ["formula"],
+                            "formula": "<0> + <1> + <2> - <3>",
                             "targets": [
                               "$..*[?(@ && @.id=='2023-05-a-01-01-a')].answer.entry",
                               "$..*[?(@ && @.id=='2023-05-a-01-02-a')].answer.entry",
                               "$..*[?(@ && @.id=='2023-05-a-01-03-a')].answer.entry",
                               "$..*[?(@ && @.id=='2023-05-a-01-04-a')].answer.entry"
-                            ]
+                            ],
+                            "$comment": "This is the sum of costs, minus the cost sharing"
                           },
                           {
-                            "actions": ["sum"],
+                            "actions": ["formula"],
+                            "formula": "<0> + <1> + <2> - <3>",
                             "targets": [
                               "$..*[?(@ && @.id=='2023-05-a-01-01-b')].answer.entry",
                               "$..*[?(@ && @.id=='2023-05-a-01-02-b')].answer.entry",
                               "$..*[?(@ && @.id=='2023-05-a-01-03-b')].answer.entry",
                               "$..*[?(@ && @.id=='2023-05-a-01-04-b')].answer.entry"
-                            ]
+                            ],
+                            "$comment": "This is the sum of costs, minus the cost sharing"
                           },
                           {
-                            "actions": ["sum"],
+                            "actions": ["formula"],
+                            "formula": "<0> + <1> + <2> - <3>",
                             "targets": [
                               "$..*[?(@ && @.id=='2023-05-a-01-01-c')].answer.entry",
                               "$..*[?(@ && @.id=='2023-05-a-01-02-c')].answer.entry",
                               "$..*[?(@ && @.id=='2023-05-a-01-03-c')].answer.entry",
                               "$..*[?(@ && @.id=='2023-05-a-01-04-c')].answer.entry"
-                            ]
+                            ],
+                            "$comment": "This is the sum of costs, minus the cost sharing"
                           }
                         ]
                       ],


### PR DESCRIPTION
### Description
This PR fixes a calculation error inside of a table. Section 5 part 1 gathers cost information, and includes a question for "cost sharing". This is not a cost, however, so it should be _subtracted_ from the other numbers in this section. Previously, it was being added.

I believe the scope of this bug is very limited - other tables in Section 5 already treat cost sharing as an offset. I do not know if this number goes anywhere to be stored; as far as I'm aware it's a display bug for this table only.

Fixed calculation:
![image](https://github.com/Enterprise-CMCS/macpro-mdct-carts/assets/126210497/d87e4204-c228-4599-a646-7858c23ee23a)


### Related ticket(s)
N/A

---
### How to test
1. Log in as admin
2. Generate forms for 2023
3. Log in as a state user
4. Enter some numbers in Section 5 Part 1
5. Observe that cost sharing reduces the number in the total row of Table 1

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
