### PR TITLE
Remove unmarshall options from Kafka calls

### DIFF
--- a/services/carts-bigmac-streams/libs/kafka-source-lib.js
+++ b/services/carts-bigmac-streams/libs/kafka-source-lib.js
@@ -38,12 +38,6 @@ class KafkaSourceLib {
    *version = "some version";
    *tables = [list of tables];
    */
-
-  unmarshallOptions = {
-    convertEmptyValues: true,
-    wrapNumbers: true,
-  };
-
   stringify(e, prettyPrint) {
     if (prettyPrint === true) return JSON.stringify(e, null, 2);
     return JSON.stringify(e);
@@ -56,7 +50,7 @@ class KafkaSourceLib {
   }
 
   doUnmarshall(r) {
-    return unmarshall(r, this.unmarshallOptions);
+    return unmarshall(r);
   }
 
   createPayload(record) {

--- a/services/carts-bigmac-streams/serverless.yml
+++ b/services/carts-bigmac-streams/serverless.yml
@@ -79,7 +79,6 @@ functions:
       cluster: !Ref KafkaConnectCluster
       connectorPrefix: carts-${self:custom.stage}-
       sinkTopics: aws.mdct.seds.cdc.state-forms.v0
-      jdbcSinkTopics: aws.mdct.seds.cdc.enrollment-counts.v0
       sinkFunctionArn: !GetAtt SinkEnrollmentCountsLambdaFunction.Arn
       sinkFunctionRegion: ${self:custom.region}
       BOOTSTRAP_BROKER_STRING_TLS: ${self:custom.bootstrapBrokerStringTls}
@@ -96,7 +95,6 @@ functions:
     environment:
       BOOTSTRAP_BROKER_STRING_TLS: ${self:custom.bootstrapBrokerStringTls}
       STAGE: ${self:custom.stage}
-      TOPIC: aws.mdct.seds.cdc.enrollment-counts.v0
       stageEnrollmentCountsTableName: ${self:custom.stageEnrollmentCountsTableName}
     maximumRetryAttempts: 2
     timeout: 120

--- a/services/database/scripts/sync-kafka-2024.js
+++ b/services/database/scripts/sync-kafka-2024.js
@@ -1,0 +1,69 @@
+/* eslint-disable no-console */
+/*
+ * Local:
+ *    `DYNAMODB_URL="http://localhost:8000" dynamoPrefix="local" node services/database/scripts/sync-kafka-2024.js`
+ *  Branch:
+ *    dynamoPrefix="YOUR BRANCH NAME" node services/database/scripts/sync-kafka-2024.js
+ */
+
+const { buildDynamoClient, scan, update } = require("./utils/dynamodb.js");
+
+const isLocal = !!process.env.DYNAMODB_URL;
+
+const sectionTableName = isLocal
+  ? "local-section"
+  : process.env.dynamoPrefix + "-section";
+const statusTableName = isLocal
+  ? "local-state-status"
+  : process.env.dynamoPrefix + "-state-status";
+const tables = [sectionTableName, statusTableName];
+const syncTime = new Date().toISOString();
+
+async function handler() {
+  try {
+    console.log("Searching for 2024 modifications");
+
+    buildDynamoClient();
+
+    for (const tableName of tables) {
+      console.log(`Processing table ${tableName}`);
+      const existingItems = await scan({
+        TableName: tableName,
+      });
+      const filteredItems = filter(existingItems);
+      const transformedItems = await transform(filteredItems);
+      await update(tableName, transformedItems);
+      console.log(`Touched ${transformedItems.length} in table ${tableName}`);
+    }
+    console.debug("Data fix complete");
+
+    return {
+      statusCode: 200,
+      body: "All done!",
+    };
+  } catch (err) {
+    console.error(err);
+    return {
+      statusCode: 500,
+      body: err.message,
+    };
+  }
+}
+
+function filter(items) {
+  return items.filter(
+    (item) => new Date(item.lastChanged).getFullYear() === 2024
+  );
+}
+
+async function transform(items) {
+  // Touch sync field only
+  const transformed = items.map((item) => {
+    const corrected = { ...item, ...{ lastSynced: syncTime } };
+    return corrected;
+  });
+
+  return transformed;
+}
+
+handler();


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Breaking change in kafka-source-lib.

The updated AWS unmarshall utility function is processing the provided settings for wrapping numbers differently and resulting in messages to bigmac that have all numbers nested like so:
```
Message: 'New item!', Id: NumberValue { value: '101' } }
vs
{ Message: 'New item!', Id: 101 } 
```

We need it to look like that second format. (`{ Message: 'New item!', Id: 101 }`). To do that, looks like all we need to do is remove the optional unmarshal options. However, we also need to let all downstream listeners know that things have been updated. To that end, we have a script that we can run to look at all the reports in 2024, update their last synced time to the time that the script is run, and then let it fire off from there.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3673

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

- `./run local`
- Go to localhost:8001 to see your local dynamo instance
- In another tab go to localhost:3000 to see CARTS
- Verify you see 3 reports with no lastchanged as 2024.
- In another console, run `DYNAMODB_URL="http://localhost:8000" dynamoPrefix="local" node services/database/scripts/sync-kafka-2024.js`
- See in the console that the output says there were no tables touched.
- Go to localhost:8001 and see nothing was updated.
- Enter a report on localhost:3000
- Update a field
- Go to localhost:8001 and see that the status table and section table was updated 
- In the console run `DYNAMODB_URL="http://localhost:8000" dynamoPrefix="local" node services/database/scripts/sync-kafka-2024.js`
- See that the form was table was updated with last synced on localhost:8001
- Verify no other form has a last synced of todays date.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
