### PR TITLE
prevent icon and text overlap before style change before 768px

### DIFF
--- a/services/ui-src/src/styles/_main.scss
+++ b/services/ui-src/src/styles/_main.scss
@@ -309,6 +309,9 @@ img {
           padding: ($padding * 2) ($padding * 5);
           text-align: center;
           width: auto;
+          @media only screen and (min-width: 768px) {
+            padding-right: 2rem;
+          }
         }
       }
 


### PR DESCRIPTION
### Description
When the screen width is small enough, theres overlap on the PDF icon and the associated text. We should make sure they are not overlapping

<img width="694" alt="Screenshot 2024-07-26 at 10 10 54 AM" src="https://github.com/user-attachments/assets/3405a189-3965-4ced-ad5f-08f56a2243b5">



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3875

---
### How to test
Login, reduce page size to just larger than 768px, see that the icon does not overlap with the text to the right.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
