### PR TITLE
Enable VPN Restriction capability for CARTS

### DIFF
--- a/.github/build_vars.sh
+++ b/.github/build_vars.sh
@@ -13,12 +13,14 @@ set_value() {
   if [ ! -z "${!varname}" ]; then
     echo "Setting $varname"
     echo "${varname}=${!varname}" >> $GITHUB_ENV
+    echo "${varname}=${!varname}" >> $GITHUB_OUTPUT
   fi
 }
 
 set_name() {
   varname=${1}
   echo "BRANCH_SPECIFIC_VARNAME_$varname=${branch_name//-/_}_$varname" >> $GITHUB_ENV
+  echo "BRANCH_SPECIFIC_VARNAME_$varname=${branch_name//-/_}_$varname" >> $GITHUB_OUTPUT
 }
 
 action=${1}

--- a/.github/waf-controller.sh
+++ b/.github/waf-controller.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+CIRCUIT_BREAKER=10
+AWS_RETRY_ERROR=254
+AWS_THROTTLING_EXCEPTION=252
+#0, 1, 2 are the levels of debug, with 0 being off
+DEBUG=1
+
+set -o pipefail -o nounset -u
+
+case ${1-} in
+  append)
+    OP=append
+    ;;
+  set)
+    OP=set
+    ;;
+  *)
+    echo "Error:  unkown operation"
+    echo "Usage: ${0} [append|set] [ip_set name] [ip_set id] [list of CIDR blocks]" && exit 1
+    ;;
+esac
+
+shift
+NAME="${1-}"
+ID="${2-}"
+shift; shift
+RUNNER_CIDRS="${@-}"
+
+[[ $DEBUG -ge 1 ]] && echo "Inputs:  NAME \"${NAME}\", ID \"${ID}\", RUNNER_CIDRS \"${RUNNER_CIDRS}\""
+
+[[ -z "${NAME}" ]] || [[ -z "${ID}" ]] || [[ -z "${RUNNER_CIDRS}" ]] && echo "Error:  one or more inputs are missing" && exit 1
+
+#Exponential backoff with jitter
+jitter() {
+  #.5 seconds
+  SHORTEST=50
+  #10 seconds
+  LONGEST=1000
+  DIV=100
+  EXP=$(perl -e "use bigint; print $SHORTEST**$1")
+  MIN=$(($EXP>$LONGEST ? $LONGEST : $EXP))
+  RND=$(shuf -i$SHORTEST-$MIN -n1)
+  perl -e "print $RND/$DIV"
+}
+
+#Attempt to avoid resource contention from the start
+sleep $(jitter $(shuf -i1-10 -n1))
+
+for ((i=1; i <= $CIRCUIT_BREAKER; i++)); do
+  #This loop is ONLY for retrying if the retries exceeded exception is thrown
+  for ((j=1; j <= $CIRCUIT_BREAKER; j++)); do
+    #Read WAF configuration from AWS
+    WAF_CONFIG=$(aws wafv2 get-ip-set --scope CLOUDFRONT --id ${ID} --name ${NAME} 2>&1)
+    CMD_CD=$?
+    [[ $DEBUG -ge 1 ]] && echo "AWS CLI Read Response Code:  ${CMD_CD}"
+    [[ $DEBUG -ge 2 ]] && echo "AWS CLI Read Response:  ${WAF_CONFIG}"
+
+    #If the retries exceeded error code is returned, try again, otherwise exit the loop
+    [[ $CMD_CD -eq $AWS_RETRY_ERROR ]] || break
+
+    SLEEP_FOR=$(jitter ${j})
+    echo "CLI retries exceed.  Waiting for ${SLEEP_FOR} seconds to execute read again...(${j})"
+    sleep ${SLEEP_FOR}
+  done
+
+  #Unable to get the lock tocken and IP set so there isn't any point in attempting the write op
+  [[ $j -ge $CIRCUIT_BREAKER ]] && echo “Attempts to read WAF IPSet exceeded” && sleep $(jitter ${i}) && continue
+
+  #The loop was short circuited with an error code other than 0, so something is wrong
+  [[ $CMD_CD -eq 0 ]] || ( echo "An unexpected read error occurred:  ${CMD_CD}" && exit 2 )
+
+  echo "Read was successful."
+
+  if [ ${OP} == "append" ]; then
+    ##If this is used to whitelist individual ips or cidrs, using an additive approach is what is required
+    #Parse out IP set addresses to array
+    IP_ADDRESSES=($(jq -r '.IPSet.Addresses | .[]' <<< ${WAF_CONFIG}))
+
+    #If CIDR is already present in IP set, eject
+    grep -q $RUNNER_CIDRS <<< ${IP_ADDRESSES}
+    [[ $? -ne 0 ]] || ( echo "CIDR is present in IP Set." && exit 0 )
+
+    #Add runner CIDR to array
+    IP_ADDRESSES+=("$RUNNER_CIDRS")
+  else 
+    ##If this is used to hard set the IP set, just clobber it
+    IP_ADDRESSES=("$RUNNER_CIDRS")
+  fi
+
+  #Stringify IPs
+  STRINGIFIED=$(echo $(IFS=" " ; echo "${IP_ADDRESSES[*]}"))
+  [[ $DEBUG -ge 2 ]] && echo "Ip Addresses:  ${STRINGIFIED}"
+
+  #Parse out optimistic concurrency control token
+  OCC_TOKEN=$(jq -r '.LockToken' <<< ${WAF_CONFIG})
+  [[ $DEBUG -ge 2 ]] && echo "LockToken:  ${OCC_TOKEN}"
+
+  #This loop is ONLY for retrying if the retries exceeded exception is thrown
+  for ((k=1; k <= $CIRCUIT_BREAKER; k++)); do
+    #Write updated WAF configuration to AWS
+    OUTPUT=$(aws wafv2 update-ip-set --scope CLOUDFRONT --id ${ID} --name ${NAME} --lock-token ${OCC_TOKEN} --addresses ${STRINGIFIED} 2>&1)
+    CMD_CD=$?
+    [[ $DEBUG -ge 1 ]] && echo "AWS CLI Write Response Code:  ${CMD_CD}"
+    [[ $DEBUG -ge 2 ]] && echo "AWS CLI Write Response:  ${OUTPUT}"
+
+    #If the retries exceeded error code is returned, try again, otherwise exit the loop
+    [[ $CMD_CD -eq $AWS_RETRY_ERROR ]] || break
+    #If WAFOptimisticLockException error code is returned, exit the loop
+    [[ "$OUTPUT" =~ "WAFOptimisticLockException" ]] && break
+
+    SLEEP_FOR=$(jitter ${k})
+    echo "CLI retries exceed.  Waiting for ${SLEEP_FOR} seconds to execute write again...(${k})"
+    sleep ${SLEEP_FOR}
+  done
+
+  [[ $CMD_CD -ne 0 ]] || break
+  #Still not having success, so try again
+
+  echo "Exit Code:  ${CMD_CD}"
+
+  SLEEP_FOR=$(jitter ${i})
+  echo "Waiting for ${SLEEP_FOR} seconds to execute main loop again...(${i})"
+  sleep ${SLEEP_FOR}
+done
+
+[[ $DEBUG -ge 1 ]] && echo "Attempts to update ip set:  $i"
+
+[[ $i -gt $CIRCUIT_BREAKER ]] && echo “Attempts to update WAF IPSet exceeded, exiting.” && exit 2
+
+echo "Applied the IP Set successfully."
+
+#Things should not have made it this far without being able to successfully write the IP Set
+exit $CMD_CD

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,11 +95,104 @@ jobs:
           MSG_MINIMAL: actions url,commit,ref
     outputs:
       application_endpoint: ${{ steps.endpoint.outputs.application_endpoint}}
