### PR TITLE
Adding additional slack capabilities

### DIFF
--- a/.github/workflows/post-deploy-slack-notification.yml
+++ b/.github/workflows/post-deploy-slack-notification.yml
@@ -30,8 +30,6 @@ jobs:
     #only check branch names that begin with snyk-
     if: ${{ github.event.workflow_run.conclusion == 'failure' && startsWith(github.event.workflow_run.head_branch, 'snyk-') }}
     steps:
-      - name: Debug
-        run: echo "Ref is ${{ github.ref }}"
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -32,8 +32,13 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: get endpoint
         id: getendpoint
-        run:  |
+        run: |
+          set +e
           application_endpoint_url=$(aws cloudformation describe-stacks --stack-name ui-${{ env.branch_name }} --output text --query "Stacks[0].Outputs[?OutputKey=='ApplicationEndpointUrl'].OutputValue")
+          set -e
+          if [[ -z $application_endpoint_url || ! $application_endpoint_url == http* ]]; then
+              application_endpoint_url="endpoint not found"
+          fi
           echo "application_endpoint_url=$application_endpoint_url" >> $GITHUB_OUTPUT
           
     outputs:

--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -22,9 +22,9 @@ jobs:
           echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - name: set branch specific variable names
-        run: ./.github/build-vars.sh set_names
+        run: ./.github/build_vars.sh set_names
       - name: set variable values
-        run: ./.github/build-vars.sh set_values
+        run: ./.github/build_vars.sh set_values
       - name: Configure AWS credentials for GitHub Actions
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -4,9 +4,45 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review]
 
+permissions:
+  id-token: write
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
+  endpoint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: set branch_name # Some integrations (Snyk) build very long branch names. This is a switch to make long branch names shorter.
+        run: |
+          BRANCH_NAME=$(./.github/setBranchName.sh ${{ github.event.pull_request.head.ref }})
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+      - name: set branch specific variable names
+        run: ./.github/build-vars.sh set_names
+      - name: set variable values
+        run: ./.github/build-vars.sh set_values
+      - name: Configure AWS credentials for GitHub Actions
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: get endpoint
+        id: getendpoint
+        run:  |
+          application_endpoint_url=$(aws cloudformation describe-stacks --stack-name ui-${{ env.branch_name }} --output text --query "Stacks[0].Outputs[?OutputKey=='ApplicationEndpointUrl'].OutputValue")
+          echo "application_endpoint_url=$application_endpoint_url" >> $GITHUB_OUTPUT
+          
+    outputs:
+      application_endpoint_url: ${{ steps.getendpoint.outputs.application_endpoint_url }}
+
   notify_integrations_channel:
     runs-on: ubuntu-latest
+    needs:
+      - endpoint
     # avoiding notifications for automated Snyk Pull Requests and draft pull requests 
     if: github.actor != 'mdct-github-service-account' && !github.event.pull_request.draft
     steps:
@@ -14,6 +50,6 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_TITLE: ":github: A new pull request has been created in ${{ github.repository }} by ${{ github.event.pull_request.user.login }}"
-          SLACK_MESSAGE: "${{ github.event.pull_request.html_url }}"
+          SLACK_MESSAGE: "${{ github.event.pull_request.html_url }} \n Cloudfront URL: ${{ needs.endpoint.outputs.application_endpoint_url }}"
           MSG_MINIMAL: true
           SLACK_WEBHOOK: ${{ secrets.INTEGRATIONS_SLACK_WEBHOOK }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -45,3 +45,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRNUM: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+
+  #Notify the integrations channel only when a Snyk auto merge fails pr checks
+  notify_on_pr_failure:
+    runs-on: ubuntu-latest
+    needs: 
+      - linting
+      - jest-frontend
+      - jest-backend
+    #only check branch names that begin with snyk-
+    if: ${{ failure() && startsWith(github.head_ref, 'snyk-') }}
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_TITLE: ":boom: A Synk auto merge has failed pull request checks in ${{ github.repository }}."
+          MSG_MINIMAL: true
+          SLACK_WEBHOOK: ${{ secrets.INTEGRATIONS_SLACK_WEBHOOK }}


### PR DESCRIPTION
### Description
Trying to fill in some gaps from the slack implementation this PR does a couple of things

when snyk opens a pr now we alert on failing pr checks, prior we were only alerting on failed deploy/tests from a failed snyk auto merge. This should cover all the failing scenarios for Snyk now.

when a pr is opened the cloudfront URL is added to the slack notification in the integrations channel

I opted not to add alerts in for from red to green builds because it started getting very custom and although nice to have, not a must have.


### Related ticket(s)
[CMDCT-3534](https://jiraent.cms.gov/browse/CMDCT-3534)

---
### How to test
create a pull request and see your cloudfront url in the integrations channel
I tested the failed pr notification in the core repo where we were seeing a failed pr step on a snyk build [here](https://github.com/Enterprise-CMCS/macpro-mdct-core/actions/runs/8691835762)


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
