### PR TITLE
Enable automerge for bot generated dependency fixes

### DIFF
--- a/.github/workflows/snyk-auto-merge.yml
+++ b/.github/workflows/snyk-auto-merge.yml
@@ -23,7 +23,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Snyk PRs
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major'}}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### Description
'Require linear history' control on the integration branch prohibits 'gh merge --merge' and requires 'gh merge --squash' in lieu.  This PR is to configure both Snyk and Dependabot jobs to be able to issue auto-merge on auto generated PRs with successfully completely checks.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3405

---
### How to test
Hurry up and wait.  Observing PRs being automatically created and automatically merged is the only way to validate this change

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
