### PR TITLE
remove underscore dependency from yarn lock

### DIFF
--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -10787,11 +10787,6 @@ underscore@1.12.1:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
   integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
 
-underscore@^1.11.0:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.2.tgz#276cea1e8b9722a8dbed0100a407dda572125881"
-  integrity sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==
-
 unfetch@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
[Another PR](https://github.com/Enterprise-CMCS/macpro-mdct-carts/pull/139684) removed the package.json and code references to `underscore`. 

This removes underscore from yarn.lock as well.

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Nothing breaks in the build
You can run CARTS locally or in the deployed branch

https://d289z0vjr9482c.cloudfront.net/

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
