### PR TITLE
Remove Section 3cs readonly fields when seeding

### DIFF
--- a/services/database/data/seed-local/seed-section.json
+++ b/services/database/data/seed-local/seed-section.json
@@ -4896,8 +4896,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -5648,8 +5647,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -5744,8 +5742,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -5840,8 +5837,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -5937,8 +5933,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -6033,8 +6028,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -6136,8 +6130,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -6232,8 +6225,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -6328,8 +6320,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -6425,8 +6416,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -6521,8 +6511,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {

--- a/services/database/data/seed/seed-section-base-2023.json
+++ b/services/database/data/seed/seed-section-base-2023.json
@@ -4888,8 +4888,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -5640,8 +5639,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -5736,8 +5734,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -5832,8 +5829,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -5929,8 +5925,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -6025,8 +6020,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -6128,8 +6122,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -6224,8 +6217,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -6320,8 +6312,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -6417,8 +6408,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {
@@ -6513,8 +6503,7 @@
                         "type": "integer",
                         "label": "Total for all ages (0-16)",
                         "answer": {
-                          "entry": null,
-                          "readonly": true
+                          "entry": null
                         },
                         "context_data": {
                           "conditional_display": {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Since we're getting rid of the readonly fields in Section 3c Parts 5 and 6 on the live versions, it only makes sense to get rid of it showing up when seeding either the local db or a future db verison. Thus, this PR does just that!

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Enter the 2023 report as stateuser2
Navigate to Section 3C Part 5
See question 19 allows for data entry
Scroll to Part 6 Questions 10-19
See those questions allow for data entry
Enter data into them, navigate away, come back and see the answers are still there.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Product: This work has been reviewed and approved by product owner, if necessary
