### PR TITLE
Move SaveError to redux hooks

### DIFF
--- a/services/ui-src/src/components/fields/Autosave.jsx
+++ b/services/ui-src/src/components/fields/Autosave.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Button } from "@cmsgov/design-system";
 
 const Autosave = () => (

--- a/services/ui-src/src/components/fields/Autosave.jsx
+++ b/services/ui-src/src/components/fields/Autosave.jsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Button } from "@cmsgov/design-system";
 
 const Autosave = () => (

--- a/services/ui-src/src/components/layout/SaveError.jsx
+++ b/services/ui-src/src/components/layout/SaveError.jsx
@@ -1,11 +1,11 @@
 import { Alert } from "@cmsgov/design-system";
 import React, { useEffect, useState } from "react";
-import { shallowEqual, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 // utils
 import { selectHasError } from "../../store/save.selectors";
 
 const SaveError = () => {
-  const saveError = useSelector((state) => selectHasError(state), shallowEqual);
+  const saveError = useSelector((state) => selectHasError(state));
   const [showSaveErrorAlert, setShowErrorAlert] = useState(saveError);
 
   useEffect(() => {

--- a/services/ui-src/src/components/layout/SaveError.jsx
+++ b/services/ui-src/src/components/layout/SaveError.jsx
@@ -1,10 +1,11 @@
 import { Alert } from "@cmsgov/design-system";
-import PropTypes from "prop-types";
-import React, { useEffect, useState } from "react";
-import { connect } from "react-redux";
+import { useEffect, useState } from "react";
+import { shallowEqual, useSelector } from "react-redux";
+// utils
 import { selectHasError } from "../../store/save.selectors";
 
-const SaveError = ({ saveError }) => {
+const SaveError = () => {
+  const saveError = useSelector((state) => selectHasError(state), shallowEqual);
   const [showSaveErrorAlert, setShowErrorAlert] = useState(saveError);
 
   useEffect(() => {
@@ -46,12 +47,4 @@ const SaveError = ({ saveError }) => {
   );
 };
 
-SaveError.propTypes = {
-  hasError: PropTypes.bool.isRequired,
-};
-
-const mapStateToProps = (state) => ({
-  saveError: selectHasError(state),
-});
-
-export default connect(mapStateToProps)(SaveError);
+export default SaveError;

--- a/services/ui-src/src/components/layout/SaveError.jsx
+++ b/services/ui-src/src/components/layout/SaveError.jsx
@@ -1,5 +1,5 @@
 import { Alert } from "@cmsgov/design-system";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { shallowEqual, useSelector } from "react-redux";
 // utils
 import { selectHasError } from "../../store/save.selectors";

--- a/services/ui-src/src/styles/_alerts.scss
+++ b/services/ui-src/src/styles/_alerts.scss
@@ -14,8 +14,8 @@
   z-index: 9;
 
   &.alert--unexpected-error__active {
-    top: 60px;
-    margin-top: 0;
+    position: sticky;
+    margin-top: 20px;
   }
 
   .flex {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Migrate redux `connect` pattern to `useSelector` hook

If anyone knows how to fix the styling let me know. Right now the error banner runs to the right edge of the window.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3814

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://def61orvrftr6.cloudfront.net/
- Log in as a state user
- Enter any in progress report
- Change something and verify it saves
- Turn your wifi off
- Change something on the page and verify it throws an error when it tries to save
- Turn your wifi back on and verify the error disappears on its own once a save succeeds

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment