### PR TITLE
MDCT-2986: Cleaning Up LD Feature Flag

### DIFF
--- a/services/ui-src/src/components/layout/FormTemplates.js
+++ b/services/ui-src/src/components/layout/FormTemplates.js
@@ -4,7 +4,6 @@ import "react-data-table-component-extensions/dist/index.css";
 import { Button } from "@cmsgov/design-system";
 import { useHistory } from "react-router-dom";
 import { apiLib } from "../../util/apiLib";
-import { useFlags } from "launchdarkly-react-client-sdk";
 
 const FormTemplates = () => {
   const history = useHistory();
@@ -25,8 +24,7 @@ const FormTemplates = () => {
     setInprogress(false);
   };
 
-  const release2023 = useFlags().release2023;
-  const defaultYear = release2023 ? "2023" : "2022";
+  const defaultYear = "2023";
 
   return (
     <>
@@ -40,7 +38,7 @@ const FormTemplates = () => {
           data-testid="generate-forms-options"
           defaultValue={defaultYear}
         >
-          {release2023 && <option value="2023">2023</option>}
+          <option value="2023">2023</option>
           <option value="2022">2022</option>
           <option value="2021">2021</option>
         </select>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Removing the `release2023` feature flag from our codebase since they are no longer being used.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2986

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as `cms.admin@test.com`
- Click on **Generate form base templates**

You should see 2023 as the default year option.

- Log in as `stateuserCA@test.com` for example

You should see a generated 2023 report.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
