### PR TITLE
Remove the react-uuid package in favor of builtins

### DIFF
--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -40,7 +40,6 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-searchable-dropdown": "^1.2.5",
-    "react-uuid": "^1.0.2",
     "redux": "4.2.1",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",

--- a/services/ui-src/src/components/layout/DateRange.jsx
+++ b/services/ui-src/src/components/layout/DateRange.jsx
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { TextField } from "@cmsgov/design-system";
 import PropTypes from "prop-types";
-import uuid from "react-uuid";
 
 /*
  * This method checks that month input is appropriate:
@@ -235,7 +234,7 @@ class DateRange extends Component {
           <div className="errors">
             {startErrorMessage.map((e) => {
               if (e !== undefined) {
-                return <div key={uuid()}> {e} </div>;
+                return <div key={crypto.randomUUID()}> {e} </div>;
               }
               return false;
             })}
@@ -278,7 +277,7 @@ class DateRange extends Component {
           <div className="errors">
             {endErrorMessage.map((e) => {
               if (e !== undefined) {
-                return <div key={uuid()}> {e} </div>;
+                return <div key={crypto.randomUUID()}> {e} </div>;
               }
               return false;
             })}

--- a/services/ui-src/src/setupTests.js
+++ b/services/ui-src/src/setupTests.js
@@ -32,6 +32,8 @@ Object.defineProperty(window, "matchMedia", {
   })),
 });
 
+Object.defineProperty(window, "crypto", { value: require("node:crypto") });
+
 jest.mock("./util/constants", () => ({
   MODE: "production",
   BASE_URL: "mdctcartsdev.cms.gov",

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -10405,11 +10405,6 @@ react-transition-group@^4.4.0, react-transition-group@^4.4.2:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-uuid@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/react-uuid/-/react-uuid-1.0.2.tgz#c77cea91cf38eafb1aaa7910f92621b2ed91b969"
-  integrity sha512-5e0GM16uuQj9MdRJlZ0GdLC8LKMwpU9PIqYmF27s3fIV2z+rLyASTaiW4aKzSY4DyGanz+ImzsECkftwGWfAwA==
-
 react@^16.13.1, react@^16.8.6, react@^16.9.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The React-uuid package is deprecated (2 years ago). This removes that and replaces it with the internal crypto package.

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

- Enter the Alabama CARTS FY2023 Report
- Navigate to Section 2, Question 3
- Answer Yes, and play with the date range component that shows up. Nothing should be out of place or different then before. It should just work and throw no console errors.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
React-uuid -> ----

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment