### PR TITLE
Convert Stateheader to functional component

### DIFF
--- a/services/ui-src/src/components/layout/StateHeader.jsx
+++ b/services/ui-src/src/components/layout/StateHeader.jsx
@@ -1,27 +1,21 @@
 import React from "react";
-import PropTypes from "prop-types";
-import { connect } from "react-redux";
+import { useSelector } from "react-redux";
 
-const StateHeader = ({ imageURI, name }) => (
-  <div
-    className="state-header"
-    data-testid="state-header"
-    aria-label="State Header"
-  >
-    <div className="state-image">
-      <img src={imageURI} alt={name} />
+const StateHeader = () => {
+  const { name, imageURI } = useSelector((state) => state.stateUser);
+
+  return (
+    <div
+      className="state-header"
+      data-testid="state-header"
+      aria-label="State Header"
+    >
+      <div className="state-image">
+        <img src={imageURI} alt={name} />
+      </div>
+      <div className="state-name">{name}</div>
     </div>
-    <div className="state-name">{name}</div>
-  </div>
-);
-StateHeader.propTypes = {
-  imageURI: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
+  );
 };
 
-const mapStateToProps = (state) => ({
-  name: state.stateUser.name,
-  imageURI: state.stateUser.imageURI,
-});
-
-export default connect(mapStateToProps)(StateHeader);
+export default StateHeader;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This migrates the Section header component. Specifically, this changes the following:

* Removes the connect property
* Uses hooks to fetch state

![Screenshot 2024-08-12 at 12 25 45 PM](https://github.com/user-attachments/assets/7a7eedbf-3901-4f77-aaac-dd3788640135)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3813

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Enter a report
See that the image and name of the state in the left hand navigation show and are set properly!

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Product: This work has been reviewed and approved by product owner, if necessary