### PR TITLE
Fix Artifact Upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,8 +66,7 @@ jobs:
             ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
       - name: Store unit test results
         uses: actions/upload-artifact@v4
-        #if: failure()
-        if: always()
+        if: failure()
         with:
           name: unit-test-results
           path: |
@@ -204,8 +203,7 @@ jobs:
           CYPRESS_ADMIN_USER_PASSWORD: ${{ secrets.CYPRESS_ADMIN_USER_PASSWORD }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
-        #if: failure()
-        if: always()
+        if: failure()
         with:
           name: cypress-test-results
           path: |
@@ -238,8 +236,7 @@ jobs:
           CYPRESS_ADMIN_USER_PASSWORD: ${{ secrets.CYPRESS_ADMIN_USER_PASSWORD }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
-        #if: failure()
-        if: always()
+        if: failure()
         with:
           name: a11y-test-results
           path: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,10 +65,14 @@ jobs:
             ${{github.workspace}}/services/app-api/coverage/lcov.info:lcov
             ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
       - name: Store unit test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
+        #if: failure()
+        if: always()
         with:
-          name: unit_test_results
-          path: ${{github.workspace}}/services/ui-src/coverage/lcov.info
+          name: unit-test-results
+          path: |
+            ${{github.workspace}}/services/app-api/coverage/lcov.info:lcov
+            ${{github.workspace}}/services/ui-src/coverage/lcov.info
       - name: deploy
         run: |
           # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.
@@ -199,13 +203,15 @@ jobs:
           CYPRESS_ADMIN_USER_EMAIL: ${{ secrets.CYPRESS_ADMIN_USER_EMAIL }}
           CYPRESS_ADMIN_USER_PASSWORD: ${{ secrets.CYPRESS_ADMIN_USER_PASSWORD }}
       - name: Upload screenshots
-        uses: actions/upload-artifact@v3
-        if: failure()
+        uses: actions/upload-artifact@v4
+        #if: failure()
+        if: always()
         with:
-          name: cypress-screenshots
+          name: cypress-test-results
           path: |
-            tests/cypress/screenshots/
-            tests/cypress/videos/
+            ${{github.workspace}}/tests/cypress/screenshots/
+            ${{github.workspace}}/tests/cypress/videos/
+          retention-days: 14
 
   a11y-tests:
     name: A11y Tests
@@ -231,13 +237,15 @@ jobs:
           CYPRESS_ADMIN_USER_EMAIL: ${{ secrets.CYPRESS_ADMIN_USER_EMAIL }}
           CYPRESS_ADMIN_USER_PASSWORD: ${{ secrets.CYPRESS_ADMIN_USER_PASSWORD }}
       - name: Upload screenshots
-        uses: actions/upload-artifact@v3
-        if: failure()
+        uses: actions/upload-artifact@v4
+        #if: failure()
+        if: always()
         with:
-          name: cypress-screenshots
+          name: a11y-test-results
           path: |
-            tests/cypress/screenshots/
-            tests/cypress/videos/
+            ${{github.workspace}}/tests/cypress/screenshots/
+            ${{github.workspace}}/tests/cypress/videos/
+          retention-days: 14            
 
   cleanup:
     name: Delist GHA Runner CIDR Blocks


### PR DESCRIPTION
### Description
There were a few problem with the artifact upload:

- Unit tests were configuration in such a way that they would probably not upload artifacts should the tests fail (this is an unverified assumption).  Also api unit tests were not being packaged.
- Cypress and A11y test paths pointed to directories one level deeper than they were actually being stored.
- Cypress and A11y artifact name would produce a collision and fail the job, so if both failed, the slower job would not be able to upload artifacts
- No retention was set so it would default to 90 days.  I picked 14 because I wouldn't expect to need to retrieve artifacts from a build older than 2 weeks


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3554

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
I pushed a build set to always upload artifacts.  The artifacts can be seen to be correctly publishing [here](https://github.com/Enterprise-CMCS/macpro-mdct-carts/actions/runs/8786840270).  A successful build will not produce artifacts.


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