+      BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION: ${{ steps.set_names.outputs.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION }}
+      BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME: ${{ steps.set_names.outputs.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME }}
+
+  register-runner:
+    name: Register GitHub Runner
+    if: ${{ github.ref_name != 'main' && github.ref_name != 'val' && github.ref_name != 'production' }}
+    runs-on: ubuntu-latest
+    needs: deploy
+    env:
+      SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: set branch_name
+        run: |
+          BRANCH_NAME=$(./.github/setBranchName.sh ${{ github.ref_name }})
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
+
+      - name: set branch specific variable names
+        id: set_names
+        run: ./.github/build-vars.sh set_names
+
+      - name: set variable values
+        id: set_values
+        run: ./.github/build-vars.sh set_values
+        env:
+          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+          AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
+          STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
+        
+      - name: Configure AWS credentials for GitHub Actions
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+
+      - name: output account id
+        id: output_account_id
+        run: |
+          #!/bin/bash
+          AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          echo "Current Account ID: ${AWS_ACCOUNT_ID}"
+
+      - name: Get Github Actions CIDR Blocks
+        id: get-gha-cidrs
+        shell: bash
+        run: |
+          #! /bin/bash
+          GHA_RESP=$(curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/meta)
+          echo "Response for GHA runner CIDR blocks:  $GHA_RESP"
+          IPV4_CIDR_ARR=($(echo $GHA_RESP | jq -r '.actions | .[]' | grep -v ':'))
+          GHA_CIDRS_IPV4=$(echo $(IFS=" "; echo ${IPV4_CIDR_ARR[*]}))
+          echo "GHA_CIDRS_IPV4=$GHA_CIDRS_IPV4" >> $GITHUB_OUTPUT
+
+      - name: Generate IP Set Name
+        id: gen-ip-set-name
+        run: |
+          #!/bin/bash
+          STAGE_GH_IPSET_NAME=$STAGE_PREFIX$branch_name-gh-ipset
+          echo "Github IP Set name:  $STAGE_GH_IPSET_NAME"
+          echo "STAGE_GH_IPSET_NAME=$STAGE_GH_IPSET_NAME" >> $GITHUB_OUTPUT
+
+      - name: Fetch AWS IP Set Metadata
+        id: fetch-ip-set-info
+        run: |
+          #!/bin/bash
+          # Fetch AWS IP set ARNs using AWS CLI and store them in a variable
+          AWS_IP_SET_INFO=$(aws wafv2 list-ip-sets --scope=CLOUDFRONT)
+          echo "Outputting AWS IP Set Info:  ${AWS_IP_SET_INFO}"
+          # Store the IP set ARNs in an output variable using GITHUB_OUTPUT
+          IPSET_NAME=${{ steps.gen-ip-set-name.outputs.STAGE_GH_IPSET_NAME }}
+          IPSET=$(jq '.IPSets | map(select(.Name == "'${IPSET_NAME}'")) | .[]' <<< ${AWS_IP_SET_INFO})
+          [ -z "$IPSET" ] && echo "IP Set with name ${IPSET_NAME} was not located.  Exiting..." && exit 1
+          echo "IP Set metadata:  ${IPSET}"
+          #Get Values from the IP SET
+          IPSET_ID=$(jq -r '.Id' <<< ${IPSET})
+          echo "IPSET_ARN=$IPSET_ARN" >> $GITHUB_OUTPUT
+          echo "IPSET_NAME=$IPSET_NAME" >> $GITHUB_OUTPUT
+          echo "IPSET_ID=$IPSET_ID" >> $GITHUB_OUTPUT
+
+      - name: Update IP Set
+        id: update-ip-set
+        run: ./.github/waf-controller.sh set ${{ steps.fetch-ip-set-info.outputs.IPSET_NAME }} ${{ steps.fetch-ip-set-info.outputs.IPSET_ID }} ${{ steps.get-gha-cidrs.outputs.GHA_CIDRS_IPV4 }}
+        env:
+          AWS_RETRY_MODE: adaptive
+          AWS_MAX_ATTEMPTS: 10
+
+    outputs:
+      ipset_name: ${{ steps.fetch-ip-set-info.outputs.IPSET_NAME }}
+      ipset_id: ${{ steps.fetch-ip-set-info.outputs.IPSET_ID }}
 
   e2e-test:
     name: E2E Integration Tests (Cypress)
