### PR TITLE
prevent state name from extending past the sidebar column

### DIFF
--- a/services/ui-src/src/components/layout/StateHeader.jsx
+++ b/services/ui-src/src/components/layout/StateHeader.jsx
@@ -1,20 +1,25 @@
-import React from "react";
 import { useSelector } from "react-redux";
+import { AppRoles } from "types";
 
 const StateHeader = () => {
-  const { name, imageURI } = useSelector((state) => state.stateUser);
-
+  const { currentUser, name, imageURI } = useSelector(
+    (state) => state.stateUser
+  );
   return (
-    <div
-      className="state-header"
-      data-testid="state-header"
-      aria-label="State Header"
-    >
-      <div className="state-image">
-        <img src={imageURI} alt={name} />
-      </div>
-      <div className="state-name">{name}</div>
-    </div>
+    <>
+      {currentUser.role === AppRoles.STATE_USER && (
+        <div
+          className="state-header"
+          data-testid="state-header"
+          aria-label="State Header"
+        >
+          <div className="state-image">
+            <img src={imageURI} alt={name} />
+          </div>
+          <div className="state-name">{name}</div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/services/ui-src/src/components/layout/StateHeader.jsx
+++ b/services/ui-src/src/components/layout/StateHeader.jsx
@@ -1,5 +1,6 @@
+import React from "react";
 import { useSelector } from "react-redux";
-import { AppRoles } from "types";
+import { AppRoles } from "../../types";
 
 const StateHeader = () => {
   const { currentUser, name, imageURI } = useSelector(
@@ -7,7 +8,7 @@ const StateHeader = () => {
   );
   return (
     <>
-      {currentUser.role === AppRoles.STATE_USER && (
+      {currentUser?.role === AppRoles.STATE_USER && (
         <div
           className="state-header"
           data-testid="state-header"
@@ -16,7 +17,9 @@ const StateHeader = () => {
           <div className="state-image">
             <img src={imageURI} alt={name} />
           </div>
-          <div className="state-name">{name}</div>
+          <div className="state-name" aria-label={name}>
+            {name}
+          </div>
         </div>
       )}
     </>

--- a/services/ui-src/src/components/layout/StateHeader.test.jsx
+++ b/services/ui-src/src/components/layout/StateHeader.test.jsx
@@ -4,30 +4,45 @@ import configureMockStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import { render } from "@testing-library/react";
 import StateHeader from "./StateHeader";
+import {
+  adminUserWithReportInProgress,
+  stateUserWithReportInProgress,
+} from "../../store/fakeStoreExamples";
 
 const mockStore = configureMockStore();
-const store = mockStore({
-  stateUser: {
-    name: "Kentucky",
-    imageURI: "kentucky.png",
-  },
-});
-const header = (
-  <Provider store={store}>
-    <StateHeader />
-  </Provider>
-);
+const stateUserStore = mockStore(stateUserWithReportInProgress);
+const adminUserStore = mockStore(adminUserWithReportInProgress);
 
 describe("State Header Component", () => {
-  it("should render correctly", () => {
+  test("should render correctly", () => {
+    const header = (
+      <Provider store={stateUserStore}>
+        <StateHeader />
+      </Provider>
+    );
     expect(shallow(header).exists()).toBe(true);
   });
 
-  it("Displays name, image, and alt-text for a state", () => {
+  test("Displays state header content for state user", () => {
+    const header = (
+      <Provider store={stateUserStore}>
+        <StateHeader />
+      </Provider>
+    );
     const { getByTestId, getByAltText } = render(header);
     const headerComponent = getByTestId("state-header");
-    expect(headerComponent).toHaveTextContent("Kentucky");
-    const img = getByAltText("Kentucky");
-    expect(img.src).toContain("kentucky.png");
+    expect(headerComponent).toHaveTextContent("Alabama");
+    const img = getByAltText("Alabama");
+    expect(img.src).toContain("al.svg");
+  });
+
+  test("Does not display state header content for admin user", () => {
+    const header = (
+      <Provider store={adminUserStore}>
+        <StateHeader />
+      </Provider>
+    );
+    const { queryByTestId } = render(header);
+    expect(queryByTestId("state-header")).not.toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/styles/_sidebar.scss
+++ b/services/ui-src/src/styles/_sidebar.scss
@@ -24,5 +24,7 @@
   .state-name {
     font-size: 1.6rem;
     font-weight: $font-weight-semi-bold;
+    overflow: hidden; 
+    text-overflow: ellipsis; 
   }
 }

--- a/services/ui-src/src/styles/_sidebar.scss
+++ b/services/ui-src/src/styles/_sidebar.scss
@@ -24,7 +24,6 @@
   .state-name {
     font-size: 1.6rem;
     font-weight: $font-weight-semi-bold;
-    overflow: hidden; 
-    text-overflow: ellipsis; 
+    overflow-wrap: anywhere; 
   }
 }

--- a/services/ui-src/src/styles/_sidebar.scss
+++ b/services/ui-src/src/styles/_sidebar.scss
@@ -5,26 +5,24 @@
 .sidebar {
   margin: ($margin * 3) 0;
 
+
   .skip-content {
     margin-bottom: ($margin * 3);
   }
   .state-header {
     margin-bottom: ($margin * 3);
     position: relative;
+    display: flex;
+    flex-flow: row wrap;
+    align-items: center;
   }
 
   .state-image {
-    position: absolute;
-    text-align: center;
-    top: 50%;
-    transform: translateY(-50%);
     width: 70px;
   }
 
   .state-name {
     font-size: 1.6rem;
     font-weight: $font-weight-semi-bold;
-    line-height: 70px;
-    padding-left: 70px;
   }
 }


### PR DESCRIPTION
### Description
The state name was extending past the sidebar column and at times overlapping with the report text:

<img width="740" alt="Screenshot 2024-07-26 at 10 16 39 AM" src="https://github.com/user-attachments/assets/71a05dee-e494-49e1-b264-0a1b0bcc6e9a">

This change will make the state name drop below the state icon if the name exceeds the column width.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3876

---
### How to test
Login, enter a report, play around with the state name. use devtools to change the state name to different lengths and resize the page to see the ways the text moves.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
