### PR TITLE
Remove unused redux code from HomeAdmin component

### DIFF
--- a/services/ui-src/src/components/layout/HomeAdmin.jsx
+++ b/services/ui-src/src/components/layout/HomeAdmin.jsx
@@ -1,13 +1,13 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { Link, Route } from "react-router-dom";
+import { Switch } from "react-router";
+// components
 import FormTemplates from "./FormTemplates";
 import CMSHomepage from "../sections/homepage/CMSHomepage";
-import InvokeSection from "../utils/InvokeSection";
 import Sidebar from "./Sidebar";
-import { Switch } from "react-router";
+// utils
+import InvokeSection from "../utils/InvokeSection";
 import ScrollToTop from "../utils/ScrollToTop";
-import { connect } from "react-redux";
 
 const AdminHome = () => {
   return (
@@ -52,13 +52,5 @@ const AdminHome = () => {
     </>
   );
 };
-AdminHome.propTypes = {
-  formYear: PropTypes.object.isRequired,
-};
 
-export const mapStateToProps = (state) => ({
-  currentUser: state.stateUser.currentUser,
-  formYear: state.global.formYear,
-});
-
-export default connect(mapStateToProps)(AdminHome);
+export default AdminHome;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Remove unused props from HomeAdmin page and organize imports

From what I could tell those props aren't necessary unless they're directly referenced in the file, right?

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3812

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://d167gqg8l0373p.cloudfront.net/
- Log in as an admin user `cms.admin@test.com`
- Verify the admin home page looks normal and matches https://mdctcartsdev.cms.gov/

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment