### PR TITLE
Cloudfront Policy Headers

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -236,9 +236,7 @@ resources:
               Cookies:
                 Forward: none
             ViewerProtocolPolicy: redirect-to-https
-            FunctionAssociations:
-              - EventType: viewer-response
-                FunctionARN: !GetAtt HstsCloudfrontFunction.FunctionMetadata.FunctionARN
+            ResponseHeadersPolicyId: !GetAtt CloudFormationHeadersPolicy.Id
           ViewerCertificate:
             Fn::If:
               - CreateCustomCloudFrontDomain
@@ -265,24 +263,26 @@ resources:
           HostedZoneId: Z2FDTNDATAQYW2
           EvaluateTargetHealth: false
         Type: A
-    HstsCloudfrontFunction:
-      Type: AWS::CloudFront::Function
+    CloudFormationHeadersPolicy:
+      Type: AWS::CloudFront::ResponseHeadersPolicy
       Properties:
-        AutoPublish: true
-        FunctionCode: |
-          function handler(event) {
-            var response = event.response;
-            var headers = response.headers;
-            headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload'};
-            headers['x-content-type-options'] = { value: 'nosniff' };
-            headers['x-frame-options'] = { value: 'DENY' };
-            headers["content-security-policy"] = { value: "default-src 'self'; img-src 'self' data: https://www.google-analytics.com; script-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com tags.tiqcdn.com tags.tiqcdn.cn tags-eu.tiqcdn.com https://*.adoberesources.net 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src https://*.amazonaws.com/ https://*.amazoncognito.com https://www.google-analytics.com https://*.launchdarkly.us https://adobe-ep.cms.gov https://adobedc.demdex.net; frame-ancestors 'none'; object-src 'none'"};
-            return response;
-          }
-        FunctionConfig:
-          Comment: This function adds headers to implement HSTS
-          Runtime: cloudfront-js-1.0
-        Name: hsts-${self:custom.stage}
+        ResponseHeadersPolicyConfig:
+          Name: Headers-Policy-${self:custom.stage}
+          Comment: Add Security Headers
+          SecurityHeadersConfig:
+            ContentTypeOptions: # sets to nosniff
+              Override: true
+            StrictTransportSecurity:
+              AccessControlMaxAgeSec: 63072000
+              IncludeSubdomains: true
+              Preload: true
+              Override: true
+            FrameOptions:
+              FrameOption: "DENY"
+              Override: true
+            ContentSecurityPolicy:
+              ContentSecurityPolicy: "default-src 'self'; img-src 'self' data: https://www.google-analytics.com; script-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com tags.tiqcdn.com tags.tiqcdn.cn tags-eu.tiqcdn.com https://*.adoberesources.net 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src https://*.amazonaws.com/ https://*.amazoncognito.com https://www.google-analytics.com https://*.launchdarkly.us https://adobe-ep.cms.gov https://adobedc.demdex.net; frame-ancestors 'none'; object-src 'none'"
+              Override: true
     ###############This code block enables logging on waf and sends all logs to s3.##################################
     WaflogsUploadBucket:
       Type: AWS::S3::Bucket


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Switch from a Cloudfront Function to Policies to apply security headers. The function is not applied on a page not found, which is how our SPA magic works. A route like `mysite.com/home` would not get the function, but `mysite.com` would, despite them both returning the same item from S3 at mysite.com's index file.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deployed instance should still have the security headers, and nested pages should have them as well, when inspecting hte network tab headers.
https://d6el7fqxko50a.cloudfront.net/
Log in, go to a page with a nested path. Refresh. Same headers should be contained.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
