### PR TITLE
Deploy Runner - handle Serverless Compose errors

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -104,6 +104,10 @@ export default class LabeledProcessRunner {
       proc.on("close", (code) => {
         const paddedPrefix = this.formattedPrefix(prefix);
         process.stdout.write(`${paddedPrefix} Exit: ${code}\n`);
+        if (code != 0) {
+          reject(code);
+          return;
+        }
         resolve();
       });
     });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Serverless compose gracefully exits with code 1 on error, thus not tripping the .error() catch in the runner. Add an extra catch for all non-success codes.

This was causing false successes in the deploy step, while logs of errors existed.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
This was tested in the HCBS repo:
- This action should have failed with an invalid ssm param: https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/actions/runs/9859930365
- This action should succeed normally: https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/actions/runs/9860132356

The logging has been adjusted slightly since the first test.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
