### PR TITLE
Convert FormNavigation to use hooks

### DIFF
--- a/services/ui-src/src/components/layout/FormNavigation.jsx
+++ b/services/ui-src/src/components/layout/FormNavigation.jsx
@@ -93,7 +93,6 @@ const FormNavigation = () => {
 
   return (
     <section className="nav-buttons">
-      <h1> vvvv Here fammmmmm vvvv </h1>
       <div className="ds-l-row">
         <div className="ds-l-col form-buttons">
           {previousUrl ? (

--- a/services/ui-src/src/components/layout/FormNavigation.jsx
+++ b/services/ui-src/src/components/layout/FormNavigation.jsx
@@ -1,17 +1,28 @@
 import React from "react";
-import PropTypes from "prop-types";
+import { useSelector, shallowEqual } from "react-redux";
+import { useHistory, useLocation } from "react-router-dom";
+
+//components
 import { Button } from "@cmsgov/design-system";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleLeft, faAngleRight } from "@fortawesome/free-solid-svg-icons";
-import { connect } from "react-redux";
-import { withRouter } from "react-router-dom";
+//selectors
 import { selectSectionsForNav } from "../../store/selectors";
+//types
 import { AppRoles } from "../../types";
 
 const idToUrl = (id) => `/sections/${id.replace(/-/g, "/")}`;
 
-const FormNavigation = (props) => {
-  const { history, location, sections, role } = props;
+const FormNavigation = () => {
+  const history = useHistory();
+  const location = useLocation();
+
+  const [formData, role] = useSelector(
+    (state) => [state.formData, state.stateUser?.currentUser?.role],
+    shallowEqual
+  );
+
+  const sections = selectSectionsForNav(formData);
 
   const items = [];
   sections.forEach((section) => {
@@ -82,6 +93,7 @@ const FormNavigation = (props) => {
 
   return (
     <section className="nav-buttons">
+      <h1> vvvv Here fammmmmm vvvv </h1>
       <div className="ds-l-row">
         <div className="ds-l-col form-buttons">
           {previousUrl ? (
@@ -120,16 +132,4 @@ const FormNavigation = (props) => {
   );
 };
 
-FormNavigation.propTypes = {
-  history: PropTypes.object.isRequired,
-  location: PropTypes.object.isRequired,
-  sections: PropTypes.array.isRequired,
-  role: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]).isRequired,
-};
-
-const mapStateToProps = (state) => ({
-  sections: selectSectionsForNav(state),
-  role: state.stateUser?.currentUser?.role,
-});
-
-export default connect(mapStateToProps)(withRouter(FormNavigation));
+export default FormNavigation;

--- a/services/ui-src/src/store/selectors.js
+++ b/services/ui-src/src/store/selectors.js
@@ -122,10 +122,9 @@ export const selectQuestionsForPart = (state, partId) => {
   return filteredQuestions;
 };
 
-export const selectSectionsForNav = (state) => {
-  if (state.formData) {
-    const sections = state.formData;
-    return sections.map(
+export const selectSectionsForNav = (formData) => {
+  if (formData) {
+    return formData.map(
       ({
         contents: {
           section: { id, ordinal, subsections, title },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This migrates the Form Navigation component. Specifically, this changes the following:

- Removes the connect property
- Uses hooks to fetch state
- Calls react-router-dom hooks to fetch history and location

![Screenshot 2024-08-06 at 12 05 32 AM](https://github.com/user-attachments/assets/bac5d914-338a-499f-b04b-8dcc53ddac06)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3813

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Form actions is actually the button at the bottom of the report section for a user to enter print mode. So to test:

Enter a report
Scroll down and click the "Next" button
Scroll down and click the "Previous" button
See that it all works!

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Product: This work has been reviewed and approved by product owner, if necessary
