### PR TITLE
Text fix script – Dental Code Typo

### DIFF
--- a/services/database/README.md
+++ b/services/database/README.md
@@ -1,1 +1,19 @@
 # database
+
+## scripts
+
+The [scripts/](./scripts/) folder is for small text and data fixes. Write and test new scripts locally and with ephemeral branches. After merging, run new scripts against the AWS main, val, and production instances (preferably with a second developer for checks along the way).
+
+Any utilities shareable across scripts can be added to the [scripts/utils/](./scripts/utils/) folder. Please use AWS SDK V3, or application latest.
+
+### Running against a local instance:
+
+- In one terminal tab start CARTS locally
+- In a new terminal tab, from CARTS root, run:
+  `DYNAMODB_URL="http://localhost:8000" dynamoPrefix="local" node services/database/scripts/{script_name}.js`
+
+### Running against a deployed instance:
+
+- Get AWS credentials from the CARTS AWS account in your terminal (carts-dev for all ephemeral branches and main)
+- From CARTS root, run:
+  `dynamoPrefix="{YOUR BRANCH NAME}" node services/database/scripts/{script_name}.js`

--- a/services/database/data/seed-local/seed-section.json
+++ b/services/database/data/seed-local/seed-section.json
@@ -8182,7 +8182,7 @@
                     "questions": [],
                     "label": "Dental care service codes and definitions",
                     "type": "fieldset",
