### PR TITLE
Revert "Move deploy to run"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.
           # This can optionally be set as an GitHub Actions Secret
-          ./run deploy --stage $STAGE_PREFIX$branch_name
+          ./deploy.sh $STAGE_PREFIX$branch_name
       - id: endpoint
         run: |
           APPLICATION_ENDPOINT=$(./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name)

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e
+
+stage=${1:-dev}
+
+services=(
+  'database'
+  'app-api'
+  'uploads'
+  'ui'
+  'ui-auth'
+  'ui-src'
+)
+
+install_deps() {
+  if [ "$CI" == "true" ]; then # If we're in a CI system
+    if [ ! -d "node_modules" ]; then # If we don't have any node_modules (CircleCI cache miss scenario), run yarn install --frozen-lockfile.  Otherwise, we're all set, do nothing.
+      yarn install --frozen-lockfile
+    fi
+  else # We're not in a CI system, let's yarn install
+    yarn install
+  fi
+}
+
+prepare_service() {
+  service=$1
+  pushd services/$service
+  install_deps
+  popd
+}
+
+install_deps
+export PATH=$(pwd)/node_modules/.bin/:$PATH
+
+for i in "${services[@]}"
+do
+	prepare_service $i
+done
+
+serverless deploy  --stage $stage
+
+# Only deploy resources for kafka ingestion in real envs
+if [[ "$stage" == "main" || "$stage" == "val" || "$stage" == "production" ]]; then
+  kafkaservice='carts-bigmac-streams'
+  prepare_service $kafkaservice
+  pushd services/$kafkaservice
+  serverless deploy --stage $stage
+  popd
+fi
+
+pushd services
+echo """
+------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------
+Application endpoint:  `./output.sh ui CloudFrontEndpointUrl $stage`
+------------------------------------------------------------------------------------------------
+"""
+popd

--- a/src/run.ts
+++ b/src/run.ts
@@ -7,15 +7,6 @@ import { execSync } from "child_process";
 // load .env
 dotenv.config();
 
-const deployedServices = [
-  "database",
-  "uploads",
-  "app-api",
-  "ui",
-  "ui-auth",
-  "ui-src",
-];
-
 // Function to update .env files using 1Password CLI
 function updateEnvFiles() {
   try {
@@ -126,46 +117,6 @@ async function run_all_locally() {
   run_fe_locally(runner);
 }
 
-async function deploy_kafka_service(
-  runner: LabeledProcessRunner,
-  stage: string
-) {
-  const kafkaservice = "carts-bigmac-streams";
-  install_deps(runner, kafkaservice);
-  const kafkaDeployCmd = ["sls", "deploy", "--stage", stage];
-  await runner.run_command_and_output(
-    "Kafka service deploy",
-    kafkaDeployCmd,
-    `services/${kafkaservice}`
-  );
-}
-
-async function install_deps(runner: LabeledProcessRunner, service: string) {
-  await runner.run_command_and_output(
-    "Installing Dependencies",
-    ["yarn", "install", "--frozen-lockfile"],
-    `services/${service}`
-  );
-}
-
-async function prepare_services(runner: LabeledProcessRunner) {
-  for (const service of deployedServices) {
-    install_deps(runner, service);
-  }
-}
-
-async function deploy(options: { stage: string }) {
-  const stage = options.stage;
-  const runner = new LabeledProcessRunner();
-  await prepare_services(runner);
-  const deployCmd = ["sls", "deploy", "--stage", stage];
-  await runner.run_command_and_output("SLS Deploy", deployCmd, ".");
-  // Only deploy resources for kafka ingestion in real envs
-  if (stage === "main" || stage === "val" || stage === "production") {
-    deploy_kafka_service(runner, stage);
-  }
-}
-
 async function destroy_stage(options: {
   stage: string;
   service: string | undefined;
@@ -202,14 +153,6 @@ yargs(process.argv.slice(2))
     run_all_locally();
   })
   .command("test", "run all tests", () => {})
-  .command(
-    "deploy",
-    "deploy the app with serverless compose to the cloud",
-    {
-      stage: { type: "string", demandOption: true },
-    },
-    deploy
-  )
   .command(
     "destroy",
     "destroy serverless stage",


### PR DESCRIPTION
Reverts Enterprise-CMCS/macpro-mdct-carts#139679

The deploy action timed out at 6 hours with the last operation stating that it couldn't find the .env file. 

Will attempt to see what we can do to fix this, however, if we need to push something in the mean time we can use this to revert it for now.