### PR TITLE
Allow PDF Creation -> DocRaptor

### DIFF
--- a/services/app-api/handlers/printing/printPdf.ts
+++ b/services/app-api/handlers/printing/printPdf.ts
@@ -1,11 +1,6 @@
 import handler from "../../libs/handler-lib";
 import * as logger from "../../libs/debug-lib";
-import createDOMPurify from "dompurify";
-import { JSDOM } from "jsdom";
 import { fetch } from "cross-fetch"; // TODO delete this line and uninstall this package, once CARTS is running on Nodejs 18+
-
-const windowEmulator: any = new JSDOM("").window;
-const DOMPurify = createDOMPurify(windowEmulator);
 
 /**
  * Generates 508 compliant PDF using an external Prince-based service for a given HTML block.
@@ -18,14 +13,6 @@ export const print = handler(async (event, _context) => {
   }
   const rawHtml = Buffer.from(encodedHtml, "base64").toString("utf-8");
 
-  let sanitizedHtml;
-  if (DOMPurify.isSupported) {
-    sanitizedHtml = DOMPurify.sanitize(rawHtml);
-  }
-  if (!sanitizedHtml) {
-    throw new Error("Could not process request");
-  }
-
   const { docraptorApiKey, stage } = process.env;
   if (!docraptorApiKey) {
     throw new Error("No config found to make request to PDF API");
@@ -34,7 +21,7 @@ export const print = handler(async (event, _context) => {
   const requestBody = {
     user_credentials: docraptorApiKey,
     doc: {
-      document_content: sanitizedHtml,
+      document_content: rawHtml,
       type: "pdf" as const,
       // This tag differentiates QMR and CARTS requests in DocRaptor's logs.
       tag: "CARTS",

--- a/services/app-api/handlers/printing/tests/printPdf.test.ts
+++ b/services/app-api/handlers/printing/tests/printPdf.test.ts
@@ -23,10 +23,8 @@ jest.mock("cross-fetch", () => ({
   }),
 }));
 
-const dangerousHtml = "<p>abc<iframe//src=jAva&Tab;script:alert(3)>def</p>";
-const sanitizedHtml = "<p>abc</p>";
-const base64EncodedDangerousHtml =
-  Buffer.from(dangerousHtml).toString("base64");
+const html = "<p>abc</p>";
+const base64EncodedHtml = Buffer.from(html).toString("base64");
 
 describe("Test Print PDF handler", () => {
   beforeEach(() => {
@@ -37,7 +35,7 @@ describe("Test Print PDF handler", () => {
   it("should make a request to prince and return data", async () => {
     const event: APIGatewayProxyEvent = {
       ...testEvent,
-      body: `{"encodedHtml": "${base64EncodedDangerousHtml}"}`,
+      body: `{"encodedHtml": "${base64EncodedHtml}"}`,
     };
 
     const res = await print(event, null);
@@ -54,7 +52,7 @@ describe("Test Print PDF handler", () => {
     expect(body).toEqual({
       user_credentials: "mock api key", // pragma: allowlist secret
       doc: expect.objectContaining({
-        document_content: sanitizedHtml,
+        document_content: html,
         type: "pdf",
         tag: "CARTS",
         prince_options: expect.objectContaining({
@@ -84,7 +82,7 @@ describe("Test Print PDF handler", () => {
     delete process.env.docraptorApiKey;
     const event: APIGatewayProxyEvent = {
       ...testEvent,
-      body: `{"encodedHtml": "${base64EncodedDangerousHtml}"}`,
+      body: `{"encodedHtml": "${base64EncodedHtml}"}`,
     };
 
     const res = await print(event, null);
@@ -94,7 +92,7 @@ describe("Test Print PDF handler", () => {
   it("should handle errors from PDF API", async () => {
     const event: APIGatewayProxyEvent = {
       ...testEvent,
-      body: `{"encodedHtml": "${base64EncodedDangerousHtml}"}`,
+      body: `{"encodedHtml": "${base64EncodedHtml}"}`,
     };
 
     (fetch as jest.Mock).mockResolvedValueOnce({


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The library we are adding to clean up the html is removing more than it should and preventing pdf generation. Allowing creation without the addition of the library to get pdf creation live again while we continue to investigate. Ticket for investigation is created and in the sprint.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Pull down the branch and generate a pdf using the DocRaptor key, or create one in the ephem branch.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
