### PR TITLE
Fix child questions not showing in section 3

### DIFF
--- a/services/ui-src/src/components/fields/Question.jsx
+++ b/services/ui-src/src/components/fields/Question.jsx
@@ -152,13 +152,13 @@ const Question = ({ hideNumber, question, prevYear, tableTitle, ...props }) => {
              not, then its children shouldn't be indented either. */}
         {shouldRenderChildren && (
           <div className="ds-c-choice__checkedChild">
-            {question.questions.map((q) => {
+            {question.questions.map((q) => (
               <Question
-                key={crypto.randomUUID()}
+                key={q?.id || crypto.randomUUID()}
                 question={q}
                 setAnswer={setAnswerEntry}
-              />;
-            })}
+              />
+            ))}
           </div>
         )}
       </Container>

--- a/services/ui-src/src/components/fields/Question.jsx
+++ b/services/ui-src/src/components/fields/Question.jsx
@@ -153,11 +153,7 @@ const Question = ({ hideNumber, question, prevYear, tableTitle, ...props }) => {
         {shouldRenderChildren && (
           <div className="ds-c-choice__checkedChild">
             {question.questions.map((q) => (
-              <Question
-                key={q?.id || crypto.randomUUID()}
-                question={q}
-                setAnswer={setAnswerEntry}
-              />
+              <Question key={q.id} question={q} setAnswer={setAnswerEntry} />
             ))}
           </div>
         )}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
I dont wanna talk about it. Just know it goes from this:

![Screenshot 2024-07-31 at 2 35 23 PM](https://github.com/user-attachments/assets/a3dd532c-9c8b-4e71-a13a-aaf6300db810)


To this:
![image](https://github.com/user-attachments/assets/bfe3d09b-e1c8-4d91-b0fb-563455aa6719)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3811

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Open a report and navigate to Section 3c.
See that the child questions in Parts 2-4 show multiple new questions. Youll see it for Part 2 Question 3, Part 3 Question 4, and Part 4 Question 4. The answers here will also populate the tables underneath each individual part.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
- [ ] Product: This work has been reviewed and approved by product owner, if necessary
