### PR TITLE
Add a column comparing absolute enrollment change

### DIFF
--- a/services/app-api/libs/validation/backend-section.schema.ts
+++ b/services/app-api/libs/validation/backend-section.schema.ts
@@ -426,6 +426,10 @@ export const sectionSchema = {
             ],
           },
         },
+        // If true, this prevents the first column from being bolded
+        all_columns_have_data: {
+          type: ["bool", "null"],
+        },
       },
       required: ["type", "questions"],
       additionalProperties: false,

--- a/services/database/data/seed/seed-section-base-2023.json
+++ b/services/database/data/seed/seed-section-base-2023.json
@@ -1922,6 +1922,13 @@
                             "compareACS": {
                               "ffy1": "2021",
                               "ffy2": "2022",
+                              "acsProperty": "numberUninsured"
+                            }
+                          },
+                          {
+                            "compareACS": {
+                              "ffy1": "2021",
+                              "ffy2": "2022",
                               "acsProperty": "percentUninsured"
                             }
                           }
@@ -1929,11 +1936,15 @@
                       ],
                       "headers": [
                         {
-                          "contents": "Percent change between 2021 and 2022"
+                          "contents": "Change in the number of uninsured children between 2021 and 2022"
+                        },
+                        {
+                          "contents": "Change in the percent of uninsured children between 2021 and 2022"
                         }
                       ]
                     },
-                    "fieldset_type": "synthesized_table"
+                    "fieldset_type": "synthesized_table",
+                    "all_columns_have_data": true
                   },
                   {
                     "id": "2023-02-a-02-01",

--- a/services/ui-src/src/components/fields/SynthesizedTable.js
+++ b/services/ui-src/src/components/fields/SynthesizedTable.js
@@ -30,7 +30,7 @@ const SynthesizedTable = ({ rows, question, tableTitle }) => {
             return (
               <tr key={index}>
                 {row.map((cell, index) => {
-                  if (index === 0) {
+                  if (index === 0 && !question.all_columns_have_data) {
                     rowLabel = cell.contents;
                     return (
                       <th


### PR DESCRIPTION
### Description
This PR adds an additional calculation to Section 2. State users were confused by the percent change in Section 2.2 being calculated between the percent enrolled year-to-year. Now we will also calculate the percent change between the number enrolled year-to-year.

This also involved a bit of funny business in the schema to prevent the left column from being bolded; normally it always is.

Screenshot below. The new column is the one of the left of the lower table.

![image](https://github.com/Enterprise-CMCS/macpro-mdct-carts/assets/126210497/f92d41e1-c567-4e54-ba19-361249476854)


### Related ticket(s)
n/a

---
### How to test
1. Log in as admin
2. Generate forms for 2023
3. Log in as a state user
4. View section 2
5. Verify, if you like, the two percentages.

### Important updates


---
### Author checklist

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