-    needs: deploy
-    if: ${{ github.ref_name != 'production' }}
+    needs: 
+      - deploy
+      - register-runner
+    if: ${{ always() && !cancelled() && needs.deploy.result == 'success' && github.ref_name != 'production' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -128,8 +221,10 @@ jobs:
 
   a11y-tests:
     name: A11y Tests
-    needs: deploy
-    if: ${{ github.ref_name != 'production' }}
+    needs: 
+      - deploy
+      - register-runner
+    if: ${{ always() && !cancelled() && needs.deploy.result == 'success' && github.ref_name != 'production' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -155,3 +250,33 @@ jobs:
           path: |
             tests/cypress/screenshots/
             tests/cypress/videos/
+
+  cleanup:
+    name: Delist GHA Runner CIDR Blocks
+    if: ${{ github.ref_name != 'main' && github.ref_name != 'val' && github.ref_name != 'production' }}
+    runs-on: ubuntu-latest
+    needs:
+      - register-runner
+      - a11y-tests
+      - e2e-test
+    env:
+      SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure AWS credentials for GitHub Actions
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+      - name: output account id
+        id: output_account_id
+        run: |
+          #!/bin/bash
+          AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          echo "Current Account ID: ${AWS_ACCOUNT_ID}"
+      - name: cleanup-ip-list
+        id: reset-ip-set
+        run: ./.github/waf-controller.sh set ${{ needs.register-runner.outputs.ipset_name }} ${{ needs.register-runner.outputs.ipset_id }} '[]'
+        env:
+          AWS_RETRY_MODE: adaptive
+          AWS_MAX_ATTEMPTS: 10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,11 +116,11 @@ jobs:
 
       - name: set branch specific variable names
         id: set_names
-        run: ./.github/build-vars.sh set_names
+        run: ./.github/build_vars.sh set_names
 
       - name: set variable values
         id: set_values
-        run: ./.github/build-vars.sh set_values
+        run: ./.github/build_vars.sh set_values
         env:
           AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
           AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}

--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
   },
   "resolutions": {
     "loader-utils": "^2.0.4"
+  },
+  "dependencies": {
+    "@enterprise-cmcs/serverless-waf-plugin": "^1.3.2"
   }
 }

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -17,6 +17,7 @@ plugins:
   - serverless-iam-helper
   - serverless-s3-bucket-helper
   - serverless-api-client-certificate
+  - "@enterprise-cmcs/serverless-waf-plugin"
 
 s3BucketHelper:
   loggingConfiguration:
@@ -28,6 +29,11 @@ custom:
     tsConfigFileLocation: "./tsconfig.json"
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
+  wafPlugin:
+    name: ${self:service}-${self:custom.stage}-webacl-waf
+  wafExcludeRules:
+    awsCommon:
+      - "SizeRestrictions_BODY"
   serverlessTerminationProtection:
     stages:
       - main
@@ -48,7 +54,7 @@ custom:
   sectionBaseTableArn: ${env:sectionBaseTableArn, cf:database-${self:custom.stage}.SectionBaseTableArn}
   stageEnrollmentCountsTableName: ${env:stageEnrollmentCountsTableName, cf:database-${self:custom.stage}.StageEnrollmentCountsTableName}
   stageEnrollmentCountsTableArn: ${env:stageEnrollmentCountsTableArn, cf:database-${self:custom.stage}.StageEnrollmentCountsTableArn}
-  webAclName: ${self:service}-${self:custom.stage}-webacl
+  webAclName: ${self:service}-${self:custom.stage}-webacl-waf
   uploadsTableName: ${env:uploadsTableName, cf:database-${self:custom.stage}.UploadsTableName}
   uploadsTableArn: ${env:uploadsTableArn, cf:database-${self:custom.stage}.UploadsTableArn}
   docraptorApiKey: ${env:docraptorApiKey, ssm:/${self:custom.stage}/pdf/docraptorApiKey, ssm:/default/pdf/docraptorApiKey}
@@ -257,35 +263,6 @@ resources:
           gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
         ResponseType: DEFAULT_5XX
         RestApiId: !Ref ApiGatewayRestApi
-    ApiGwWebAcl:
-      Type: AWS::WAFv2::WebACL
-      Properties:
-        Name: ${self:custom.webAclName}
-        DefaultAction:
-          Block: {}
-        Rules:
-          - Action:
-              Allow: {}
-            Name: ${self:custom.webAclName}-allow-usa-plus-territories
-            Priority: 0
-            Statement:
-              GeoMatchStatement:
-                CountryCodes:
-                  - GU # Guam
-                  - PR # Puerto Rico
-                  - US # USA
-                  - UM # US Minor Outlying Islands
-                  - VI # US Virgin Islands
-                  - MP # Northern Mariana Islands
-            VisibilityConfig:
-              SampledRequestsEnabled: true
-              CloudWatchMetricsEnabled: true
-              MetricName: WafWebAcl
-        Scope: REGIONAL
-        VisibilityConfig:
-          CloudWatchMetricsEnabled: true
-          SampledRequestsEnabled: true
-          MetricName: ${self:custom.stage}-webacl
   Outputs:
     ApiGatewayRestApiName:
       Value: !Ref ApiGatewayRestApi

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -17,6 +17,7 @@ plugins:
   - serverless-stack-termination-protection
   - serverless-iam-helper
   - serverless-s3-bucket-helper
+  - "@enterprise-cmcs/serverless-waf-plugin"
 
 s3BucketHelper:
   loggingConfiguration:
@@ -35,17 +36,69 @@ custom:
   route53DomainName: ${ssm:/configuration/${self:custom.stage}/route53/domainName, ""}
   cloudfrontCertificateArn: ${ssm:/configuration/${self:custom.stage}/cloudfront/certificateArn, ssm:/configuration/default/cloudfront/certificateArn, ""}
   cloudfrontDomainName: ${ssm:/configuration/${self:custom.stage}/cloudfront/domainName, ""}
-  webAclName: ${self:service}-${self:custom.stage}-webacl
+  vpnIpSetArn: ${ssm:/configuration/${self:custom.stage}/vpnIpSetArn, ssm:/configuration/default/vpnIpSetArn, ""}
+  vpnIpv6SetArn: ${ssm:/configuration/${self:custom.stage}/vpnIpv6SetArn, ssm:/configuration/default/vpnIpv6SetArn, ""}
   firehoseStreamName: aws-waf-logs-${self:service}-${self:custom.stage}-firehose
+  wafExcludeRules:
+    wafScope: CLOUDFRONT
+  wafPlugin:
+    name: ${self:service}-${self:custom.stage}-webacl-waf
+    rules:
+      - enable: ${param:restrictToVpn}
+        rule:
+          Name: vpn-only
+          Priority: 0
+          Action:
+            Allow: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: ${self:service}-${self:custom.stage}-webacl-vpn-only
+          Statement:
+            OrStatement:
+              Statements:
+                - IPSetReferenceStatement:
+                    ARN: ${self:custom.vpnIpSetArn}
+                - IPSetReferenceStatement:
+                    ARN: !GetAtt GitHubIPSet.Arn
+                - IPSetReferenceStatement:
+                    ARN: ${self:custom.vpnIpv6SetArn}
+      - enable: ${param:restrictToVpn}
+        rule:
+          Name: block-all-other-traffic
+          Priority: 3
+          Action:
+            Block:
+              CustomResponse:
+                ResponseCode: 403
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: ${self:service}-${self:custom.stage}-block-traffic
+          Statement:
+            NotStatement:
+              Statement:
+                IPSetReferenceStatement:
+                  ARN: ${self:custom.vpnIpSetArn}
   scripts:
     hooks:
       # Associate the WAF ACL with the Firehose Delivery Stream
       deploy:finalize: |
-        wafAclArn=`aws wafv2 list-web-acls --scope CLOUDFRONT | jq -r '.WebACLs | .[] | select(.Name=="${self:custom.webAclName}") | .ARN'`
+        wafAclArn=`aws wafv2 list-web-acls --scope CLOUDFRONT | jq -r '.WebACLs | .[] | select(.Name=="${self:custom.wafPlugin.name}") | .ARN'`
         firehoseStreamArn=`aws firehose describe-delivery-stream --delivery-stream-name ${self:custom.firehoseStreamName} | jq -r '.DeliveryStreamDescription.DeliveryStreamARN'`
         aws wafv2 put-logging-configuration \
           --logging-configuration ResourceArn=$wafAclArn,LogDestinationConfigs=$firehoseStreamArn \
           --region ${self:provider.region}
+
+params:
+production:
+  restrictToVpn: false
+val:
+  restrictToVpn: false
+main:
+  restrictToVpn: false
+default:
+  restrictToVpn: true
 
 resources:
   Conditions:
@@ -70,6 +123,13 @@ resources:
                 - ""
                 - ${self:custom.cloudfrontDomainName}
   Resources:
+    GitHubIPSet:
+      Type: AWS::WAFv2::IPSet
+      Properties:
+        Name: ${self:custom.stage}-gh-ipset
+        Scope: CLOUDFRONT
+        IPAddressVersion: IPV4
+        Addresses: []
     S3Bucket:
       Type: AWS::S3::Bucket
       Properties:
@@ -142,35 +202,6 @@ resources:
                 Bool:
                   aws:SecureTransport: false
         Bucket: !Ref LoggingBucket
-    CloudFrontWebAcl:
-      Type: AWS::WAFv2::WebACL
-      Properties:
-        Name: ${self:custom.webAclName}
-        DefaultAction:
-          Block: {}
-        Rules:
-          - Action:
-              Allow: {}
-            Name: ${self:custom.webAclName}-allow-usa-plus-territories
-            Priority: 0
-            Statement:
-              GeoMatchStatement:
-                CountryCodes:
-                  - GU # Guam
-                  - PR # Puerto Rico
-                  - US # USA
-                  - UM # US Minor Outlying Islands
-                  - VI # US Virgin Islands
-                  - MP # Northern Mariana Islands
-            VisibilityConfig:
-              SampledRequestsEnabled: true
-              CloudWatchMetricsEnabled: true
-              MetricName: WafWebAcl
-        Scope: CLOUDFRONT
-        VisibilityConfig:
-          CloudWatchMetricsEnabled: true
-          SampledRequestsEnabled: true
-          MetricName: ${self:custom.stage}-webacl
     CloudFrontOriginAccessIdentity:
       Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
       Properties:
@@ -219,7 +250,7 @@ resources:
             - ErrorCode: 403
               ResponseCode: 403
               ResponsePagePath: /index.html
-          WebACLId: !GetAtt CloudFrontWebAcl.Arn
+          WebACLId: !GetAtt WafPluginAcl.Arn
           Logging:
             Bucket: !Sub "${LoggingBucket}.s3.amazonaws.com"
             Prefix: AWSLogs/CLOUDFRONT/${self:custom.stage}/

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -98,7 +98,7 @@ params:
   main:
     restrictToVpn: false
   default:
-    restrictToVpn: true
+    restrictToVpn: false
 
 resources:
   Conditions:

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -91,14 +91,14 @@ custom:
           --region ${self:provider.region}
 
 params:
-production:
-  restrictToVpn: false
-val:
-  restrictToVpn: false
-main:
-  restrictToVpn: false
-default:
-  restrictToVpn: true
+  production:
+    restrictToVpn: false
+  val:
+    restrictToVpn: false
+  main:
+    restrictToVpn: false
+  default:
+    restrictToVpn: true
 
 resources:
   Conditions:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1490,6 +1490,11 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
+"@enterprise-cmcs/serverless-waf-plugin@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@enterprise-cmcs/serverless-waf-plugin/-/serverless-waf-plugin-1.3.2.tgz#66efd0b91326b7d1b045ab7ea7ba5826ed2e635d"
+  integrity sha512-577MWRddWK2uPEaeUMorOFQq6rhUhGwbdmz+tuKaU9+v77/bDQPqoc6cmhF2oYMswqpxvMgW0P07HAAcmKtquw==
+
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"


### PR DESCRIPTION
### Description
This pull request is to provide the capability to lock down non production environments for CARTS to be only accessible behind CMS VPN. In addition to locking down the environments to be accessible behind VPN changes were required to temporarily enable access for GitHub Actions to access the environment to run tests.

Because the serverless environment uses AWS Cloudfront we cannot place Cloudfront inside of a private subnet. Therefore, to restrict traffic the AWS WAF is being utilized to lock down access. To accomplish this we're beginning to utilize the [CMS WAF Serverless plugin](https://github.com/Enterprise-CMCS/serverless-waf-plugin) to apply standard rule sets and extend that by applying custom IP sets.

This pull request does the following:

Implements the CMS WAF Plugin for both the cloudfront distro as well as the app-api
Creates a prioritized rule set for the WAF
Creates a custom IP set per stack
Associates a manually created global IP (for both ipv4 and ipv6) set that houses all CMS VPN IP addresses to the stacks WAF
Looks up GitHub Runner IP's and adds them to the stacks custom IP set (that is only applied to that stack)
Upon successful run of all tests clears out the GitHub Runner IP's from the stacks custom IP set


### Related ticket(s)
https://jiraent.cms.gov/browse/CMDCT-3234
---
### How to test
To test locally connect to Zscaler or Cisco Any Connect:

currently the environment is set to not be behind vpn, if we did want to verify this though we would change the ui serverless.yaml to change the vpn default to true 

`params:
  production:
    restrictToVpn: false
  val:
    restrictToVpn: false
  main:
    restrictToVpn: false
  default:
    restrictToVpn: true`

and do the following:

In an incognito window navigate to the endpoint (https://d3ub16mn4r7jim.cloudfront.net) of the environment and you should see the login page for MCR and should be able to login and use the app as expected
Disconnect from Zscaler and navigate to the same endpoint in a new incognito window and you should receive a 403.

Here's a link to a successful run with the above environment behind vpn restriction
https://github.com/Enterprise-CMCS/macpro-mdct-carts/actions/runs/8361544512

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
