### PR TITLE
Update fmap seed year key to match schema: 'fiscalYear'

### DIFF
--- a/services/database/handlers/seed/tables/fmap.js
+++ b/services/database/handlers/seed/tables/fmap.js
@@ -2,7 +2,7 @@ const seed = {
   name: "FMAP",
   data: require("../../../data/seed/seed-fmap.json"),
   tableNameBuilder: (stage) => `${stage}-fmap`,
-  keys: ["stateId", "year"],
+  keys: ["stateId", "fiscalYear"],
 };
 
 module.exports = seed;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The FMAP seed runner has been failing since it was [created](https://github.com/Enterprise-CMCS/macpro-mdct-carts/pull/138798/files#diff-167751f5f3f2d98a1c79b05f108fc3352fd64e3231d693c5e4edde6bdd510f7b) with this error
`ERROR UPLOADING production-fmap ValidationException: The provided key element does not match the schema`

If you compare the keys provided in the script to those in the DB schema you'll notice the year key differs
[fmap script](https://github.com/Enterprise-CMCS/macpro-mdct-carts/blob/main/services/database/handlers/seed/tables/fmap.js#L5)
[fmap table keys](https://github.com/Enterprise-CMCS/macpro-mdct-carts/blob/main/services/database/serverless.yml#L150)

By updating `year` to `fiscalYear` the keys now match the table keys and the runner succeeds.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3144

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Three ways you can verify, from different angles


1. Verify FMAP data loads in deployed URL
  - Go to `https://d1abiiwzbfk8c4.cloudfront.net/`
  - Log in as a state or admin user (I've already generated 2023 reports)
  - Navigate to Section 5 in any 2023 report
  - Verify Table 3 has the row `eFMAP` populated for columns 2023 and 2024
2. Verify FMAP database has values for 2023 and 2024
  - Log in to CARTS dev AWS account
  - Go to Dynamodb and explore items in table `fix-fmap-seed-fmap`
  - Verify values for 2023 and 2024 are there
3. Verify script ran in AWS
  - Log in to CARTS dev AWS account
  - The script ran once and failed. Then ran again and succeeded
  - View [log insights](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-43200~timeType~'RELATIVE~unit~'seconds~editorString~'fields*20*40timestamp*2c*20*40message*2c*20*40logStream*2c*20*40log*0a*7c*20filter*20*40message*20like*20*2fERROR*2f*0a*7c*20sort*20*40timestamp*20desc*0a*7c*20limit*2020~queryId~'869bf7ab1bcbeab-3129bd96-4743547-1237957f-8640c23f807d37b292fb851b~source~(~'*2faws*2flambda*2fdatabase-fix-fmap-seed-seed))) for 2023-12-18 and verify that there are four error logs (from the unsuccessful run). Verify no error logs happen after those, and the timestamps correspond to the first two runs in the [cloudwatch logs for the seed function](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fdatabase-fix-fmap-seed-seed) you'll see two logs from the failure and one from the success. These have DEBUG logs turned on so they are quite noisy to sort through.


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---
