### PR TITLE
Allow for undefined OldImage in Dynamo stream events

### DIFF
--- a/services/carts-bigmac-streams/libs/kafka-source-lib.js
+++ b/services/carts-bigmac-streams/libs/kafka-source-lib.js
@@ -68,7 +68,7 @@ class KafkaSourceLib {
     const { eventID, eventName } = record;
     const dynamoRecord = {
       NewImage: this.unmarshall(dynamodb.NewImage),
-      OldImage: this.unmarshall(dynamodb.OldImage),
+      OldImage: this.unmarshall(dynamodb.OldImage ?? {}),
       Keys: this.unmarshall(dynamodb.Keys),
     };
     return {


### PR DESCRIPTION
### Description
We create Kafka messages from AWS event streams, which can be triggered by activity in DynamoDB. Usually, the event contains both a "before" and "after" of the object - but when the event is an insert, there is no "before". That is, `event.Records[n].dynamodb.OldImage` will be `undefined`. Unless we account for this, it will cause an error when we attempt to unmarshall it.

This is a low-impact bug; subsequent updates to that record will go through just fine, because they will have an OldImage. This PR just cleans up the initial edge case.

### Related ticket(s)
CMDCT-3431

---
### How to test
🤷‍♂️  I guess we just merge it, and then watch the logs from our postKafkaData lambda?

### Notes
n/a

---
### Pre-review checklist
- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~

---
### Pre-merge checklist

#### Review
- ~[ ] Design: This work has been reviewed and approved by design, if necessary~
- ~[ ] Product: This work has been reviewed and approved by product owner, if necessary~

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~[ ] These changes are significant enough to require an update to the SIA.~
- ~[ ] These changes are significant enough to require a penetration test.~
