### PR TITLE
Fix infrastructure destroy action

### DIFF
--- a/.github/setBranchName.sh
+++ b/.github/setBranchName.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+GITHUB_REFNAME="${1}"
+
+[ -z "${GITHUB_REFNAME}" ] && echo "Error setting branch name.  No input given." && exit 1
+
+case ${GITHUB_REFNAME} in
+  $([[ "$GITHUB_REFNAME" =~ ^dependabot/.* ]] && echo ${GITHUB_REFNAME}))
+    echo ${GITHUB_REFNAME} | md5sum | head -c 10 | sed 's/^/x/'
+    ;;
+  $([[ "$GITHUB_REFNAME" =~ ^snyk-* ]] && echo ${GITHUB_REFNAME}))
+    echo ${GITHUB_REFNAME} | head -c 10 | sed 's/^/s/'
+    ;;
+  *)
+    echo ${GITHUB_REFNAME}
+    ;;
+esac

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,12 +23,11 @@ jobs:
     env:
       SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: set branch_name # Some integrations (Dependabot & Snyk) build very long branch names. This is a switch to make long branch names shorter.
         run: |
           BRANCH_NAME=$(./.github/setBranchName.sh ${{ github.ref_name }})
           echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
-      - uses: actions/checkout@v3
       - name: Validate branch name
         run: ./.github/branchNameValidation.sh $STAGE_PREFIX$branch_name
       - name: set branch specific variable names
