### PR TITLE
remove references to branch master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
       - "!skipci*"
 
 concurrency:
-  # Ensuring group key matches the destroy workflow currently in master
+  # Ensuring group key matches the destroy workflow currently in main
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: false
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/f1775f53aedf747e85b2/maintainability)](https://codeclimate.com/repos/6449718c21275100df510ea9/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/f1775f53aedf747e85b2/test_coverage)](https://codeclimate.com/repos/6449718c21275100df510ea9/test_coverage)
 
-### Integration Environment Deploy Status:
+## Integration Environment Deploy Status:
 | Branch  | Build Status |
 | ------------- | ------------- |
 | main  | ![deploy](https://github.com/Enterprise-CMCS/macpro-mdct-carts/actions/workflows/deploy.yml/badge.svg)  |
@@ -16,7 +16,7 @@ CARTS is the CMCS MDCT application for collecting state data related to coverage
 
 Under section 2108(a) of the Act, states must assess the operation of their separate CHIP and Medicaid expansion programs and the progress made in reducing the number of uncovered, low-income children. The results of the assessment are reported to the Secretary by January 1 following the end of the FY in the CHIP Annual Reporting Template System (CARTS). CARTS collects information about programmatic changes, performance goals, program operation, program financing, program challenges and accomplishments.
 
-_Note: The [`main`](https://github.com/Enterprise-CMCS/macpro-mdct-carts/tree/main) branch contains CARTSv3. All code related to CARTSv2 (legacy) can be found in the [`master`](https://github.com/Enterprise-CMCS/macpro-mdct-carts/tree/master) branch._
+_Note: The [`main`](https://github.com/Enterprise-CMCS/macpro-mdct-carts/tree/main) branch contains CARTSv3. All code related to CARTSv2 (legacy) can be found in the [`skipci-archive-master`](https://github.com/Enterprise-CMCS/macpro-mdct-carts/tree/skipci-archive-master) branch._
 
 ## Table of contents
 
@@ -115,10 +115,7 @@ On the SEDS side, this topic is updated on every submission of seds data, but CA
 - 4th quarter data.
 - The rollover for a "new year" is October, and future submissions are not recognized until that threshold
 
-Updates outside of that time frame will need to be manually corrected in CARTS, or the integration will need to be modifed to collect data for old forms. CARTS additionally looks for the `enrollmentCounts` property which is only included in forms 21E and 64.21E (question 7), either by manual trigger or update. See SEDS files:
-
-- [generateEnrollmentTotals](https://github.com/Enterprise-CMCS/macpro-mdct-seds/blob/master/services/app-api/handlers/state-forms/post/generateEnrollmentTotals.js)
-- [updateStateForms](https://github.com/Enterprise-CMCS/macpro-mdct-seds/blob/master/services/app-api/handlers/state-forms/post/updateStateForms.js)
+Updates outside of that time frame will need to be manually corrected in CARTS, or the integration will need to be modifed to collect data for old forms. CARTS additionally looks for the `enrollmentCounts` property which is only included in forms 21E and 64.21E (question 7), either by manual trigger or update.
 
 For testing convenience, stateuser2 points at AL in CARTS and the stateuser points at AL in SEDS.
 

--- a/services/carts-bigmac-streams/serverless.yml
+++ b/services/carts-bigmac-streams/serverless.yml
@@ -19,14 +19,10 @@ custom:
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
   serverlessTerminationProtection:
-    stages: # This is a list of common names for important envs that should not be destroyed. You can remove the stage names your project doesn't use; this list is meant to be inclusive.
-      - master
+    stages:
+      - main
       - val
       - production
-      - develop
-      - main
-      - impl
-      - prod
   kafkaConnectImage: ${ssm:/configuration/${self:custom.stage}/kafka_connect_image, ssm:/configuration/default/kafka_connect_image,"confluentinc/cp-kafka-connect:6.2.0"}
   bootstrapBrokerStringTls: ${ssm:/configuration/${self:custom.stage}/bigmac/bootstrapBrokerStringTls, ssm:/configuration/default/bigmac/bootstrapBrokerStringTls}
   vpcId: ${ssm:/configuration/${self:custom.stage}/vpc/id, ssm:/configuration/default/vpc/id}

--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -21,7 +21,6 @@ custom:
   serverlessTerminationProtection:
     stages:
       - main
-      - master
       - val
       - production
   acsTableName: ${self:custom.stage}-acs

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -42,7 +42,6 @@ custom:
   serverlessTerminationProtection:
     stages:
       - main
-      - master
       - val
       - production
   sesSourceEmailAddress: ${ssm:/configuration/${self:custom.stage}/sesSourceEmailAddress, ssm:/configuration/default/sesSourceEmailAddress, ""}

--- a/services/ui-src/serverless.yml
+++ b/services/ui-src/serverless.yml
@@ -29,7 +29,6 @@ custom:
   serverlessTerminationProtection:
     stages:
       - main
-      - master
       - val
       - production
   api_region: ${param:ApiRegion}

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -46,7 +46,6 @@ custom:
   serverlessTerminationProtection:
     stages:
       - main
-      - master
       - val
       - production
   scripts:


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The `master` branch of CARTS holds what we call CARTS v2. It uses a different pattern and infrastructure than the rest of our MDCT suite. Two years ago we migrated to `main` (CARTS v3). All of our dev infrastructure and code promoted to prod comes from `main`

`master` has been copied to `skipci-archive-master`

We need to remove any references to master in the code so as to avoid errors and confusion.

Once this is merged, github settings are updated, and we've determined it's safe to do so, we will delete the branch named `master`

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3804

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
See if you can find any more references that need to be updated.

Verify CARTS works as expected https://d13roq1oz0l6c0.cloudfront.net/

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
Someone with higher permissions will need to remove branch protections and any other git configuration on master

🤔 can you think of a better archived branch name? `skipci-archive-carts-v2`? Also how long do we anticipate keeping this, and for what purpose? I imagine the drift is already large enough that it may not be helpful to reference the old master branch.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] ~I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment