### PR TITLE
Change incorrect money types to integer - etl and seed update

### DIFF
--- a/services/database/data/seed-local/seed-section.json
+++ b/services/database/data/seed-local/seed-section.json
@@ -11665,7 +11665,7 @@
                             "comment": "This is the first real question so far in this part…",
                             "id": "2022-05-a-03-01-a",
                             "label": "2022",
-                            "type": "money",
+                            "type": "integer",
                             "answer": {
                               "entry": "5"
                             }
@@ -11673,7 +11673,7 @@
                           {
                             "id": "2022-05-a-03-01-b",
                             "label": "2023",
-                            "type": "money",
+                            "type": "integer",
                             "answer": {
                               "entry": "5"
                             }
@@ -11681,7 +11681,7 @@
                           {
                             "id": "2022-05-a-03-01-c",
                             "label": "2024",
-                            "type": "money",
+                            "type": "integer",
                             "answer": {
                               "entry": "5"
                             }
@@ -11825,7 +11825,7 @@
                             "comment": "This is the first real question so far in this part…",
                             "id": "2022-05-a-04-01-a",
                             "label": "2022",
-                            "type": "money",
+                            "type": "integer",
                             "answer": {
                               "entry": "5"
                             }
@@ -11833,7 +11833,7 @@
                           {
                             "id": "2022-05-a-04-01-b",
                             "label": "2023",
-                            "type": "money",
+                            "type": "integer",
                             "answer": {
                               "entry": "5"
                             }
@@ -11841,7 +11841,7 @@
                           {
                             "id": "2022-05-a-04-01-c",
                             "label": "2024",
-                            "type": "money",
+                            "type": "integer",
                             "answer": {
                               "entry": "5"
                             }

--- a/services/database/data/seed/seed-section-base-2022.json
+++ b/services/database/data/seed/seed-section-base-2022.json
@@ -11673,7 +11673,7 @@
                         "questions": [
                           {
                             "id": "2022-05-a-04-01-a",
-                            "type": "money",
+                            "type": "integer",
                             "label": "2022",
                             "answer": {
                               "entry": null
@@ -11682,7 +11682,7 @@
                           },
                           {
                             "id": "2022-05-a-04-01-b",
-                            "type": "money",
+                            "type": "integer",
                             "label": "2023",
                             "answer": {
                               "entry": null
@@ -11690,7 +11690,7 @@
                           },
                           {
                             "id": "2022-05-a-04-01-c",
-                            "type": "money",
+                            "type": "integer",
                             "label": "2024",
                             "answer": {
                               "entry": null
@@ -11715,7 +11715,7 @@
                         "questions": [
                           {
                             "id": "2022-05-a-04-02-a",
-                            "type": "money",
+                            "type": "integer",
                             "label": "2022",
                             "answer": {
                               "entry": null
@@ -11724,7 +11724,7 @@
                           },
                           {
                             "id": "2022-05-a-04-02-b",
-                            "type": "money",
+                            "type": "integer",
                             "label": "2023",
                             "answer": {
                               "entry": null
@@ -11732,7 +11732,7 @@
                           },
                           {
                             "id": "2022-05-a-04-02-c",
-                            "type": "money",
+                            "type": "integer",
                             "label": "2024",
                             "answer": {
                               "entry": null

--- a/services/database/data/seed/seed-section-base-2022.json
+++ b/services/database/data/seed/seed-section-base-2022.json
@@ -11513,7 +11513,7 @@
                         "questions": [
                           {
                             "id": "2022-05-a-03-01-a",
-                            "type": "money",
+                            "type": "integer",
                             "label": "2022",
                             "answer": {
                               "entry": null
@@ -11522,7 +11522,7 @@
                           },
                           {
                             "id": "2022-05-a-03-01-b",
-                            "type": "money",
+                            "type": "integer",
                             "label": "2023",
                             "answer": {
                               "entry": null
@@ -11530,7 +11530,7 @@
                           },
                           {
                             "id": "2022-05-a-03-01-c",
-                            "type": "money",
+                            "type": "integer",
                             "label": "2024",
                             "answer": {
                               "entry": null
@@ -11715,7 +11715,7 @@
                         "questions": [
                           {
                             "id": "2022-05-a-04-02-a",
-                            "type": "integer",
+                            "type": "money",
                             "label": "2022",
                             "answer": {
                               "entry": null
@@ -11724,7 +11724,7 @@
                           },
                           {
                             "id": "2022-05-a-04-02-b",
-                            "type": "integer",
+                            "type": "money",
                             "label": "2023",
                             "answer": {
                               "entry": null
@@ -11732,7 +11732,7 @@
                           },
                           {
                             "id": "2022-05-a-04-02-c",
-                            "type": "integer",
+                            "type": "money",
                             "label": "2024",
                             "answer": {
                               "entry": null

--- a/services/database/data/seed/seed-section-base-2023.json
+++ b/services/database/data/seed/seed-section-base-2023.json
@@ -11454,7 +11454,7 @@
                         "questions": [
                           {
                             "id": "2023-05-a-03-01-a",
-                            "type": "money",
+                            "type": "integer",
                             "label": "2023",
                             "answer": {
                               "entry": null
@@ -11463,7 +11463,7 @@
                           },
                           {
                             "id": "2023-05-a-03-01-b",
-                            "type": "money",
+                            "type": "integer",
                             "label": "2024",
                             "answer": {
                               "entry": null
@@ -11471,7 +11471,7 @@
                           },
                           {
                             "id": "2023-05-a-03-01-c",
-                            "type": "money",
+                            "type": "integer",
                             "label": "2025",
                             "answer": {
                               "entry": null
@@ -11614,7 +11614,7 @@
                         "questions": [
                           {
                             "id": "2023-05-a-04-01-a",
-                            "type": "money",
+                            "type": "integer",
                             "label": "2023",
                             "answer": {
                               "entry": null
@@ -11623,7 +11623,7 @@
                           },
                           {
                             "id": "2023-05-a-04-01-b",
-                            "type": "money",
+                            "type": "integer",
                             "label": "2024",
                             "answer": {
                               "entry": null
@@ -11631,7 +11631,7 @@
                           },
                           {
                             "id": "2023-05-a-04-01-c",
-                            "type": "money",
+                            "type": "integer",
                             "label": "2025",
                             "answer": {
                               "entry": null

--- a/services/database/handlers/dataCorrections/convertMoneyTypeToInteger.js
+++ b/services/database/handlers/dataCorrections/convertMoneyTypeToInteger.js
@@ -1,0 +1,140 @@
+let dynamoClient;
+let dynamoPrefix;
+// eslint-disable-next-line no-unused-vars
+async function handler(event, context, callback) {
+  // eslint-disable-next-line no-console
+  console.log("Start of data fix");
+
+  const aws = require("aws-sdk");
+
+  const dynamoConfig = {};
+  const endpoint = process.env.DYNAMODB_URL;
+  if (endpoint) {
+    dynamoConfig.endpoint = endpoint;
+    dynamoConfig.accessKeyId = "LOCAL_FAKE_KEY"; // pragma: allowlist secret
+    dynamoConfig.secretAccessKey = "LOCAL_FAKE_SECRET"; // pragma: allowlist secret
+    dynamoPrefix = "local";
+  } else {
+    dynamoConfig["region"] = "us-east-1";
+    dynamoPrefix = process.env.dynamoPrefix;
+  }
+
+  dynamoClient = new aws.DynamoDB.DocumentClient(dynamoConfig);
+
+  const results = await scan(dynamoClient);
+  const transformed = await transform(results);
+  const keys = ["pk", "sectionId"];
+  await updateItems(`${dynamoPrefix}-section`, transformed, keys);
+
+  return results;
+  // console.log("Completed data fix");
+}
+
+async function transform(items) {
+  const transformed = items.map((item) => {
+    const corrected = { ...item };
+
+    // part 3
+    corrected.contents.section.subsections[0].parts[2].questions[0].questions[0].questions[0].type =
+      "integer";
+    corrected.contents.section.subsections[0].parts[2].questions[0].questions[0].questions[1].type =
+      "integer";
+    corrected.contents.section.subsections[0].parts[2].questions[0].questions[0].questions[2].type =
+      "integer";
+    // part 4
+    corrected.contents.section.subsections[0].parts[3].questions[0].questions[0].questions[0].type =
+      "integer";
+    corrected.contents.section.subsections[0].parts[3].questions[0].questions[0].questions[1].type =
+      "integer";
+    corrected.contents.section.subsections[0].parts[3].questions[0].questions[0].questions[2].type =
+      "integer";
+
+    return corrected;
+  });
+
+  return transformed;
+}
+
+async function scan(dynamoClient) {
+  let startingKey;
+  let existingItems = [];
+  let results;
+
+  const queryParams = {
+    TableName: `${dynamoPrefix}-section`,
+    ExpressionAttributeNames: {
+      "#year": "year",
+      "#sectionId": "sectionId",
+    },
+    ExpressionAttributeValues: {
+      ":year": 2023,
+      ":sectionId": 5,
+    },
+    FilterExpression: "#year = :year AND #sectionId = :sectionId",
+  };
+
+  const queryTable = async (startingKey) => {
+    queryParams.ExclusiveStartKey = startingKey;
+    let results = await dynamoClient.scan(queryParams).promise();
+    if (results.LastEvaluatedKey) {
+      startingKey = results.LastEvaluatedKey;
+      return [startingKey, results];
+    } else {
+      return [null, results];
+    }
+  };
+
+  // Looping to perform complete scan of tables due to 1 mb limit per iteration
+  do {
+    [startingKey, results] = await queryTable(startingKey);
+    const items = results?.Items;
+    existingItems.push(...items);
+  } while (startingKey);
+
+  return existingItems;
+}
+
+// eslint-disable-next-line no-unused-vars
+const updateItems = async (tableName, items, keys) => {
+  try {
+    for (const item of items) {
+      let key = {};
+      for (const k of keys) {
+        key[k] = item[k];
+        delete item[k];
+      }
+
+      const params = {
+        TableName: tableName,
+        Key: key,
+        ...convertToDynamoExpression(item),
+      };
+      await dynamoClient.update(params).promise();
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(` -- ERROR UPLOADING ${tableName}\n`, e);
+  }
+};
+
+const convertToDynamoExpression = (listOfVars) => {
+  let expressionAttributeNames = {};
+  let expressionAttributeValues = {};
+  let updateExpression = "";
+  Object.keys(listOfVars).forEach((key, index) => {
+    expressionAttributeNames[`#${key}`] = key;
+    expressionAttributeValues[`:${key}`] = listOfVars[key];
+
+    updateExpression =
+      index === 0
+        ? `set #${key}=:${key}`
+        : `${updateExpression}, #${key}=:${key}`;
+  });
+  return {
+    UpdateExpression: updateExpression,
+    ExpressionAttributeNames: expressionAttributeNames,
+    ExpressionAttributeValues: expressionAttributeValues,
+  };
+};
+
+exports.handler = handler;

--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -106,6 +106,11 @@ functions:
       dynamoPrefix: ${self:custom.stage}
       seedTestData: ${self:custom.seedTestData}
     timeout: 120
+  convertMoneyTypeToInteger:
+    handler: handlers/dataCorrections/convertMoneyTypeToInteger.handler
+    environment:
+      dynamoPrefix: ${self:custom.stage}
+    timeout: 120
 
 resources:
   Resources:


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Six fields in Section 5 incorrectly have type "money" when they should be "integer". This updates the templates and seed data (for local dev) and contains an ETL to run in each environment to fix existing reports.

### ETL
- Looks for these six questions and updates `type` attribute to `integer`
Note: I checked if there are differences between  money and integer in validation. All money values must be whole numbers, and all periods, commas, dollar signs are removed upon type/blur/save, so there should be no issue with changing the type if users have already entered values. 

ETL only runs for 2023. DK said leave 2022 as is.
The lambda for the ETL can be safely removed after this change is in every environment | 

### Seed updates: 
- update 2022 and 2023 seed templates, just so when we make future reports (2024+) we have a more accurate base
  - also means when we generate 2023 locally and in deployed branches it has correct type
- update 2022 seed-section to have correct type, for local dev only


Note: I verified that the question numbers `2023-05-a-03-01*` and `2023-05-a-04-01*` are only used to display in the table below those questions, not anywhere else for calculations or display.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3048

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Test seed files updated
- Run CARTS
- Generate 2023 forms as admin
- As state user, go to 2023 form, section 5, parts 3 and 4
- Ensure the questions about "How many children were eligible for managed care..." in each part correctly shows an integer field, not a money field (no dollar sign)

Test ETL script
- Login to the CARTS-dev AWS account
- Open dynamodb and lambda in two tabs
  - Dynamo table: `cmdct-3048-section`
  - Lambda: `database-cmdct-3048-convertMoneyTypeToInteger`
- In another tab go to the deployed ui: `https://de853vni0o7zv.cloudfront.net`
- Login as stateuser2 and go to `/sections/2023/05`
- Scroll down to Parts 3 and 4. See if the first question box begins with a dollar sign or not.
- If not
  - Find `AL-2023` in the dynamo table and click on the section 5 entry
  - Go to JSON view
  - Search for `2023-05-a-03-01-` and change the types of `a,b,c` to "money" (resetting to verify the fix)
  - Repeat for `2023-05-a-04-01-`
- On the lambda, run "test" in the test tab. It should complete in seconds.
- Refresh the UI and see that the dollar signs are gone, and any number value remains the same

See demo video:

https://github.com/Enterprise-CMCS/macpro-mdct-carts/assets/57802560/2e11cf70-0d0f-4ee0-a0bf-95623fc5bd56

---
### Author checklist
<!-- Complete the following steps before opening for review -->
- [x] I have performed a self-review of my code
---
