### PR TITLE
Purify pdfs

### DIFF
--- a/services/app-api/handlers/printing/tests/printPdf.test.ts
+++ b/services/app-api/handlers/printing/tests/printPdf.test.ts
@@ -109,4 +109,20 @@ describe("Test Print PDF handler", () => {
       expect.stringContaining("It broke.")
     );
   });
+
+  it("should preserve html, head, and body tags", async () => {
+    const inputHtml = `<html lang="en"><head><title>My Page</title></head><body>Hello, world</body></html>`;
+    const b64html = Buffer.from(inputHtml).toString("base64");
+    const event = {
+      ...testEvent,
+      body: JSON.stringify({ encodedHtml: b64html }),
+    };
+
+    await print(event, null);
+
+    const request = (fetch as jest.Mock).mock.calls[0][1];
+    const body = JSON.parse(request.body);
+    const sentHtml = body.doc.document_content;
+    expect(sentHtml).toBe(inputHtml);
+  });
 });

--- a/services/ui-src/src/styles/_form.scss
+++ b/services/ui-src/src/styles/_form.scss
@@ -459,7 +459,7 @@
   }
   .ds-c-choice:checked + label:before {
     background-color: $white;
-    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="gray" viewBox="0 0 24 24"><path d="M20.285 2l-11.285 11.567-5.286-5.011-3.714 3.716 9 8.728 15-15.285z"/></svg>');
+    background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22gray%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20d%3D%22M20.285%202l-11.285%2011.567-5.286-5.011-3.714%203.716%209%208.728%2015-15.285z%22%2F%3E%3C%2Fsvg%3E');
     background-position: 50%;
     background-repeat: no-repeat;
     background-size: 24px;
@@ -491,7 +491,7 @@
     }
     .ds-c-choice:checked + label:before {
       background-color: $white;
-      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="gray" viewBox="0 0 24 24"><path d="M20.285 2l-11.285 11.567-5.286-5.011-3.714 3.716 9 8.728 15-15.285z"/></svg>');
+      background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22gray%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20d%3D%22M20.285%202l-11.285%2011.567-5.286-5.011-3.714%203.716%209%208.728%2015-15.285z%22%2F%3E%3C%2Fsvg%3E');
       background-position: 50%;
       background-repeat: no-repeat;
       background-size: 24px;


### PR DESCRIPTION
### Description
This PR applies DOMPurify's sanitization to our HTML before sending it to DocRaptor for rendering to PDF.

Since this HTML comes from the browser and goes through our API, in theory an attacker could send their own HTML to our API, with malicious code to access the filesystem. While this does not pose a risk to us (it's DocRaptor who is evaluating the HTML, and they have their own filesystem protections in place), it's still a good idea.

This PR also contains a frontend change. If DOMPurify finds a style tag that contains CSS which might be usable for some kind of attack, DOMPurify will remove that entire style tag. We had just a few lines (of SVG code embedded in CSS) that triggered DOMPurify in this way, and I've changed them to appear safer (by running the SVG through `encodeUriComponent`).

**QUESTION FOR REVIEWERS**: How might we test against regressions here (such as new SVGs embedded in CSS in the future, which may render fine in the browser but break the PDF call)? Would it be worthwhile to do so?

### Related ticket(s)
CMDCT-3370

---
### How to test
1. Log into Carts
2. Enter a report
3. Click the print button at the bottom
4. Click the print button at the top
5. You should see a "nice" PDF. If it fails to load at all, or if the styles are out of whack (for example, tiny SVG icons expanding to take up the entire page), then you've found a bug.

### Important updates
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
