### PR TITLE
Fix years in question labels in section 6

### DIFF
--- a/services/database/data/seed-local/seed-section.json
+++ b/services/database/data/seed-local/seed-section.json
@@ -12036,7 +12036,7 @@
                   },
                   {
                     "id": "2022-06-a-01-02",
-                    "label": "What’s the greatest challenge your CHIP program has faced in FFY 2023?",
+                    "label": "What’s the greatest challenge your CHIP program has faced in FFY 2022?",
                     "type": "text_multiline",
                     "answer": {
                       "entry": "test"
@@ -12044,7 +12044,7 @@
                   },
                   {
                     "id": "2022-06-a-01-03",
-                    "label": "What are some of the greatest accomplishments your CHIP program has experienced in FFY 2023?",
+                    "label": "What are some of the greatest accomplishments your CHIP program has experienced in FFY 2022?",
                     "type": "text_multiline",
                     "answer": {
                       "entry": "test"
@@ -12052,7 +12052,7 @@
                   },
                   {
                     "id": "2022-06-a-01-04",
-                    "label": "What changes have you made to your CHIP program in FFY 2023 or plan to make in FFY 2024? Why have you decided to make these changes?",
+                    "label": "What changes have you made to your CHIP program in FFY 2022 or plan to make in FFY 2023? Why have you decided to make these changes?",
                     "type": "text_multiline",
                     "answer": {
                       "entry": "test"

--- a/services/database/data/seed/seed-section-base-2022.json
+++ b/services/database/data/seed/seed-section-base-2022.json
@@ -11878,7 +11878,7 @@
                   {
                     "id": "2022-06-a-01-02",
                     "type": "text_multiline",
-                    "label": "What’s the greatest challenge your CHIP program has faced in FFY 2023?",
+                    "label": "What’s the greatest challenge your CHIP program has faced in FFY 2022?",
                     "answer": {
                       "entry": null
                     }
@@ -11886,7 +11886,7 @@
                   {
                     "id": "2022-06-a-01-03",
                     "type": "text_multiline",
-                    "label": "What are some of the greatest accomplishments your CHIP program has experienced in FFY 2023?",
+                    "label": "What are some of the greatest accomplishments your CHIP program has experienced in FFY 2022?",
                     "answer": {
                       "entry": null
                     }
@@ -11894,7 +11894,7 @@
                   {
                     "id": "2022-06-a-01-04",
                     "type": "text_multiline",
-                    "label": "What changes have you made to your CHIP program in FFY 2023 or plan to make in FFY 2024? Why have you decided to make these changes?",
+                    "label": "What changes have you made to your CHIP program in FFY 2022 or plan to make in FFY 2023? Why have you decided to make these changes?",
                     "answer": {
                       "entry": null
                     }

--- a/services/database/data/seed/seed-section-base-2023.json
+++ b/services/database/data/seed/seed-section-base-2023.json
@@ -11819,7 +11819,7 @@
                   {
                     "id": "2023-06-a-01-02",
                     "type": "text_multiline",
-                    "label": "What’s the greatest challenge your CHIP program has faced in FFY 2022?",
+                    "label": "What’s the greatest challenge your CHIP program has faced in FFY 2023?",
                     "answer": {
                       "entry": null
                     }
@@ -11827,7 +11827,7 @@
                   {
                     "id": "2023-06-a-01-03",
                     "type": "text_multiline",
-                    "label": "What are some of the greatest accomplishments your CHIP program has experienced in FFY 2022?",
+                    "label": "What are some of the greatest accomplishments your CHIP program has experienced in FFY 2023?",
                     "answer": {
                       "entry": null
                     }
@@ -11835,7 +11835,7 @@
                   {
                     "id": "2023-06-a-01-04",
                     "type": "text_multiline",
-                    "label": "What changes have you made to your CHIP program in FFY 2022 or plan to make in FFY 2023? Why have you decided to make these changes?",
+                    "label": "What changes have you made to your CHIP program in FFY 2023 or plan to make in FFY 2024? Why have you decided to make these changes?",
                     "answer": {
                       "entry": null
                     }

--- a/services/database/scripts/section-6-label-year-fix.js
+++ b/services/database/scripts/section-6-label-year-fix.js
@@ -2,7 +2,9 @@
 const aws = require("aws-sdk");
 const isLocal = !!process.env.DYNAMODB_URL;
 const localEndpoint = process.env.DYNAMODB_URL;
-const sectionTableName = isLocal ? "local-section" : "main-section";
+const sectionTableName = isLocal
+  ? "local-section"
+  : process.env.dynamoPrefix + "-section";
 
 async function handler() {
   try {

--- a/services/database/scripts/section-6-label-year-fix.js
+++ b/services/database/scripts/section-6-label-year-fix.js
@@ -1,0 +1,148 @@
+/* eslint-disable no-console */
+const aws = require("aws-sdk");
+const isLocal = !!process.env.DYNAMODB_URL;
+const localEndpoint = process.env.DYNAMODB_URL;
+const sectionTableName = isLocal ? "local-section" : "main-section";
+
+async function handler() {
+  try {
+    console.log("Start of data fix");
+
+    const db = buildDynamoClient();
+
+    const results = await scan(db);
+    const transformed = await transform(results);
+    const keys = ["pk", "sectionId"];
+    await updateItems(db, sectionTableName, transformed, keys);
+
+    console.debug("Data fix complete");
+
+    return {
+      statusCode: 200,
+      body: "All done!",
+    };
+  } catch (err) {
+    console.error(err);
+    return {
+      statusCode: 500,
+      body: err.message,
+    };
+  }
+}
+
+function buildDynamoClient() {
+  if (isLocal) {
+    return new aws.DynamoDB.DocumentClient({
+      region: "localhost",
+      endpoint: localEndpoint,
+      accessKeyId: "LOCALFAKEKEY", // pragma: allowlist secret
+      secretAccessKey: "LOCALFAKESECRET", // pragma: allowlist secret
+    });
+  } else {
+    return new aws.DynamoDB.DocumentClient({
+      region: "us-east-1",
+    });
+  }
+}
+
+async function transform(items) {
+  const transformed = items.map((item) => {
+    const corrected = { ...item };
+
+    // section 6, question 2 label
+    corrected.contents.section.subsections[0].parts[0].questions[1].label =
+      "What’s the greatest challenge your CHIP program has faced in FFY 2023?";
+    // section 6, question 3 label
+    corrected.contents.section.subsections[0].parts[0].questions[2].label =
+      "What are some of the greatest accomplishments your CHIP program has experienced in FFY 2023?";
+    // section 6, question 4 label
+    corrected.contents.section.subsections[0].parts[0].questions[3].label =
+      "What changes have you made to your CHIP program in FFY 2023 or plan to make in FFY 2024? Why have you decided to make these changes?";
+
+    return corrected;
+  });
+
+  return transformed;
+}
+
+async function scan(dynamoClient) {
+  let startingKey;
+  let existingItems = [];
+  let results;
+
+  const queryParams = {
+    TableName: sectionTableName,
+    ExpressionAttributeNames: {
+      "#year": "year",
+      "#sectionId": "sectionId",
+    },
+    ExpressionAttributeValues: {
+      ":year": 2023,
+      ":sectionId": 6,
+    },
+    FilterExpression: "#year = :year AND #sectionId = :sectionId",
+  };
+
+  const queryTable = async (startingKey) => {
+    queryParams.ExclusiveStartKey = startingKey;
+    let results = await dynamoClient.scan(queryParams).promise();
+    if (results.LastEvaluatedKey) {
+      startingKey = results.LastEvaluatedKey;
+      return [startingKey, results];
+    } else {
+      return [null, results];
+    }
+  };
+
+  // Looping to perform complete scan of tables due to 1 mb limit per iteration
+  do {
+    [startingKey, results] = await queryTable(startingKey);
+    const items = results?.Items;
+    existingItems.push(...items);
+  } while (startingKey);
+
+  return existingItems;
+}
+
+const updateItems = async (db, tableName, items, keys) => {
+  try {
+    for (const item of items) {
+      let key = {};
+      for (const k of keys) {
+        key[k] = item[k];
+        delete item[k];
+      }
+
+      const params = {
+        TableName: tableName,
+        Key: key,
+        ...convertToDynamoExpression(item),
+      };
+      await db.update(params).promise();
+    }
+  } catch (e) {
+    console.log(` -- ERROR UPLOADING ${tableName}\n`, e);
+  }
+};
+
+const convertToDynamoExpression = (listOfVars) => {
+  let expressionAttributeNames = {};
+  let expressionAttributeValues = {};
+  let updateExpression = "";
+  Object.keys(listOfVars).forEach((key, index) => {
+    expressionAttributeNames[`#${key}`] = key;
+    expressionAttributeValues[`:${key}`] = listOfVars[key];
+
+    updateExpression =
+      index === 0
+        ? `set #${key}=:${key}`
+        : `${updateExpression}, #${key}=:${key}`;
+  });
+  return {
+    UpdateExpression: updateExpression,
+    ExpressionAttributeNames: expressionAttributeNames,
+    ExpressionAttributeValues: expressionAttributeValues,
+  };
+};
+
+handler();


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Fix incorrect years in section 6 questions for 2023 forms.
I also noted some 2022 forms had the incorrect years so I adjusted those, just for local dev.
Code here is based on a combination of a [former lambda ETL](https://github.com/Enterprise-CMCS/macpro-mdct-carts/blob/main/services/database/handlers/dataCorrections/convertMoneyTypeToInteger.js) and a [script ETL](https://github.com/Enterprise-CMCS/macpro-mdct-carts/blob/main/services/database/scripts/wyoming-2022-fix.js) 

Note: DB scan explicitly only scans for 2023 and section 6. No other sections should be affected by this script. 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3112

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Create your own test branch or choose an existing one (I may have already run this against main 🙈)
- Go to the deployed instance of that branch
  - Generate 2023 forms as an admin
  - Go to Section 6 in any 2023 report
  - Verify the second and third questions ask for 2022 and the fourth asks for 2022 and 2023
- Get AWS credentials from carts-dev in your terminal
- From local you can run `dynamoPrefix="YOUR BRANCH NAME" node services/database/scripts/section-6-label-year-fix.js`
- This will modify section 6 of that branch
- Refresh your browser and verify the associated questions now ask for 2023 and 2024.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---