### PR TITLE
[CMDCT-3117] use sessions for cypress to avoid external logout

### DIFF
--- a/tests/cypress/cypress.config.js
+++ b/tests/cypress/cypress.config.js
@@ -19,6 +19,7 @@ module.exports = defineConfig({
   },
   e2e: {
     baseUrl: "http://localhost:3000/",
+    testIsolation: false,
     specPattern: "**/*.spec.js",
     supportFile: "support/index.js",
     excludeSpecPattern: "**/filterReports.spec.js",

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -11,8 +11,6 @@ before(() => {
 const emailForCognito = "input[name='email']";
 const passwordForCognito = "input[name='password']";
 const uncertifyButton = "[data-testid='uncertifyButton']";
-const logoutButton = "[data-testid='header-menu-option-log-out']";
-const headerDropdownMenu = "[data-testid='headerDropDownMenu']";
 
 const stateUser = {
   email: Cypress.env("STATE_USER_EMAIL"),
@@ -25,45 +23,59 @@ const adminUser = {
 };
 
 Cypress.Commands.add("authenticate", (userType, userCredentials) => {
-  cy.reload();
-  let credentials = {};
-  if (userType && userCredentials) {
-    console.warn(
-      "If userType and userCredentials are both provided, userType is ignored and provided userCredentials are used."
-    );
-  } else if (userCredentials) {
-    credentials = userCredentials;
-  } else if (userType) {
-    switch (userType) {
-      case "adminUser":
-        credentials = adminUser;
-        break;
-      case "stateUser":
-        credentials = stateUser;
-        break;
-      default:
-        throw new Error("Provided userType not recognized.");
+  cy.session([userType, userCredentials], () => {
+    cy.visit("/");
+    cy.wait(2000);
+    let credentials = {};
+
+    if (userType && userCredentials) {
+      console.warn(
+        "If userType and userCredentials are both provided, userType is ignored and provided userCredentials are used."
+      );
+    } else if (userCredentials) {
+      credentials = userCredentials;
+    } else if (userType) {
+      switch (userType) {
+        case "adminUser":
+          credentials = adminUser;
+          break;
+        case "stateUser":
+          credentials = stateUser;
+          break;
+        default:
+          throw new Error("Provided userType not recognized.");
+      }
+    } else {
+      throw new Error("Must specify either userType or userCredentials.");
     }
-  } else {
-    throw new Error("Must specify either userType or userCredentials.");
-  }
-  cy.get(emailForCognito).type(credentials.email);
-  cy.get(passwordForCognito).type(credentials.password);
-  cy.get('[data-cy="login-with-cognito-button"]').click();
+    cy.get(emailForCognito).type(credentials.email);
+    cy.get(passwordForCognito).type(credentials.password, { log: false });
+    cy.get('[data-cy="login-with-cognito-button"]').click();
+
+    /**
+     * Waits for cognito session tokens to be set in local storage before saving session
+     * This ensures reused sessions maintain these tokens
+     * We expect at least three for the id, access, and refresh tokens
+     */
+    cy.wait(4500);
+  });
+  cy.navigateToHomePage();
 });
 
-Cypress.Commands.add("logout", () => {
+Cypress.Commands.add("clearSession", () => {
+  cy.session([], () => {});
+});
+
+Cypress.Commands.add("navigateToHomePage", () => {
+  if (cy.location("pathname") !== "/") cy.visit("/");
   cy.wait(3000);
-  cy.get(headerDropdownMenu).click();
-  cy.get(logoutButton).click();
-  cy.wait(3000); // let logout settle
-  cy.visit("/", { failOnStatusCode: false });
 });
 
 Cypress.Commands.add("ensureAvailableReport", () => {
   // login as admin
   cy.visit("/");
   cy.authenticate("adminUser");
+  cy.navigateToHomePage();
 
   /*
    * check if there is a certified program, if so, uncertify
@@ -83,8 +95,6 @@ Cypress.Commands.add("ensureAvailableReport", () => {
     }
     return;
   });
-
-  cy.logout();
 });
 
 // Define at the top of the spec file or just import it

--- a/tests/cypress/tests/integration/filterReports.spec.js
+++ b/tests/cypress/tests/integration/filterReports.spec.js
@@ -1,4 +1,8 @@
 describe("Check Report Filtering as a CMS Admin", () => {
+  before(() => {
+    Cypress.session.clearAllSessionData;
+  });
+
   beforeEach(() => {
     cy.visit("/");
     cy.authenticate("adminUser");

--- a/tests/cypress/tests/integration/login.spec.js
+++ b/tests/cypress/tests/integration/login.spec.js
@@ -4,6 +4,10 @@ const logoutButton = "[data-testid='header-menu-option-log-out']";
 const headerDropdownMenu = "[data-testid='headerDropDownMenu']";
 
 describe("CARTS Login Integration Tests", () => {
+  before(() => {
+    Cypress.session.clearAllSessionData;
+  });
+
   beforeEach(() => {
     cy.visit("/");
   });
@@ -21,6 +25,7 @@ describe("CARTS Login Integration Tests", () => {
   });
 
   it("Should display Login screen after logging out", () => {
+    cy.clearSession();
     cy.location("pathname").should("match", /\//);
     cy.get(cognitoLoginButton).should("be.visible");
   });

--- a/tests/cypress/tests/integration/section1Fill.spec.js
+++ b/tests/cypress/tests/integration/section1Fill.spec.js
@@ -3,6 +3,10 @@ const actionButton = "[data-testid='report-action-button']";
 const navigationLink = "[aria-label='Vertical Navigation Element'] a";
 
 describe("CARTS Report Fill Tests", () => {
+  before(() => {
+    Cypress.session.clearAllSessionData;
+  });
+
   it("Should fill out some answers in Section 1", () => {
     cy.ensureAvailableReport(); // Needs to happen each iteration of the test
 

--- a/tests/cypress/tests/integration/submitAndUncertify.spec.js
+++ b/tests/cypress/tests/integration/submitAndUncertify.spec.js
@@ -3,6 +3,10 @@ const actionButton = "[data-testid='report-action-button']";
 const certifySubmitButton = "[data-testid='certifySubmit']";
 const uncertifyButton = "[data-testid='uncertifyButton']";
 describe("CARTS Submit and Uncertify Integration Tests", () => {
+  before(() => {
+    Cypress.session.clearAllSessionData;
+  });
+
   it("Should submit form as a State User and uncertify as an Admin", () => {
     cy.ensureAvailableReport(); // Needs to happen each iteration of the test
 
@@ -19,8 +23,6 @@ describe("CARTS Submit and Uncertify Integration Tests", () => {
     cy.get("button").contains("Confirm Certify and Submit").click();
     cy.get("button").contains("Return Home").click();
 
-    cy.logout();
-
     // log in as CMS Admin (user who can uncertify)
     cy.authenticate("adminUser");
 
@@ -34,8 +36,6 @@ describe("CARTS Submit and Uncertify Integration Tests", () => {
 
     cy.get(uncertifyButton).first().contains("Uncertify").click();
     cy.get("button").contains("Yes, Uncertify").click();
-
-    cy.logout();
 
     // log back in as State User - the report should be "In Progress" again
     cy.authenticate("stateUser");


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Sets up sessions for cypress authentication the same way MCR handles it. This lets the tests generally avoid testing an external web page (the redirect to IDM post-logout).

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3117

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Run Tests locally
- Make sure they pass on this branch
- Validate after merge the dev branch no longer has errors

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
