### PR TITLE
Encode file name before allowing download on upload component

### DIFF
--- a/services/ui-src/src/components/layout/UploadComponent.js
+++ b/services/ui-src/src/components/layout/UploadComponent.js
@@ -227,24 +227,22 @@ class UploadComponent extends Component {
           />
         </div>
 
-        {this.state.loadedFiles
-          ? this.state.loadedFiles.map((element, i) => (
-              <div key={element.name}>
-                <a href={element.name} download>
-                  {" "}
-                  {element.name}{" "}
-                </a>
-                <Button
-                  data-testid={`unstage-${i}`}
-                  name={element.name}
-                  onClick={this.removeFile}
-                  size="small"
-                >
-                  x
-                </Button>
-              </div>
-            ))
-          : null}
+        {this.state.loadedFiles?.map((file, i) => (
+          <div key={file.name}>
+            <a href={encodeURIComponent(file.name)} download>
+              {" "}
+              {file.name}{" "}
+            </a>
+            <Button
+              data-testid={`unstage-${i}`}
+              name={file.name}
+              onClick={this.removeFile}
+              size="small"
+            >
+              x
+            </Button>
+          </div>
+        ))}
 
         <Button
           onClick={this.submitUpload}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
We received a security alert noting that [DOM text is being reinterpreted as HTML](https://github.com/Enterprise-CMCS/macpro-mdct-carts/security/code-scanning/6), specifically around the upload component. This PR encodes the file name so that any bad actors can't use it to XSS

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
https://github.com/Enterprise-CMCS/macpro-mdct-carts/security/code-scanning/6

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment