### PR TITLE
Script to remove readonly fields in Section 3c

### DIFF
--- a/services/database/scripts/remove-readonly-in-section-3c.js
+++ b/services/database/scripts/remove-readonly-in-section-3c.js
@@ -1,0 +1,99 @@
+/* eslint-disable no-console */
+/*
+ * Local:
+ *    `DYNAMODB_URL="http://localhost:8000" dynamoPrefix="local" node services/database/scripts/remove-readonly-in-section-3c.js`
+ *  Branch:
+ *    dynamoPrefix="YOUR BRANCH NAME" node services/database/scripts/remove-readonly-in-section-3c.js
+ */
+
+const { buildDynamoClient, scan, update } = require("./utils/dynamodb.js");
+
+const isLocal = !!process.env.DYNAMODB_URL;
+
+const sectionTable = isLocal
+  ? "local-section"
+  : process.env.dynamoPrefix + "-section";
+
+async function handler() {
+  try {
+    console.log("Searching for 2023 Forms");
+
+    buildDynamoClient();
+
+    console.log(`Processing table ${sectionTable}`);
+    const existingItems = await scan({
+      TableName: sectionTable,
+    });
+    const filteredItems = filter(existingItems);
+    const transformedItems = await transform(filteredItems);
+    await update(sectionTable, transformedItems);
+    console.log(`Touched ${transformedItems.length} in table ${sectionTable}`);
+    console.debug("Data fix complete");
+
+    return {
+      statusCode: 200,
+      body: "All done!",
+    };
+  } catch (err) {
+    console.error(err);
+    return {
+      statusCode: 500,
+      body: err.message,
+    };
+  }
+}
+
+function filter(items) {
+  return items.filter((item) => item.year === 2023 && item.sectionId === 3);
+}
+
+async function transform(items) {
+  // Touch sync field only
+  const transformed = items.map((section) => {
+    console.log("Transforming section!", section);
+    return updateSection3(section);
+  });
+
+  return transformed;
+}
+
+const updateSection3 = (section) => {
+  section.contents.section.subsections[2].parts.map((part) => {
+    return recurseAndUpdateQuestions(part.questions, section.pk);
+  });
+  return section;
+};
+
+const recurseAndUpdateQuestions = (questions, reportBeingTransformed) => {
+  const fieldstoRemoveReadonly = [
+    "2023-03-c-05-19-a",
+    "2023-03-c-06-10-a",
+    "2023-03-c-06-11-a",
+    "2023-03-c-06-12-a",
+    "2023-03-c-06-13-a",
+    "2023-03-c-06-14-a",
+    "2023-03-c-06-15-a",
+    "2023-03-c-06-16-a",
+    "2023-03-c-06-17-a",
+    "2023-03-c-06-18-a",
+    "2023-03-c-06-19-a",
+  ];
+  for (let question of questions) {
+    if (
+      fieldstoRemoveReadonly.includes(question?.id) &&
+      question?.answer?.readonly
+    ) {
+      console.log(
+        reportBeingTransformed,
+        "Found and deleting readonly field from question",
+        question.id
+      );
+      delete question.answer.readonly;
+    }
+    if (question?.questions) {
+      recurseAndUpdateQuestions(question.questions, reportBeingTransformed);
+    }
+  }
+};
+
+handler();


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

We've received reports that in Section 3c, Questions 19a of Part 5 and Questions 10a-19a of Part 6 have been unable to have data entered into them. Looking into this, it seems that this is because of a readonly error. The base form that generated the 2023 forms for each state had a readonly tag on each of these fields. So, this script goes through all of the generated forms for 2023 and looks specifically for these questions and removes the readonly tag from them. This will allow users to enter their data. You can see the before and after in the attached video here:

https://github.com/user-attachments/assets/32c55f4f-d820-45a1-8e87-abe84ded2ac5

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

- `./run local` (To ensure a brand new, seeded database)
- In a new terminal run `DYNAMO_ENDPOINT=http://localhost:8000 dynamodb-admin` after the local environment has fully spun up.
- Navigate to localhost:8001 to see the local instance of dynamo.
- Confirm that for the report AL-2023, Section 3 that there are indeed 11 readonly fields.
- Navigate to localhost:3000
- Sign in as stateuser2
- Enter the 2023 report
- Navigate to Section 3c
- Click "No" for question 1 in Part 5
- See that question 19a in Part 5 is disabled
- Click "No" for quesiton 1 in Part 6
- See that question 10a-19a in Part 6 is disabled
- In a new terminal, run `DYNAMODB_URL="http://localhost:8000" dynamoPrefix="local" node services/database/scripts/update-section-3.js`
- Reload the 2023 report
- Navigate to Section 3c
- See that question 19a in Part 5 is enabled
- See that question 10a-19a in Part 6 is enabled
- Navigate to localhost:8001 to see the local instance of dynamo.
- Confirm that for the report AL-2023, Section 3 that there are indeed 0 readonly fields.

Extra Credit
- Logout and sign in as an admin (cms.admin@test.com)
- Open the 2023 report and navigate to Section 3c
- See that all the fields (Part 5 19a and Part 6 10a-19a) are correctly disabled from editing

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
Updates the AWS-sdk in the database to 3.629 from 3.621

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Product: This work has been reviewed and approved by product owner, if necessary
