### PR TITLE
Block destroy on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   # Ensuring group key matches the destroy workflow currently in main
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.ref_name }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -8,6 +8,9 @@ on:
         description: "Name of the environment to destroy:"
         required: true
 
+concurrency:
+  group: ${{ inputs.environment || github.event.ref }}
+        
 permissions:
   id-token: write
   contents: read


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Add a concurrency control to block destroy action from running while deploy is in progress. Destroy isn't prevented from running, it is just queued until after deploy finishes. All other workflows are still namespaced by the workflow which allows them to run concurrently, but if destroy runs while a deploy is running, Cloudformation will simple "nope" out and it will leak infrastructure. This edge case will only really happen if someone pushes a branch and decides they don't need it, and delete the branch before destroy finishes.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-NOTICKETFORYOU

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Create a branch, push it, delete it immediately, and then verify that destroy is queued, and that it will eventually run.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
