### PR TITLE
Migrate TableOfContents Component to use React Hooks

### DIFF
--- a/services/ui-src/src/components/layout/TableOfContents.jsx
+++ b/services/ui-src/src/components/layout/TableOfContents.jsx
@@ -1,132 +1,123 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
+import React from "react";
+import { useLocation, useHistory } from "react-router-dom";
+import { useSelector, shallowEqual } from "react-redux";
+//components
 import { VerticalNav } from "@cmsgov/design-system";
-import { connect } from "react-redux";
-import { withRouter } from "react-router-dom";
+//types
 import { AppRoles } from "../../types";
 
-const idToUrl = (location, id) => {
-  const endOfPath = id.replace(/-/g, "/");
-  if (location.pathname.startsWith("/views/sections")) {
-    const pathChunks = location.pathname.split("/");
-    const base = pathChunks.slice(0, 4).join("/");
-    return `${base}/${endOfPath}`;
-  }
-  return `/sections/${endOfPath}`;
-};
-const subsection = (index) => String.fromCharCode("A".charCodeAt(0) + index);
+const TableOfContents = () => {
+  const [userRole, formYear, formData] = useSelector(
+    (state) => [
+      state.stateUser.currentUser.role,
+      state.global.formYear,
+      state.formData,
+    ],
+    shallowEqual
+  );
 
-class TableOfContents extends Component {
-  constructor(props) {
-    super(props);
-    this.click = this.click.bind(this);
-  }
+  const location = useLocation();
+  const history = useHistory();
 
-  click = (e, _, url) => {
+  const sections = () => {
+    if (formData) {
+      const sections = formData;
+      return sections.map(
+        ({
+          contents: {
+            section: {
+              id: sectionId,
+              ordinal,
+              subsections,
+              title: sectionTitle,
+            },
+          },
+        }) => ({
+          id: sectionId,
+          ordinal,
+          title: sectionTitle,
+          subsections: subsections.map(
+            ({ id: subsectionId, title: subsectionTitle }) => ({
+              id: subsectionId,
+              title: subsectionTitle,
+            })
+          ),
+        })
+      );
+    }
+    return [];
+  };
+
+  const idToUrl = (location, id) => {
+    const endOfPath = id.replace(/-/g, "/");
+    if (location.pathname.startsWith("/views/sections")) {
+      const pathChunks = location.pathname.split("/");
+      const base = pathChunks.slice(0, 4).join("/");
+      return `${base}/${endOfPath}`;
+    }
+    return `/sections/${endOfPath}`;
+  };
+  const subsection = (index) => String.fromCharCode("A".charCodeAt(0) + index);
+
+  const click = (e, _, url) => {
     e.preventDefault();
     e.stopPropagation();
-
-    const { history } = this.props;
 
     history.push(url);
   };
 
-  render() {
-    const { location, sections, userRole, formYear } = this.props;
+  const items = sections()
+    .map(({ id: sectionId, ordinal, subsections, title: sectionTitle }) => ({
+      id: sectionId,
+      items:
+        subsections.length < 2
+          ? null
+          : subsections.map(
+              ({ id: subsectionId, title: subsectionTitle }, i) => ({
+                label: `Section ${ordinal}${subsection(i)}: ${subsectionTitle}`,
+                onClick: click,
+                selected: location.pathname
+                  .toLowerCase()
+                  .startsWith(idToUrl(location, subsectionId).toLowerCase()),
+                url: idToUrl(location, subsectionId),
+              })
+            ),
+      label: ordinal > 0 ? `Section ${ordinal}: ${sectionTitle}` : sectionTitle,
+      onClick: click,
+      selected: location.pathname
+        .toLowerCase()
+        .startsWith(idToUrl(location, sectionId).toLowerCase()),
+    }))
+    .map(({ id, items: childItems, ...rest }) => {
+      const updated = { id, items: childItems, ...rest };
+      if (childItems == null) {
+        updated.url = idToUrl(location, id);
+      }
+      return updated;
+    });
 
-    const items = sections
-      .map(({ id: sectionId, ordinal, subsections, title: sectionTitle }) => ({
-        id: sectionId,
-        items:
-          subsections.length < 2
-            ? null
-            : subsections.map(
-                ({ id: subsectionId, title: subsectionTitle }, i) => ({
-                  label: `Section ${ordinal}${subsection(
-                    i
-                  )}: ${subsectionTitle}`,
-                  onClick: this.click,
-                  selected: location.pathname
-                    .toLowerCase()
-                    .startsWith(idToUrl(location, subsectionId).toLowerCase()),
-                  url: idToUrl(location, subsectionId),
-                })
-              ),
-        label:
-          ordinal > 0 ? `Section ${ordinal}: ${sectionTitle}` : sectionTitle,
-        onClick: this.click,
-        selected: location.pathname
-          .toLowerCase()
-          .startsWith(idToUrl(location, sectionId).toLowerCase()),
-      }))
-      .map(({ id, items: childItems, ...rest }) => {
-        const updated = { id, items: childItems, ...rest };
-        if (childItems == null) {
-          updated.url = idToUrl(location, id);
-        }
-        return updated;
-      });
-
-    // If the user can certify and submit AND the form is not yet submitted...
-    if (userRole === AppRoles.STATE_USER) {
-      items.push({
-        id: "certify-and-submit",
-        label: "Certify and Submit",
-        onClick: this.click,
-        selected:
-          location.pathname === `/sections/${formYear}/certify-and-submit`,
-        url: `/sections/${formYear}/certify-and-submit`,
-      });
-    }
-
-    const foundSelectedId = items.find((item) => item.selected)?.id;
-    return (
-      <div className="toc" data-testid="toc" aria-label="Table of Contents">
-        <VerticalNav
-          selectedId={foundSelectedId}
-          ariaNavLabel="Vertical Navigation Element"
-          items={items}
-        />
-      </div>
-    );
+  // If the user can certify and submit AND the form is not yet submitted...
+  if (userRole === AppRoles.STATE_USER) {
+    items.push({
+      id: "certify-and-submit",
+      label: "Certify and Submit",
+      onClick: click,
+      selected:
+        location.pathname === `/sections/${formYear}/certify-and-submit`,
+      url: `/sections/${formYear}/certify-and-submit`,
+    });
   }
-}
-TableOfContents.propTypes = {
-  history: PropTypes.object.isRequired,
-  location: PropTypes.object.isRequired,
-  sections: PropTypes.array.isRequired,
-  userRole: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]).isRequired,
-  formYear: PropTypes.number.isRequired,
+
+  const foundSelectedId = items.find((item) => item.selected)?.id;
+  return (
+    <div className="toc" data-testid="toc" aria-label="Table of Contents">
+      <VerticalNav
+        selectedId={foundSelectedId}
+        ariaNavLabel="Vertical Navigation Element"
+        items={items}
+      />
+    </div>
+  );
 };
 
-const selectSectionsForNav = (state) => {
-  if (state.formData) {
-    const sections = state.formData;
-    return sections.map(
-      ({
-        contents: {
-          section: { id: sectionId, ordinal, subsections, title: sectionTitle },
-        },
-      }) => ({
-        id: sectionId,
-        ordinal,
-        title: sectionTitle,
-        subsections: subsections.map(
-          ({ id: subsectionId, title: subsectionTitle }) => ({
-            id: subsectionId,
-            title: subsectionTitle,
-          })
-        ),
-      })
-    );
-  }
-  return [];
-};
-
-const mapStateToProps = (state) => ({
-  sections: selectSectionsForNav(state),
-  userRole: state.stateUser.currentUser.role,
-  formYear: state.global.formYear,
-});
-
-export default connect(mapStateToProps)(withRouter(TableOfContents));
+export default TableOfContents;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
As part of an larger dependency upgrade to React-Router, I'll be updating code slowly overtime to use React hooks where possible throughout the code. This is because React-Redux and React-Router are both pushing towards using hooks and will stop or have stopped supporting older methods. Thus, to make this transition easier and to make sure we're on keeping our code up to date, I'll be going through where possible to make these updates.

This Second PR updates the Table of Contents component and does the following:

1. Updates the component from using a class structure to a functional component structure
2. Updates the react-router-dom call to the location to use the associated hook
3. Updates the react-redux state calls to use the useSelector hook

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Run the application
Play around with the Table of contents in the report. See that you can navigate to the various report pages, it opens up the sub contents when clicking on a section with child links, and it lets you go to the certify submit page as a state user

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary
