### PR TITLE
Set Report Type to Combo to ensure theres a section 1 to fill in sect…

### DIFF
--- a/tests/cypress/tests/integration/section1Fill.spec.js
+++ b/tests/cypress/tests/integration/section1Fill.spec.js
@@ -17,6 +17,16 @@ describe("CARTS Report Fill Tests", () => {
     cy.get(actionButton, { timeout: 30000 }).contains("Edit").click();
     cy.wait(3000);
 
+    //Set Report Type to Combo to ensure theres a section 1 to fill
+    cy.get("legend")
+      .contains("Program type")
+      .siblings()
+      .find("label")
+      .contains("Both Medicaid Expansion")
+      .then((label) => {
+        cy.get(`#${label.attr("for")}`).check();
+      });
+
     // Navigate to Section 1
     cy.get(navigationLink, { timeout: 3000 }).contains("Section 1").click();
     cy.wait(3000);


### PR DESCRIPTION

### Description
<!-- Detailed description of changes and related context -->
E2E tests are failing because sometimes there isn't a section1 to fill out. This ensures there always is.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
