### PR TITLE
Convert FormActions to use hooks

### DIFF
--- a/services/ui-src/src/components/layout/FormActions.jsx
+++ b/services/ui-src/src/components/layout/FormActions.jsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useRef } from "react";
+import { useSelector, shallowEqual } from "react-redux";
+// components
 import { Button } from "@cmsgov/design-system";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPrint, faWindowClose } from "@fortawesome/free-solid-svg-icons";
-import { connect } from "react-redux";
-import PropTypes from "prop-types";
+//types
 import { AppRoles } from "../../types";
 
 /**
@@ -12,10 +13,14 @@ import { AppRoles } from "../../types";
  * @returns {JSX.Element}
  * @constructor
  */
-const FormActions = (props) => {
+const FormActions = () => {
+  const [currentUser, formYear] = useSelector(
+    (state) => [state.stateUser.currentUser, state.global.formYear],
+    shallowEqual
+  );
+
   // Initialise printDialogeRef
   const printDialogeRef = useRef(null);
-  const { currentUser, formYear } = props;
 
   // Get section IDs and subsection IDs for printing single section
   let searchParams = document.location.pathname
@@ -103,6 +108,7 @@ const FormActions = (props) => {
 
   return (
     <section className="action-buttons">
+      <h1> This is the form action button!</h1>
       <div className="print-button">
         <Button
           className="ds-c-button--primary ds-c-button--small"
@@ -163,15 +169,4 @@ const FormActions = (props) => {
   );
 };
 
-FormActions.propTypes = {
-  currentUser: PropTypes.object.isRequired,
-  formYear: PropTypes.number.isRequired,
-};
-
-export const mapStateToProps = (state) => ({
-  currentUser: state.stateUser.currentUser,
-  formYear: state.global.formYear,
-  printType: state.global.printType,
-});
-
-export default connect(mapStateToProps)(FormActions);
+export default FormActions;

--- a/services/ui-src/src/components/layout/FormActions.jsx
+++ b/services/ui-src/src/components/layout/FormActions.jsx
@@ -108,7 +108,6 @@ const FormActions = () => {
 
   return (
     <section className="action-buttons">
-      <h1> This is the form action button!</h1>
       <div className="print-button">
         <Button
           className="ds-c-button--primary ds-c-button--small"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This migrates the Form Actions component. Specifically, this changes the following:

Removes the connect property
Uses hooks to fetch state

![Screenshot 2024-08-05 at 11 50 32 PM](https://github.com/user-attachments/assets/9b793b1a-b7cd-45a6-bee7-0b0d58c86765)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3813

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Form actions is actually the button at the bottom of the report section for a user to enter print mode. So to test:

Enter a report
Click the Print button
Enter a print and see that it does open the print page
Come back and try to other option
See that it all works!

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Product: This work has been reviewed and approved by product owner, if necessary