@@ -103,7 +102,7 @@ jobs:
     if: ${{ github.ref_name != 'production' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v5
         with:
@@ -133,7 +132,7 @@ jobs:
     if: ${{ github.ref_name != 'production' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check Project A11y
         uses: cypress-io/github-action@v5
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   # Ensuring group key matches the destroy workflow currently in master
-  group: dev-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: false
 
 permissions:
@@ -23,16 +23,11 @@ jobs:
     env:
       SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
     steps:
+      - uses: actions/checkout@v3
       - name: set branch_name # Some integrations (Dependabot & Snyk) build very long branch names. This is a switch to make long branch names shorter.
         run: |
-          echo "GITHUB_REF=${GITHUB_REF}"        
-          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then
-            echo "branch_name=`echo ${GITHUB_REF##*/*-} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
-          elif [[ "$GITHUB_REF" =~ ^refs/.*/snyk-* ]]; then
-            echo "branch_name=`echo ${GITHUB_REF##*/*-} | head -c 10 | sed 's/^/s/'`" >> $GITHUB_ENV
-          else
-            echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-          fi
+          BRANCH_NAME=$(./.github/setBranchName.sh ${{ github.ref_name }})
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: Validate branch name
         run: ./.github/branchNameValidation.sh $STAGE_PREFIX$branch_name
@@ -105,7 +100,7 @@ jobs:
   e2e-test:
     name: E2E Integration Tests (Cypress)
     needs: deploy
-    if: ${{ github.ref != 'refs/heads/production' }}
+    if: ${{ github.ref_name != 'production' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -135,7 +130,7 @@ jobs:
   a11y-tests:
     name: A11y Tests
     needs: deploy
-    if: ${{ github.ref != 'refs/heads/production' }}
+    if: ${{ github.ref_name != 'production' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -38,7 +38,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: set branch_name
         run: |
           BRANCH_NAME=$(./.github/setBranchName.sh ${{ inputs.environment || github.event.ref }})

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -25,7 +25,6 @@ jobs:
     # This conditional is a backup mechanism to help prevent mistakes from becoming disasters.
     # This is a list of branch names that are commonly used for protected branches/environments.
     # Add/remove names from this list as appropriate.
-    # Names include current v3 branches (main/val/production) and v2 branches in an effort to protect any preserved resources like saved databases
     if: |
       (
         github.event.ref_type == 'branch' &&

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -1,10 +1,16 @@
 name: Destroy
 
-on: delete
+on: 
+  delete:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Name of the environment to destroy:"
+        required: true
 
 concurrency:
   # Ensuring group key matches the destroy workflow currently in master
-  group: dev-${{ github.event.ref }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: false
 
 permissions:
@@ -20,17 +26,23 @@ jobs:
     # This is a list of branch names that are commonly used for protected branches/environments.
     # Add/remove names from this list as appropriate.
     # Names include current v3 branches (main/val/production) and v2 branches in an effort to protect any preserved resources like saved databases
-    if: github.event.ref_type == 'branch' && !contains(fromJson('["master", "main", "staging", "val", "production", "prod"]'), github.event.ref)
+    if: |
+      (
+        github.event.ref_type == 'branch' &&
+        (!startsWith(github.event.ref, 'skipci')) &&
+        (!contains(fromJson('["main", "val", "production"]'), github.event.ref))
+      ) ||
+      (
+        inputs.environment != '' &&
+        (!contains(fromJson('["main", "val", "production"]'), inputs.environment))
+      )
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: set branch_name
         run: |
-          if [[ "${{ github.event.ref }}" =~ ^dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
-            echo "branch_name=`echo ${{ github.event.ref }} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
-          else
-            echo "branch_name=${{ github.event.ref }}" >> $GITHUB_ENV
-          fi
-      - uses: actions/checkout@v3
+          BRANCH_NAME=$(./.github/setBranchName.sh ${{ inputs.environment || github.event.ref }})
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
       - name: set branch specific variable names
         run: ./.github/build_vars.sh set_names
       - name: set variable values

--- a/destroy.sh
+++ b/destroy.sh
@@ -34,6 +34,16 @@ set -e
 # Find cloudformation stacks associated with stage
 stackList=($(aws cloudformation describe-stacks | jq -r ".Stacks[] | select(.Tags[] | select(.Key==\"STAGE\") | select(.Value==\"$stage\")) | .StackName"))
 
+if [ ${#stackList[@]} -eq 0 ]; then
+    echo """
+      ---------------------------------------------------------------------------------------------
+      ERROR: No stacks were identified for destruction
+      ---------------------------------------------------------------------------------------------
+      Please verify the stage name:  $stage
+    """
+    exit 1
+fi
+
 # Find buckets attached to any of the stages, so we can empty them before removal.
 bucketList=()
 set +e


### PR DESCRIPTION
### Description

The purpose of this pull request is to correct destroy actions for Snyk or Dependabot created branches by providing a consistent means to generate shortened stage names from autogenerated branches that may exceed Cloudformation length requirements when prefixed to services managed by Cloudformation stacks.  Additionally, this pull request adds the ability to trigger destroy actions manually against any non-protected target using any Github hosted branch.

- `GITHUB_REF` environment variable is the same as `github.ref` and includes the fully qualified path
- Destroy actions always trigger on the default branch so `GITHUB_REF`/`github.ref` would be `/refs/heads/master`
- Destroy actions know what the target is based on `github.event.ref` which is NOT the fully qualified path
- Defining `workflow_dispatch` enables manual triggering destroy actions against a given code base and enables specifying target.

The changes in this pull request do the following:
- Apply consistent lookups in Deploy (concurrency lock would be deploy-[branch] rather than deploy-/refs/heads/[branch])
- Remove hard coded addition to destroy action which would break if a tag is deleted
- Enable manual dispatching of events.

For other repositories which may differ in structure, it is suggested that the `workflow_dispatch` be added as an initial pull request, as this has to make it to the default stage before it can be acted upon.  This will enable development against destroy actions which can only trigger from the default branch until the configuration change is merged.

<!-- Detailed description of changes and related context -->


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3256

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Once this has been merged...

Create three branches

dependabot/npm_and_yarn/berry-did-this
snyk-upgrade-berry-did-this9faf06c882b46cc4a8e83
berry-test
Push and wait for builds to succeed.

Delete the remote branches and verify the destroy step completes.

Create one more branch, any arbitrary name, and add echo this is a test && exit 1 to the destroy yaml file at line 37. Exercise the manual trigger and verify the update in the unmerged branch is executed in the destroy step

### Important updates

No functional changes should be experienced during normal development activities.  The changes do include some minor refactoring of how references are leveraged, but the functional changes should apply to Snyk and Dependabot created branches with the addition of Github actions manual triggering from the destroy workflow.

As of the time of writing of this pull request, the following are the remote branches for this product, and the highlighted ones are the ones this pull requests asserts to be protected:
  origin/bigmac-sdk-v3
  origin/deployed-login
  origin/docraptor-poc-3249
  origin/entjira
  origin/fix-snykdependa-destroy
  origin/iam
  **origin/main** <
  origin/master
  **origin/production** <
  origin/snyk-fix-99615638953ff7b1ad7a664beb9a511f
  origin/snyk-upgrade-3e2e25b088f8510923cf3077dfec294f
  origin/snyk-upgrade-448443e6ea2d600363dda07c986b9de0
  origin/snyk-upgrade-783178dddacd564062a91dc354304dc0
  origin/tealium-3288
  **origin/val** <

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
