### PR TITLE
Add tests for Range and Ranges

### DIFF
--- a/services/ui-src/src/components/fields/Range.test.js
+++ b/services/ui-src/src/components/fields/Range.test.js
@@ -1,0 +1,146 @@
+import React, { useState } from "react";
+import { Provider } from "react-redux";
+import { screen, render } from "@testing-library/react";
+import userEventLib from "@testing-library/user-event";
+import configureMockStore from "redux-mock-store";
+import { Range } from "./Ranges";
+
+const userEvent = userEventLib.setup();
+
+const mockStore = configureMockStore();
+const store = mockStore({
+  formData: [
+    {
+      contents: {
+        section: {
+          year: 2023,
+          state: "AL",
+        },
+      },
+    },
+  ],
+  lastYearFormData: [],
+  lastYearTotals: {},
+});
+
+/*
+ * <Range> expects to be contained within a component that receives value
+ * updates via an onChange handler, and sends them back via the values prop.
+ * So we create this harness component to test <Range> in isolation.
+ */
+const RangeComponentWithProps = (testSpecificProps) => {
+  const defaultMockProps = {
+    id: "mock-id",
+    category: ["start label", "end label"],
+    index: 42,
+    row: 12,
+    type: "mock-type",
+    values: ["1,234", "5,678"],
+  };
+
+  const props = {
+    ...defaultMockProps,
+    ...testSpecificProps,
+  };
+
+  const [vals, setVals] = useState(props.values);
+  const changeHandler = (_row, _cat, index, value) => {
+    const newVals = [...vals];
+    newVals[index] = value;
+    setVals(newVals);
+  };
+
+  return (
+    <Provider store={store}>
+      <Range {...props} onChange={changeHandler} values={vals} />
+    </Provider>
+  );
+};
+
+describe("Range component", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should render two child inputs with appropriate properties", () => {
+    render(<RangeComponentWithProps />);
+
+    const startInput = screen.getByLabelText("start label");
+    expect(startInput).toHaveAttribute("id", "mock-id-12-42-0");
+    expect(startInput).toHaveValue("1,234");
+
+    const endInput = screen.getByLabelText("end label");
+    expect(endInput).toHaveAttribute("id", "mock-id-12-42-1");
+    expect(endInput).toHaveValue("5,678");
+
+    expect(
+      screen.queryByText("Start value must be less than end value")
+    ).not.toBeInTheDocument();
+  });
+
+  test("Should render Text inputs by default", () => {
+    render(<RangeComponentWithProps type="some unaccounted-for type" />);
+    const startInput = screen.getByLabelText("start label");
+    expect(startInput).not.toHaveAttribute("inputmode", "numeric");
+  });
+
+  test("Should render Text inputs when specified", () => {
+    render(<RangeComponentWithProps type="text" />);
+    const startInput = screen.getByLabelText("start label");
+    expect(startInput).not.toHaveAttribute("inputmode", "numeric");
+  });
+
+  test("Should render Percentage inputs", () => {
+    render(<RangeComponentWithProps type="percentage" />);
+    const startInput = screen.getByLabelText("start label");
+    expect(startInput).toHaveAttribute("inputmode", "numeric");
+    expect(screen.queryAllByText("$")).toHaveLength(0);
+  });
+
+  test("Should render Money inputs", () => {
+    render(<RangeComponentWithProps type="money" />);
+    const startInput = screen.getByLabelText("start label");
+    expect(startInput).toHaveAttribute("inputmode", "numeric");
+    expect(screen.getAllByText("$")).toHaveLength(2);
+  });
+
+  test("Should disable inputs when specified", () => {
+    render(<RangeComponentWithProps disabled />);
+
+    const startInput = screen.getByLabelText("start label");
+    expect(startInput).toBeDisabled();
+
+    const endInput = screen.getByLabelText("end label");
+    expect(endInput).toBeDisabled();
+  });
+
+  test("Should display an error when start is greater than end", async () => {
+    render(<RangeComponentWithProps type="percentage" values={["", ""]} />);
+
+    const startInput = screen.getByLabelText("start label");
+    await userEvent.type(startInput, "5,678");
+
+    const endInput = screen.getByLabelText("end label");
+    await userEvent.type(endInput, "1,234");
+    endInput.dispatchEvent(new Event("blur"));
+
+    expect(
+      screen.getByText("Start value must be less than end value")
+    ).toBeInTheDocument();
+  });
+
+  test("Should not validate values for text ranges", async () => {
+    render(<RangeComponentWithProps type="text" values={["", ""]} />);
+
+    const startInput = screen.getByLabelText("start label");
+    await userEvent.type(startInput, "5,678");
+
+    const endInput = screen.getByLabelText("end label");
+    await userEvent.type(endInput, "1,234");
+    endInput.dispatchEvent(new Event("blur"));
+
+    expect(
+      screen.queryByText("Start value must be less than end value")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/ui-src/src/components/fields/Ranges.test.js
+++ b/services/ui-src/src/components/fields/Ranges.test.js
@@ -1,0 +1,140 @@
+import React from "react";
+import { Provider } from "react-redux";
+import { screen, render } from "@testing-library/react";
+import userEventLib from "@testing-library/user-event";
+import configureMockStore from "redux-mock-store";
+import { Ranges } from "./Ranges";
+
+const userEvent = userEventLib.setup();
+
+const mockStore = configureMockStore();
+const store = mockStore({
+  formData: [
+    {
+      contents: {
+        section: {
+          year: 2023,
+          state: "AL",
+        },
+      },
+    },
+  ],
+  lastYearFormData: [],
+  lastYearTotals: {},
+});
+
+const defaultProps = {
+  question: {
+    id: "mock-question-id",
+    answer: {
+      header: "Mock Question Header",
+      entry_max: 2,
+      entry_min: 1,
+      range_type: ["money"],
+      range_categories: [["Mock Range Start", "Mock Range End"]],
+    },
+  },
+  onChange: jest.fn(),
+};
+
+const RangesComponentWithProps = (testSpecificProps) => {
+  return (
+    <Provider store={store}>
+      <Ranges {...defaultProps} {...testSpecificProps} />
+    </Provider>
+  );
+};
+
+describe("Range component", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should render header and labels", () => {
+    render(RangesComponentWithProps());
+
+    expect(screen.getByText("Mock Question Header")).toBeInTheDocument();
+    expect(screen.getByLabelText("Mock Range Start")).toBeInTheDocument();
+    expect(screen.getByLabelText("Mock Range End")).toBeInTheDocument();
+  });
+
+  test("should render existing values if provided", () => {
+    render(
+      RangesComponentWithProps({
+        ...defaultProps,
+        question: {
+          ...defaultProps.question,
+          answer: {
+            ...defaultProps.question.answer,
+            entry: [[["123", "456"]]],
+          },
+        },
+      })
+    );
+
+    expect(screen.getByLabelText("Mock Range Start")).toHaveValue("123");
+    expect(screen.getByLabelText("Mock Range End")).toHaveValue("456");
+  });
+
+  test("should allow a ranges to be added and removed", async () => {
+    render(RangesComponentWithProps());
+
+    expect(screen.getAllByLabelText("Mock Range Start")).toHaveLength(1);
+    expect(screen.queryByText("Remove Last Entry")).not.toBeInTheDocument();
+
+    const addButton = screen.getByText("Add another?");
+    await userEvent.click(addButton);
+
+    expect(screen.getAllByLabelText("Mock Range Start")).toHaveLength(2);
+    expect(screen.queryByText("Add another?")).not.toBeInTheDocument();
+
+    const removeButton = screen.getByText("Remove Last Entry");
+    await userEvent.click(removeButton);
+
+    expect(screen.getAllByLabelText("Mock Range Start")).toHaveLength(1);
+  });
+
+  test("Should disable inputs when specified", () => {
+    render(
+      RangesComponentWithProps({
+        ...defaultProps,
+        disabled: true,
+        question: {
+          ...defaultProps.question,
+          answer: {
+            ...defaultProps.question.answer,
+            // Specifying entry, min, and max such that both buttons are visible
+            entry: [[["1", "2"]], [["3", "4"]]],
+            entry_min: 1,
+            entry_max: 3,
+          },
+        },
+      })
+    );
+
+    const anInput = screen.getAllByLabelText("Mock Range Start")[0];
+    expect(anInput).toBeDisabled();
+
+    const addButton = screen.getByText("Add another?");
+    expect(addButton).toBeDisabled();
+
+    const removeButton = screen.getByText("Remove Last Entry");
+    expect(removeButton).toBeDisabled();
+  });
+
+  test("Should emit appropriate onChange events", async () => {
+    render(RangesComponentWithProps());
+
+    const rangeEndInput = screen.getByLabelText("Mock Range End");
+    await userEvent.type(rangeEndInput, "5");
+
+    expect(defaultProps.onChange).toBeCalled();
+    const evt = defaultProps.onChange.mock.calls[0][0];
+    expect(evt).toEqual({
+      target: {
+        name: "mock-question-id",
+        value: [[[null, "5"]]],
+      },
+    });
+  });
+});


### PR DESCRIPTION
### Description
It's more tests! Woohoo.

The two components `<Range>` and `<Ranges>` are never used in isolation from each other, but I created separate suites to test them just to keep the tests digestible.

### Related ticket(s)
n/a

---
### How to test
`yarn test`

### Important updates
n/a

---
### Author checklist

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~

