### PR TITLE
Fixing workflow reference for slack notifications 

### DIFF
--- a/.github/workflows/post-deploy-slack-notification.yml
+++ b/.github/workflows/post-deploy-slack-notification.yml
@@ -2,7 +2,7 @@ name: Post Deploy
 
 on:
   workflow_run:
-    workflows: [Deploy]
+    workflows: [Deploy CARTSv3]
     types: [completed]
     branches:
       - 'main'


### PR DESCRIPTION
### Description
this was an oversight on my part ... I thought the deploy workflow had a standardized name. I was wrong. this fixes that. 


### Related ticket(s)


---
### How to test
make sure notifications get published. 


### Notes



---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
