### PR TITLE
Adding in slack changes for CARTS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,6 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
           AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
       - name: Configure AWS credentials for GitHub Actions
         uses: aws-actions/configure-aws-credentials@v4
@@ -82,16 +81,6 @@ jobs:
           echo "## Application Endpoint" >> $GITHUB_STEP_SUMMARY
           echo "<$APPLICATION_ENDPOINT>" >> $GITHUB_STEP_SUMMARY
         working-directory: services
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["main", "val", "production"]'), env.branch_name) && failure ()
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_USERNAME: Destroy Alerts
-          SLACK_ICON_EMOJI: ":bell:"
-          SLACK_COLOR: ${{job.status}}
-          SLACK_FOOTER: ""
-          MSG_MINIMAL: actions url,commit,ref
     outputs:
       application_endpoint: ${{ steps.endpoint.outputs.application_endpoint}}
       BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION: ${{ steps.set_names.outputs.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION }}

--- a/.github/workflows/post-deploy-slack-notification.yml
+++ b/.github/workflows/post-deploy-slack-notification.yml
@@ -1,0 +1,53 @@
+name: Post Deploy
+
+on:
+  workflow_run:
+    workflows: [Deploy]
+    types: [completed]
+    branches:
+      - 'main'
+      - 'val'
+      - 'production'
+      - 'snyk-**'
+
+jobs:
+  notify_on_failure:
+    # Sends alert to macpro-mdct-<product name>-alerts channel in CMS slack when any integration environment fails to deploy or run tests
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.head_branch == 'val' || github.event.workflow_run.head_branch == 'production') }}
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_TITLE: ":boom: The latest ${{ github.repository }} build on branch '${{ github.event.workflow_run.head_branch }}' has failed"
+          SLACK_MESSAGE: "${{ github.event.workflow_run.html_url }}"
+          MSG_MINIMAL: true
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  # Notify the integrations channel only when a Snyk auto merge fails
+  notify_failed_snyk_auto_merge:
+    runs-on: ubuntu-latest
+    #only check branch names that begin with snyk-
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && startsWith(github.event.workflow_run.head_branch, 'snyk-') }}
+    steps:
+      - name: Debug
+        run: echo "Ref is ${{ github.ref }}"
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_TITLE: ":boom: A Synk auto merge has failed in ${{ github.repository }}"
+          SLACK_MESSAGE: "${{ github.event.workflow_run.html_url }}"
+          MSG_MINIMAL: true
+          SLACK_WEBHOOK: ${{ secrets.INTEGRATIONS_SLACK_WEBHOOK }}
+
+  # Sends a slack message to the mdct-prod-releases channel in CMS slack
+  notify_on_prod_release:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'production') }}
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_TITLE: ":rocket: ${{ github.repository }} has successfully released to production."
+          MSG_MINIMAL: true
+          SLACK_WEBHOOK: ${{ secrets.PROD_RELEASE_SLACK_WEBHOOK }}

--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -1,0 +1,19 @@
+name: Pull Request Notification
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  notify_integrations_channel:
+    runs-on: ubuntu-latest
+    # avoiding notifications for automated Snyk Pull Requests and draft pull requests 
+    if: github.actor != 'mdct-github-service-account' && !github.event.pull_request.draft
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_TITLE: ":github: A new pull request has been created in ${{ github.repository }} by ${{ github.event.pull_request.user.login }}"
+          SLACK_MESSAGE: "${{ github.event.pull_request.html_url }}"
+          MSG_MINIMAL: true
+          SLACK_WEBHOOK: ${{ secrets.INTEGRATIONS_SLACK_WEBHOOK }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,13 @@ repos:
     hooks:
       - id: check-added-large-files
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.12.0
+    rev: v8.56.0
     hooks:
       - id: eslint
         files: '\.[jt]sx?$' # *.js, *.jsx, *.ts and *.tsx
         types: [file]
         additional_dependencies:
-          - "eslint"
+          - "eslint@8.56.0"
           - "@typescript-eslint/parser"
           - "@typescript-eslint/eslint-plugin"
           - "eslint-plugin-jest"

--- a/README.md
+++ b/README.md
@@ -179,6 +179,22 @@ We use Prettier to format all code. This runs as part of a Git Hook and changes 
 
 Most IDEs have a Prettier plugin that can be configured to run on file save. You can also run the format check manually from the IDE or invoking Prettier on the command line.
 
+## Slack Webhooks
+
+This repository uses 3 webhooks to publish to  3 different channels all in CMS Slack.
+
+- SLACK_WEBHOOK: This pubishes to the `macpro-mdct-carts-alerts` channel. Alerts published there are for deploy or test failures to the `main`, `val`, or `production` branches.
+
+- INTEGRATIONS_SLACK_WEBHOOK: This is used to publish new pull requests to the `mdct-integrations-channel`
+
+- PROD_RELEASE_SLACK_WEBHOOK: This is used to publish to the `mdct-prod-releases` channel upon successful release of Seds to production.
+
+    - Webhooks are created by CMS tickets, populated into GitHub Secrets
+
+## GitHub Actions Secret Management
+- Secrets are added to GitHub secrets by GitHub Admins 
+- Upon editing and adding new secrets Admins should also update the encypted `/github/secret-list` SSM parameter in the SEDS AWS Production Account.
+
 ## Architecture
 
 TODO: Get an updated diagram


### PR DESCRIPTION
### Description
Current slack notification functionality is noisy and often gives alerts on events we don't particularly care about and omits events that we do care about. This aims to fix that by doing the following.

macpro-mdct-carts-alerts, mdct-prod-releases, and mdct-integrations-channel have all been created in cms slack
webhooks have been requested, created, and populated into github secrets for the SEDS repository
following standards the webhooks were also populated into the carts aws ssm account (readme for this is also updated as part of this PR)
webhooks were implemented to alert on the following things
new pr creation - alerts to the mdct-integrations-channel
failed builds of main, val, or prod - alerts to the macpro-mdct-carts-alerts channel
failed snyk auto merges - alerts to mdct-integrations-channel
release to production - alerts to the mdct-prod-releases channel


### Related ticket(s)
https://jiraent.cms.gov/browse/CMDCT-3428

---
### How to test
merge and watch for issues. this has already been tested in seds. 


### Notes
once we get all the products done, we'll move everyone over to the new channels but that should be fast after the first one of these goes through and is tested


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