-                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D0100–D9999 (or equivalent CDT codes D0100–D9999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416)."
+                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416)."
                   },
                   {
                     "questions": [
@@ -8301,7 +8301,7 @@
                     "questions": [],
                     "label": "Dental care service codes and definitions",
                     "type": "fieldset",
-                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D0100 - D9999 (or equivalent CDT codes D0100 - D9999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416)."
+                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416)."
                   },
                   {
                     "questions": [
@@ -20069,7 +20069,7 @@
                     "fieldset_type": "marked"
                   },
                   {
-                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D0100–D9999 (or equivalent CDT codes D0100–D9999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
+                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
                     "type": "fieldset",
                     "label": "Dental care service codes and definitions",
                     "questions": []
@@ -20188,7 +20188,7 @@
                     "fieldset_type": "marked"
                   },
                   {
-                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D0100 - D9999 (or equivalent CDT codes D0100 - D9999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
+                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
                     "type": "fieldset",
                     "questions": []
                   },
@@ -33736,7 +33736,7 @@
                     "fieldset_type": "marked"
                   },
                   {
-                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D0100–D9999 (or equivalent CDT codes D0100–D9999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
+                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
                     "type": "fieldset",
                     "label": "Dental care service codes and definitions",
                     "questions": []
@@ -33855,7 +33855,7 @@
                     "fieldset_type": "marked"
                   },
                   {
-                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D0100 - D9999 (or equivalent CDT codes D0100 - D9999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
+                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
                     "type": "fieldset",
                     "questions": []
                   },

--- a/services/database/data/seed/seed-section-base-2022.json
+++ b/services/database/data/seed/seed-section-base-2022.json
@@ -8032,7 +8032,7 @@
                     "fieldset_type": "marked"
                   },
                   {
-                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D0100–D9999 (or equivalent CDT codes D0100–D9999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
+                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
                     "type": "fieldset",
                     "label": "Dental care service codes and definitions",
                     "questions": []
@@ -8151,7 +8151,7 @@
                     "fieldset_type": "marked"
                   },
                   {
-                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D0100 - D9999 (or equivalent CDT codes D0100 - D9999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
+                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
                     "type": "fieldset",
                     "label": "Dental care service codes and definitions",
                     "questions": []

--- a/services/database/data/seed/seed-section-base-2023.json
+++ b/services/database/data/seed/seed-section-base-2023.json
@@ -7838,7 +7838,7 @@
                     "fieldset_type": "marked"
                   },
                   {
-                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D0100–D9999 (or equivalent CDT codes D0100–D9999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
+                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
                     "type": "fieldset",
                     "label": "Dental care service codes and definitions",
                     "questions": []
@@ -7957,7 +7957,7 @@
                     "fieldset_type": "marked"
                   },
                   {
-                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D0100 - D9999 (or equivalent CDT codes D0100 - D9999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
+                    "hint": "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).",
                     "type": "fieldset",
                     "label": "Preventive dental care service codes and definitions",
                     "questions": []

--- a/services/database/scripts/dental-code-text-fix.js
+++ b/services/database/scripts/dental-code-text-fix.js
@@ -1,0 +1,61 @@
+/* eslint-disable no-console */
+const { buildDynamoClient, scan, update } = require("./utils/dynamodb.js");
+
+const isLocal = !!process.env.DYNAMODB_URL;
+const sectionTableName = isLocal
+  ? "local-section"
+  : process.env.dynamoPrefix + "-section";
+
+async function handler() {
+  try {
+    console.log("Start of data fix");
+
+    buildDynamoClient();
+
+    const scanParams = {
+      TableName: sectionTableName,
+      ExpressionAttributeNames: {
+        "#year": "year",
+        "#sectionId": "sectionId",
+      },
+      ExpressionAttributeValues: {
+        ":year": 2023,
+        ":sectionId": 3,
+      },
+      FilterExpression: "#year = :year AND #sectionId = :sectionId",
+    };
+
+    const existingItems = await scan(scanParams);
+    const transformedItems = await transform(existingItems);
+    await update(sectionTableName, transformedItems);
+
+    console.debug("Data fix complete");
+
+    return {
+      statusCode: 200,
+      body: "All done!",
+    };
+  } catch (err) {
+    console.error(err);
+    return {
+      statusCode: 500,
+      body: err.message,
+    };
+  }
+}
+
+async function transform(items) {
+  const transformed = items.map((item) => {
+    const corrected = { ...item };
+
+    // section 3, subsection g, questions 3 and 4 hints (array index 6 is question 4 because index 5 is conditional display)
+    corrected.contents.section.subsections[6].parts[0].questions[4].hint = "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416)."
+    corrected.contents.section.subsections[6].parts[0].questions[6].hint = "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416)."
+
+    return corrected;
+  });
+
+  return transformed;
+}
+
+handler();

--- a/services/database/scripts/dental-code-text-fix.js
+++ b/services/database/scripts/dental-code-text-fix.js
@@ -49,8 +49,10 @@ async function transform(items) {
     const corrected = { ...item };
 
     // section 3, subsection g, questions 3 and 4 hints (array index 6 is question 4 because index 5 is conditional display)
-    corrected.contents.section.subsections[6].parts[0].questions[4].hint = "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416)."
-    corrected.contents.section.subsections[6].parts[0].questions[6].hint = "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416)."
+    corrected.contents.section.subsections[6].parts[0].questions[4].hint =
+      "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim.\n\nAll data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).";
+    corrected.contents.section.subsections[6].parts[0].questions[6].hint =
+      "The dental service must be provided by or under the supervision of a dentist as defined by HCPCS codes D1000–D1999 (or equivalent CDT codes D1000–D1999, or equivalent CPT codes) based on an unduplicated paid, unpaid, or denied claim. \n All data should be based on the definitions in the Early and Periodic Screening, Diagnostic, and Treatment (EPSDT) Report (Form CMS-416).";
 
     return corrected;
   });

--- a/services/database/scripts/utils/dynamodb.js
+++ b/services/database/scripts/utils/dynamodb.js
@@ -1,0 +1,69 @@
+/* eslint-disable no-console */
+const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
+const {
+  DynamoDBDocumentClient,
+  PutCommand,
+  ScanCommand
+} = require("@aws-sdk/lib-dynamodb");
+
+let dynamoClient;
+let dynamoPrefix;
+
+const buildDynamoClient = () => {
+  const dynamoConfig = {
+    logger: {
+      debug: console.debug,
+      info: console.info,
+      warn: console.warn,
+      error: console.error,
+    },
+  };
+  const endpoint = process.env.DYNAMODB_URL;
+  if (endpoint) {
+    dynamoConfig.endpoint = endpoint;
+    dynamoConfig.accessKeyId = "LOCALFAKEKEY"; // pragma: allowlist secret
+    dynamoConfig.secretAccessKey = "LOCALFAKESECRET"; // pragma: allowlist secret
+    dynamoPrefix = "local";
+  } else {
+    dynamoConfig["region"] = "us-east-1";
+    dynamoPrefix = process.env.dynamoPrefix;
+  }
+
+  const bareBonesClient = new DynamoDBClient(dynamoConfig);
+  dynamoClient = DynamoDBDocumentClient.from(bareBonesClient);
+};
+
+const scan = async (scanParams) => {
+  let ExclusiveStartKey;
+  let items = [];
+
+  do {
+    const command = new ScanCommand({ ...scanParams, ExclusiveStartKey });
+    const result = await dynamoClient.send(command);
+    items = items.concat(result.Items ?? []);
+    ExclusiveStartKey = result.LastEvaluatedKey;
+  } while (ExclusiveStartKey);
+
+  return items;
+}
+
+const update = async (tableName, items) => {
+  try {
+    for (const item of items) {
+
+      const params = {
+        TableName: tableName,
+        Item: {
+          ...item
+        },
+      };
+
+      const command = new PutCommand(params);
+      await dynamoClient.send(command);
+    }
+  } catch (e) {
+    console.log(` -- ERROR UPLOADING ${tableName}\n`, e);
+  }
+};
+
+module.exports = { buildDynamoClient, scan, update }

--- a/services/database/scripts/utils/dynamodb.js
+++ b/services/database/scripts/utils/dynamodb.js
@@ -3,11 +3,10 @@ const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
 const {
   DynamoDBDocumentClient,
   PutCommand,
-  ScanCommand
+  ScanCommand,
 } = require("@aws-sdk/lib-dynamodb");
 
 let dynamoClient;
-let dynamoPrefix;
 
 const buildDynamoClient = () => {
   const dynamoConfig = {
@@ -23,10 +22,8 @@ const buildDynamoClient = () => {
     dynamoConfig.endpoint = endpoint;
     dynamoConfig.accessKeyId = "LOCALFAKEKEY"; // pragma: allowlist secret
     dynamoConfig.secretAccessKey = "LOCALFAKESECRET"; // pragma: allowlist secret
-    dynamoPrefix = "local";
   } else {
     dynamoConfig["region"] = "us-east-1";
-    dynamoPrefix = process.env.dynamoPrefix;
   }
 
   const bareBonesClient = new DynamoDBClient(dynamoConfig);
@@ -45,16 +42,15 @@ const scan = async (scanParams) => {
   } while (ExclusiveStartKey);
 
   return items;
-}
+};
 
 const update = async (tableName, items) => {
   try {
     for (const item of items) {
-
       const params = {
         TableName: tableName,
         Item: {
-          ...item
+          ...item,
         },
       };
 
@@ -66,4 +62,4 @@ const update = async (tableName, items) => {
   }
 };
 
-module.exports = { buildDynamoClient, scan, update }
+module.exports = { buildDynamoClient, scan, update };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
HELLO! 

This script fixes a typo in the Dental Codes
| | |
|-----|-----|
| OLD | `D0100-D9999` |
| NEW | `D1000-D1999` |

- Updated all instances in the seed JSON files (and unified `  -  ` (space hyphen space) and `–` (endash) to use endash for all of them
- Added script utils file for dynamodb to make future script fixes like this easier (and in aws-sdk-v3)
- Added script for this specific text fix, updates two question hints with new text (only change is the codes)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3203

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Create a branch off CARTS main and add _only the script files_ (the seed files are correct, so local seeds will reflect the correct text if you start from this branch)
- In one terminal tab start CARTS locally
- In a new terminal tab, from CARTS root, run:
  `DYNAMODB_URL="http://localhost:8000" dynamoPrefix="local" node services/database/scripts/dental-code-text-fix.js`


Alternatively
- Create your own test branch or choose an existing one based on CARTS main
- Go to the deployed instance of that branch
  - Generate 2023 forms as an admin
  - Go to Section 3G in any 2023 report
  - Verify the third and fourth questions (3a and 4a if you answer 'No' to question 1) have D0100-D9999 in the hint text
- Get AWS credentials from carts-dev in your terminal
- From local you can run `dynamoPrefix="YOUR BRANCH NAME" node services/database/scripts/dental-code-text-fix.js`
- This will modify section 3 of that branch
- Refresh your browser and verify the associated question hints now mention D1000-D1999.
- Delete your test branch to release those resources

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---


### Looking for feedback
1. Do we want to add tests for the utils file? I think that would make sense if it's a more permanent fixture in our workflow. The tests would be very similar to the dynamodb-lib tests in app-api, which makes me wonder if there is a way to save on code duplication (monorepo and whatnot)
2. Do we want to delete the existing scripts that use AWS SDK V2 so that it's easier for future devs to pick up on the new pattern (V3, utils file, etc.)? I also think documentation could help with that.