### PR TITLE
Remove withRouter in favor of history hook

### DIFF
--- a/services/ui-src/src/components/utils/ScrollToTop.js
+++ b/services/ui-src/src/components/utils/ScrollToTop.js
@@ -1,11 +1,11 @@
 import { useEffect } from "react";
-import { withRouter } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 
-function ScrollToTop({ history }) {
+function ScrollToTop() {
+  let history = useHistory();
   useEffect(() => {
     const unlisten = history.listen(() => {
       window.scrollTo(0, 0);
-
       // Remove focus from clicked button
       document.activeElement.blur();
     });
@@ -17,4 +17,4 @@ function ScrollToTop({ history }) {
   return null;
 }
 
-export default withRouter(ScrollToTop);
+export default ScrollToTop;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This simply removes the withRouter call and replaces it with useHistory hook in the scrollToTop component!

Example of it working while I'm logged in as a Help desk user (help.desk@test.com)

https://github.com/user-attachments/assets/e300ae86-7fa4-4dca-932f-566208680a41


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3816

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Log in as a help desk user
Enter a report
Scroll down
Click on something in the side panel
See that you're now at the top of the page & the highlight is gone from the link you clicked!

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Product: This work has been reviewed and approved by product owner, if necessary
