### PR TITLE
Ensure Section 2 tables populate for admins

### DIFF
--- a/services/ui-src/src/util/synthesize.js
+++ b/services/ui-src/src/util/synthesize.js
@@ -215,6 +215,19 @@ const snakeToCamel = (str) =>
       group.toUpperCase().replace("-", "").replace("_", "")
     );
 
+const getStateAbbr = (stateUserAbbr) => {
+  if (stateUserAbbr) return stateUserAbbr;
+  const windowPathName = window.location.pathname;
+  // if admin, grab the state from the URL
+  const stateFromURL = windowPathName.split("/")[3];
+
+  // if admin and in a print view get state param
+  const urlSearchParams = new URLSearchParams(window.location.search);
+  const stateFromParams = urlSearchParams.get("state");
+
+  return windowPathName.includes("print") ? stateFromParams : stateFromURL;
+};
+
 /**
  * Retrieve acsSet from state and return for individual state.
  *
@@ -231,19 +244,8 @@ const lookupAcs = (allStatesData, stateUserAbbr, { ffy, acsProperty }) => {
     : acsProperty;
 
   // if allStatesData and stateUser are available
-  if (allStatesData && stateUserAbbr) {
-    const windowPathName = window.location.pathname;
-    // if admin, grab the state from the URL
-    const stateFromURL = windowPathName.split("/")[3];
-
-    // if admin and in a print view get state param
-    const urlSearchParams = new URLSearchParams(window.location.search);
-    const stateFromParams = urlSearchParams.get("state");
-
-    // Get stateUser state or fallback to the URL, if an admin
-    const stateAbbr =
-      stateUserAbbr ||
-      (windowPathName.includes("print") ? stateFromParams : stateFromURL);
+  if (allStatesData) {
+    const stateAbbr = getStateAbbr(stateUserAbbr);
 
     // Filter for only matching state
     const stateData = allStatesData.filter((st) => st.code === stateAbbr)[0];
@@ -280,11 +282,9 @@ export const compareACS = (
   const percentagePrecision = 2;
   let returnValue = "Not Available";
   // if allStatesData and stateUser are available
-  if (allStatesData && stateUserAbbr) {
-    // Filter for only matching state
-    const stateData = allStatesData.filter(
-      (st) => st.code === stateUserAbbr
-    )[0];
+  if (allStatesData) {
+    const stateAbbr = getStateAbbr(stateUserAbbr);
+    const stateData = allStatesData.filter((st) => st.code === stateAbbr)[0];
 
     // Filter for the correct year of state data
     const startACS = stateData?.acsSet.filter(

--- a/services/ui-src/src/util/synthesize.js
+++ b/services/ui-src/src/util/synthesize.js
@@ -215,6 +215,7 @@ const snakeToCamel = (str) =>
       group.toUpperCase().replace("-", "").replace("_", "")
     );
 
+// returns the state abbreviation for the associated report
 const getStateAbbr = (stateUserAbbr) => {
   if (stateUserAbbr) return stateUserAbbr;
   const windowPathName = window.location.pathname;
@@ -243,15 +244,13 @@ const lookupAcs = (allStatesData, stateUserAbbr, { ffy, acsProperty }) => {
     ? snakeToCamel(acsProperty)
     : acsProperty;
 
-  // if allStatesData and stateUser are available
-  if (allStatesData) {
+  // if allStatesData is a populated array
+  if (allStatesData?.length > 0) {
     const stateAbbr = getStateAbbr(stateUserAbbr);
 
-    // Filter for only matching state
-    const stateData = allStatesData.filter((st) => st.code === stateAbbr)[0];
-
-    // Filter for matching state from JSON
-    const acs = stateData?.acsSet.filter((year) => year.year === +ffy)[0];
+    // Find data for matching state
+    const stateData = allStatesData.find((st) => st.code === stateAbbr);
+    const acs = stateData?.acsSet.find((year) => year.year === +ffy);
 
     // If acs exists, return the value from the object
     if (acs) {
@@ -281,18 +280,18 @@ export const compareACS = (
 ) => {
   const percentagePrecision = 2;
   let returnValue = "Not Available";
-  // if allStatesData and stateUser are available
-  if (allStatesData) {
+  // if allStatesData is a populated array
+  if (allStatesData?.length > 0) {
     const stateAbbr = getStateAbbr(stateUserAbbr);
-    const stateData = allStatesData.filter((st) => st.code === stateAbbr)[0];
+    const stateData = allStatesData.find((st) => st.code === stateAbbr);
 
-    // Filter for the correct year of state data
-    const startACS = stateData?.acsSet.filter(
+    // Find the correct year of state data
+    const startACS = stateData?.acsSet.find(
       (year) => year.year === parseInt(ffy1, 10)
-    )[0];
-    const endACS = stateData?.acsSet.filter(
+    );
+    const endACS = stateData?.acsSet.find(
       (year) => year.year === parseInt(ffy2, 10)
-    )[0];
+    );
 
     // If start year and end year of ACS exist, return the calculated value (percent change) from the objects
     if (startACS && endACS) {

--- a/services/ui-src/src/util/synthesize.test.js
+++ b/services/ui-src/src/util/synthesize.test.js
@@ -128,7 +128,7 @@ const fallbackChipState = {
   },
 };
 
-describe("value synthesization utility", () => {
+describe("value synthesis utility", () => {
   describe("handles identity", () => {
     test("with no values", () => {
       // Returns undefined, because there's not a value
@@ -610,6 +610,29 @@ describe("value synthesization utility", () => {
         state.allStatesData,
         state.global.stateName,
         state.stateUser.abbr,
+        state.enrollmentCounts.chipEnrollments,
+        state.formData
+      );
+      expect(out).toEqual({ contents: ["3.70%"] });
+    });
+
+    it("compares two ffys as admin user", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          pathname: "/views/sections/AL/2023/02",
+        },
+      });
+      const out = synthesize(
+        {
+          compareACS: {
+            ffy1: 2021,
+            ffy2: 2020,
+            acsProperty: "numberUninsured",
+          },
+        },
+        state.allStatesData,
+        state.global.stateName,
+        undefined, // state user abbreviation
         state.enrollmentCounts.chipEnrollments,
         state.formData
       );


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The tables in Section 2 Part 2 were not populating for admin users because they did not have the abbreviation property from the state user. There was already code to search for it in the url, so this PR applies that function where necessary.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3934

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://d1t80sp91r37nt.cloudfront.net/

- Log in as a state user
- Enter section 2 of any report
- Verify the two tables in Part 2: Number of Uninsured Children in Your State populate (a few missing values are ok/expected)
- Log in as an admin user
- Enter section 2 of the same report
- Verify the tables show the same information as for the state user

Compare to [CARTS dev](https://mdctcartsdev.cms.gov/) where admin does not have any info populated

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary

---
