### PR TITLE
Update Spinner to use useSelector

### DIFF
--- a/services/ui-src/src/components/utils/Spinner.jsx
+++ b/services/ui-src/src/components/utils/Spinner.jsx
@@ -1,30 +1,22 @@
 import React from "react";
-import { connect } from "react-redux";
-import PropTypes from "prop-types";
+import { useSelector } from "react-redux";
 
-const Spinner = (props) => {
-  const { isFetching } = props;
+const Spinner = () => {
+  const isFetching = useSelector((state) => state.global.isFetching);
 
-  return isFetching ? (
-    <div className="preloader">
-      <div className="preloader-image">
-        <img
-          data-testid="spinner-img"
-          src={`/img/spinner.gif`}
-          alt="Loading. Please wait."
-        />
+  return (
+    isFetching && (
+      <div className="preloader">
+        <div className="preloader-image">
+          <img
+            data-testid="spinner-img"
+            src={`/img/spinner.gif`}
+            alt="Loading. Please wait."
+          />
+        </div>
       </div>
-    </div>
-  ) : null;
+    )
+  );
 };
 
-Spinner.propTypes = {
-  isFetching: PropTypes.bool.isRequired,
-};
-const mapStateToProps = (state) => {
-  return {
-    isFetching: state.global.isFetching,
-  };
-};
-
-export default connect(mapStateToProps)(Spinner);
+export default Spinner;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Move props mapper to `useSelector`

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3815

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://d3mufvlod759if.cloudfront.net/
- Log in as a state user
- Enter any report
- The Spinner should show while the report is loading and then disappear once it's loaded
- Change something on the report
- Verify the spinner shows in the saving banner (apparently they are the same spinner?!)
- If it's not showing up for you you can run locally and remove the `isFetching &&` condition. The spinner will now run over the page until you change it back

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary
