### PR TITLE
Swap from react-uuid to uuid

### DIFF
--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -40,7 +40,7 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-searchable-dropdown": "^1.2.5",
-    "react-uuid": "^1.0.2",
+    "uuid": "^10.0.0",
     "redux": "4.2.1",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",

--- a/services/ui-src/src/components/layout/DateRange.jsx
+++ b/services/ui-src/src/components/layout/DateRange.jsx
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { TextField } from "@cmsgov/design-system";
 import PropTypes from "prop-types";
-import uuid from "react-uuid";
+import { v4 as uuidv4 } from "uuid";
 
 /*
  * This method checks that month input is appropriate:
@@ -235,7 +235,7 @@ class DateRange extends Component {
           <div className="errors">
             {startErrorMessage.map((e) => {
               if (e !== undefined) {
-                return <div key={uuid()}> {e} </div>;
+                return <div key={uuidv4()}> {e} </div>;
               }
               return false;
             })}
@@ -278,7 +278,7 @@ class DateRange extends Component {
           <div className="errors">
             {endErrorMessage.map((e) => {
               if (e !== undefined) {
-                return <div key={uuid()}> {e} </div>;
+                return <div key={uuidv4()}> {e} </div>;
               }
               return false;
             })}

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -10405,11 +10405,6 @@ react-transition-group@^4.4.0, react-transition-group@^4.4.2:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-uuid@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/react-uuid/-/react-uuid-1.0.2.tgz#c77cea91cf38eafb1aaa7910f92621b2ed91b969"
-  integrity sha512-5e0GM16uuQj9MdRJlZ0GdLC8LKMwpU9PIqYmF27s3fIV2z+rLyASTaiW4aKzSY4DyGanz+ImzsECkftwGWfAwA==
-
 react@^16.13.1, react@^16.8.6, react@^16.9.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
@@ -11802,6 +11797,11 @@ uuid@3.4.0, uuid@^3.0.0, uuid@^3.2.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
+  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
 uuid@^8.0.0, uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The React-uuid package is deprecated (2 years ago). This updates the package to UUID which is widely used and supported.

I was unable to simply get rid of the uuid packages completely in favor of the internal crypto uuid method as Vite does not support it for browser compatability.

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

- Enter the Alabama CARTS FY2023 Report
- Navigate to Section 2, Question 3
- Answer Yes, and play with the date range component that shows up. Nothing should be out of place or different then before. It should just work and throw no console errors.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
React-uuid -> UUID

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment