### PR TITLE
add base url for vite config, load assets consistently

### DIFF
--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -103,16 +103,16 @@
     ],
     "testEnvironment": "jsdom",
     "collectCoverageFrom": [
-      "src/components/**/*.js",
-      "src/util/**/*.js",
-      "!src/index.js",
+      "src/components/**/*.{js,jsx}",
+      "src/util/**/*.{js,jsx}",
+      "!src/index.jsx",
       "!src/types.js",
       "!src/config.js",
-      "!src/**/index.js",
+      "!src/**/index.{js,jsx}",
       "!src/components/utils/statesArray.js",
-      "!src/util/testing/**/*.js",
-      "!src/actions/**/*.js",
-      "!src/store/**/*.js",
+      "!src/util/testing/**/*.{js,jsx}",
+      "!src/actions/**/*.{js,jsx}",
+      "!src/store/**/*.{js,jsx}",
       "!src/util/idLetterMarkers.js"
     ],
     "coverageReporters": [

--- a/services/ui-src/src/components/layout/UploadComponent.jsx
+++ b/services/ui-src/src/components/layout/UploadComponent.jsx
@@ -11,7 +11,6 @@ import {
   getUploadedFiles,
   deleteUploadedFile,
 } from "../../util/fileApi";
-import { BASE_URL } from "../../util/constants";
 
 class UploadComponent extends Component {
   constructor(props) {
@@ -278,7 +277,7 @@ class UploadComponent extends Component {
                   <td>
                     <img
                       // eslint-disable-next-line
-                      src={`${BASE_URL}/img/bouncing_ball.gif`}
+                      src={`/img/bouncing_ball.gif`}
                       alt="Retrieving uploaded files... Please wait..."
                     />{" "}
                     <br />

--- a/services/ui-src/src/components/utils/Spinner.jsx
+++ b/services/ui-src/src/components/utils/Spinner.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
-import { BASE_URL } from "../../util/constants";
 
 const Spinner = (props) => {
   const { isFetching } = props;
@@ -11,7 +10,7 @@ const Spinner = (props) => {
       <div className="preloader-image">
         <img
           data-testid="spinner-img"
-          src={`${BASE_URL}/img/spinner.gif`}
+          src={`/img/spinner.gif`}
           alt="Loading. Please wait."
         />
       </div>

--- a/services/ui-src/src/store/fakeUserData.js
+++ b/services/ui-src/src/store/fakeUserData.js
@@ -1,4 +1,3 @@
-import { BASE_URL } from "../util/constants";
 import { AppRoles } from "../types";
 
 const fakeUserData = {
@@ -8,7 +7,7 @@ const fakeUserData = {
     programType: "medicaid_exp_chip",
     programName: "WTF AK Program Name??",
     // eslint-disable-next-line no-undef
-    imageURI: `${BASE_URL}/img/states/ak.svg`,
+    imageURI: "/img/states/ak.svg",
     formName: "CARTS FY",
     currentUser: {
       role: AppRoles.STATE_USER,
@@ -25,7 +24,7 @@ const fakeUserData = {
     programType: "separate_chip",
     programName: "AZ Program Name??",
     // eslint-disable-next-line no-undef
-    imageURI: `${BASE_URL}/img/states/az.svg`,
+    imageURI: "/img/states/az.svg",
     formName: "CARTS FY",
     currentUser: {
       role: AppRoles.STATE_USER,
@@ -42,7 +41,7 @@ const fakeUserData = {
     programType: "combo",
     programName: "MA Program Name??",
     // eslint-disable-next-line no-undef
-    imageURI: `${BASE_URL}/img/states/ma.svg`,
+    imageURI: "/img/states/ma.svg",
     formName: "CARTS FY",
     currentUser: {
       role: AppRoles.STATE_USER,

--- a/services/ui-src/src/store/stateUser.js
+++ b/services/ui-src/src/store/stateUser.js
@@ -1,4 +1,3 @@
-import { BASE_URL } from "../util/constants";
 import statesArray from "../components/utils/statesArray";
 
 // ACTION TYPES
@@ -52,7 +51,7 @@ const initialState = {
   abbr: "NY",
   programType: "combo", // values can be combo, medicaid_exp_chip, or separate_chip
   programName: "NY Combo Program",
-  imageURI: `${BASE_URL}/img/states/ny.svg`,
+  imageURI: `/img/states/ny.svg`,
   formName: "CARTS FY",
   currentUser: {
     role: false,

--- a/services/ui-src/src/util/testing/testUtils.js
+++ b/services/ui-src/src/util/testing/testUtils.js
@@ -1,6 +1,5 @@
 import { createStore, applyMiddleware } from "redux";
 import thunk from "redux-thunk";
-import { BASE_URL } from "../constants";
 
 //import checkPropTypes from "check-prop-types";
 
@@ -34,7 +33,7 @@ export const mockInitialState = {
     programType: "comboCHIP", //values can be comboCHIP, mCHIP or sCHIP
     programName: "NY Combo Program",
     // eslint-disable-next-line no-undef
-    imageURI: `${BASE_URL + "/img/states/ny.svg"}`,
+    imageURI: "/img/states/ny.svg",
     formName: "CARTS FY",
     currentUser: {
       role: "admin",

--- a/services/ui-src/vite.config.ts
+++ b/services/ui-src/vite.config.ts
@@ -3,17 +3,13 @@ import react from "@vitejs/plugin-react";
 import viteTsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  // depending on your application, base can also be "/"
-  base: "",
+  base: "/",
   plugins: [react(), viteTsconfigPaths()],
   server: {
-    // this ensures that the browser opens upon server start
     open: true,
-    // this sets a default port to 3000
     port: 3000,
   },
   define: {
-    // here is the main update
     global: "globalThis",
   },
   build: {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
1) Set base url as / in the vite config, so that assets always load relative to the root, and not the current path.
2) Include jsx files in code coverage. This results in a drop to coverage %, as we artificially inflate the number by missing that in the past commit.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://d27ygu8tqey9fr.cloudfront.net/ <- Make sure this looks good, and the spinner loads when navigating around.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
