### PR TITLE
Reduce flakiness for uncertify unit test

### DIFF
--- a/services/app-api/handlers/stateStatus/tests/uncertify.test.ts
+++ b/services/app-api/handlers/stateStatus/tests/uncertify.test.ts
@@ -37,6 +37,7 @@ describe("Test Uncertify CARTS Report Handler", () => {
       .toString()
       .replace("(", "\\(")
       .replace(")", "\\)")
+      .replace("+", "\\+")
       .replace(/(?<=\d{2}:\d{2}:)\d{2}/, "..");
 
     expect(res.statusCode).toBe(200);


### PR DESCRIPTION
### Description
We very occasionally see failures from the uncertify unit tests, because a second ticks over while the test is in progress.

Let's not have those failures.

### Related ticket(s)
n/a

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
