### PR TITLE
Remove generic example content from FAQ page

### DIFF
--- a/services/ui-src/src/components/sections/GetHelp.jsx
+++ b/services/ui-src/src/components/sections/GetHelp.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Accordion, AccordionItem, Alert } from "@cmsgov/design-system";
 import techIcon from "../../assets/images/noun-technical-support-1873885-D5DEE4.png";
 import ActionCard from "../utils/ActionCard";
 
@@ -7,12 +6,6 @@ const GetHelp = () => {
   return (
     <main className="help-page ds-l-container">
       <div className="ds-l-col--12">
-        <Alert heading="Informative status">
-          <p className="ds-c-alert__text">
-            Lorem ipsum dolor sit link text, consectetur adipiscing elit, sed do
-            eiusmod.
-          </p>
-        </Alert>
         <div className="help-page-container ds-l-container">
           <h1 className="help-page-title">How can we help you?</h1>
           <p>
@@ -28,21 +21,6 @@ const GetHelp = () => {
               </strong>
             </p>
           </ActionCard>
-
-          <Accordion>
-            <AccordionItem heading="First FAQ Question">
-              <p>
-                This is the first FAQ Answer. It's quite a verbose one, really.
-                In fact, wouldn't you know that the person is simply using this
-                as example text for what the accordion could possibly reveal?
-                Pretty meta right? The worlds crazy and we're living in crazy
-                times. Calls for crazy meta accordion measures.
-              </p>
-            </AccordionItem>
-            <AccordionItem heading="Second FAQ Question">
-              <p>Hello world!</p>
-            </AccordionItem>
-          </Accordion>
         </div>
       </div>
     </main>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Removes the generic FAQ content from the contact us page

Before:

![image](https://github.com/Enterprise-CMCS/macpro-mdct-carts/assets/19439679/e866819a-df2f-4457-b912-86beb3eb2ae5)

After:

![image](https://github.com/Enterprise-CMCS/macpro-mdct-carts/assets/19439679/4afb522e-2ef9-47da-a359-2955bbdc4a12)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3772

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Click the "Contact Us" link in the footer
See theres no generic faq content

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Product: This work has been reviewed and approved by product owner, if necessary
