### PR TITLE
CMDCT-3288.III: Tealium Fix

### DIFF
--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -37,6 +37,7 @@
     "jsonpath-plus": "^5.1.0",
     "jsonschema": "^1.4.1",
     "jwt-decode": "^3.1.2",
+    "serverless-plugin-warmup": "8.2.1",
     "uuid": "^7.0.3"
   },
   "jest": {

--- a/services/app-api/yarn.lock
+++ b/services/app-api/yarn.lock
@@ -3746,6 +3746,11 @@ serverless-plugin-typescript@^2.1.0:
     globby "^10.0.2"
     lodash "^4.17.21"
 
+serverless-plugin-warmup@8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/serverless-plugin-warmup/-/serverless-plugin-warmup-8.2.1.tgz#b776a886d4390a9e7c907f0db1c4639fed913350"
+  integrity sha512-bVPqK2tt3m6AVjVnjuiU/nsGtm+hukaQmVn7zx2KbKSTCwOZEkMcsqKhkKw3Y4cm/vA2Wxd+3d1lftaGKFkG/Q==
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"

--- a/services/carts-bigmac-streams/package.json
+++ b/services/carts-bigmac-streams/package.json
@@ -12,6 +12,6 @@
     "serverless-dotenv-plugin": "^3.0.0",
     "serverless-online": "Enterprise-CMCS/macpro-serverless-online",
     "serverless-plugin-scripts": "^1.0.2",
-    "serverless-plugin-warmup": "^4.9.0"
+    "serverless-plugin-warmup": "8.2.1"
   }
 }

--- a/services/carts-bigmac-streams/yarn.lock
+++ b/services/carts-bigmac-streams/yarn.lock
@@ -5923,12 +5923,10 @@ serverless-plugin-scripts@^1.0.2:
   resolved "https://registry.yarnpkg.com/serverless-plugin-scripts/-/serverless-plugin-scripts-1.0.2.tgz#21808c3cfd0a1a84e48c0660b0f6f370b5665486"
   integrity sha1-IYCMPP0KGoTkjAZgsPbzcLVmVIY=
 
-serverless-plugin-warmup@^4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/serverless-plugin-warmup/-/serverless-plugin-warmup-4.9.0.tgz#4617a10e2b95d166647abab557b55aea9e5ae0ef"
-  integrity sha512-o6u0Wovyjm1tJNsa38oHOKEjmjBdhie8sCIlCCUAtHZza7L7y9WgtHTFqK6QGTl7O6sbw98vB8z4pNsSQGH6YA==
-  dependencies:
-    fs-extra "^9.0.0"
+serverless-plugin-warmup@8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/serverless-plugin-warmup/-/serverless-plugin-warmup-8.2.1.tgz#b776a886d4390a9e7c907f0db1c4639fed913350"
+  integrity sha512-bVPqK2tt3m6AVjVnjuiU/nsGtm+hukaQmVn7zx2KbKSTCwOZEkMcsqKhkKw3Y4cm/vA2Wxd+3d1lftaGKFkG/Q==
 
 serverless-webpack@^5.6.1:
   version "5.11.0"

--- a/services/ui-src/public/index.html
+++ b/services/ui-src/public/index.html
@@ -53,13 +53,8 @@
     <!-- Tealium Analytics Tag Manager -->
     <script>
       var tealiumEnvMap = {
-<<<<<<< HEAD
         "mdctcarts.cms.gov": "production",
         "mdctcartsval.cms.gov": "qa",
-=======
-        val: "qa",
-        production: "production",
->>>>>>> origin
       };
       var tealiumEnv = tealiumEnvMap[window.location.hostname] || "dev";
       var tealiumUrl = `https://tags.tiqcdn.com/utag/cmsgov/cms-general/${tealiumEnv}/utag.sync.js`;

--- a/services/ui-src/public/index.html
+++ b/services/ui-src/public/index.html
@@ -52,12 +52,11 @@
     </script>
     <!-- Tealium Analytics Tag Manager -->
     <script>
-      var nodeEnv = window.env.STAGE;
       var tealiumEnvMap = {
-        val: "qa",
-        production: "production",
+        "mdctcarts.cms.gov": "production",
+        "mdctcartsval.cms.gov": "qa",
       };
-      var tealiumEnv = tealiumEnvMap[nodeEnv] || "dev";
+      var tealiumEnv = tealiumEnvMap[window.location.hostname] || "dev";
       var tealiumUrl = `https://tags.tiqcdn.com/utag/cmsgov/cms-general/${tealiumEnv}/utag.sync.js`;
       document.write(`<script src="${tealiumUrl}" async><\/script>`);
     </script>

--- a/services/ui-src/public/index.html
+++ b/services/ui-src/public/index.html
@@ -55,7 +55,7 @@
       var nodeEnv = window.env.STAGE;
       var tealiumEnvMap = {
         val: "qa",
-        production: "prod",
+        production: "production",
       };
       var tealiumEnv = tealiumEnvMap[nodeEnv] || "dev";
       var tealiumUrl = `https://tags.tiqcdn.com/utag/cmsgov/cms-general/${tealiumEnv}/utag.sync.js`;

--- a/services/ui-src/src/util/tealium.js
+++ b/services/ui-src/src/util/tealium.js
@@ -2,6 +2,11 @@ export const fireTealiumPageView = (user, url, pathname) => {
   const isReportPage = pathname.includes("sections");
   const contentType = isReportPage ? "form" : "app";
   const sectionName = isReportPage ? pathname.split("/")[1] : "main app";
+  const tealiumEnvMap = {
+    "mdctcarts.cms.gov": "production",
+    "mdctcartsval.cms.gov": "qa",
+  };
+  const tealiumEnv = tealiumEnvMap[window.location.hostname] || "dev";
   const { host: siteDomain } = url ? new URL(url) : null;
   if (window.utag) {
     window.utag.view({
@@ -10,7 +15,7 @@ export const fireTealiumPageView = (user, url, pathname) => {
       page_name: sectionName + ":" + pathname,
       page_path: pathname,
       site_domain: siteDomain,
-      site_environment: process.env.NODE_ENV,
+      site_environment: tealiumEnv,
       site_section: sectionName,
       logged_in: !!user,
     });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Note that in addition to correcting the env name we send to Tealium, this PR updates the serverless warmup plugin to a fixed version. This stops the package from trying to use node12, but can't go higher until we upgrade CARTS to node18+.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3288

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
N/A

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
