### PR TITLE
Pull previous year value for 3c fields

### DIFF
--- a/services/ui-src/src/components/fields/Integer.jsx
+++ b/services/ui-src/src/components/fields/Integer.jsx
@@ -4,12 +4,54 @@ import { TextField } from "@cmsgov/design-system";
 import { useSelector } from "react-redux";
 import { generateQuestionNumber } from "../utils/helperFunctions";
 
+const getPrevYearValue = (question) => {
+  let prevYearValue;
+
+  // Split and create array from id
+  const splitID = question.id.split("-");
+
+  // the subquestion id (a, b, c, etc)
+  const questionId = splitID[5];
+
+  // Custom handling for -03-c-05 and -03-c-06
+  if (
+    splitID[1] === "03" &&
+    splitID[2] === "c" &&
+    (splitID[3] === "05" || splitID[3] === "06") &&
+    questionId === "a" &&
+    parseInt(splitID[4]) > 2 &&
+    parseInt(splitID[4]) < 10
+  ) {
+    const lastYearFormData = useSelector((state) => state.lastYearFormData);
+    // Set year to last year
+    splitID[0] = parseInt(splitID[0]) - 1;
+    splitID.pop();
+
+    const fieldsetId = splitID.join("-");
+    const partIndex = parseInt(splitID[3]) - 1;
+
+    // Get questions from last years JSON
+    const questions =
+      lastYearFormData[3].contents.section.subsections[2].parts[partIndex]
+        .questions;
+
+    // Filter down to this question
+    const matchingQuestion = questions.filter(
+      (question) => fieldsetId === question?.fieldset_info?.id
+    );
+
+    // The first will always be correct
+    if (matchingQuestion[0]) {
+      prevYearValue = parseInt(matchingQuestion[0].questions[0].answer?.entry);
+    }
+  }
+  return prevYearValue;
+};
+
 const Integer = ({ onChange, question, prevYear, ...props }) => {
   const [error, setError] = useState(false);
   const [answer, setAnswer] = useState(question.answer.entry);
-  const lastYearTotals = useSelector((state) => state.lastYearTotals);
-  const prevYearNumber =
-    lastYearTotals[question.id.substring(0, question.id.length - 2)];
+
   const change = ({ target: { name, value } }) => {
     const stripped = value.replace(/[^0-9]+/g, "");
     const parsed = parseFloat(stripped);
@@ -25,22 +67,14 @@ const Integer = ({ onChange, question, prevYear, ...props }) => {
     }
   };
 
-  if (prevYearNumber && question.id.indexOf("-a") > -1) {
-    return (
-      <TextField
-        className="ds-c-input"
-        errorMessage={error}
-        label={`${generateQuestionNumber(question.id)} ${question.label}`}
-        hint={question.hint}
-        name={question.id}
-        numeric
-        onChange={change}
-        value={prevYearNumber}
-        {...props}
-      />
-    );
-  }
-  const renderAnswer = (val) => (val || Number.isInteger(val) ? val : ""); // may attempt to rerender string on page load, so both val || isInteger
+  const renderAnswer = () => {
+    if (answer === null) {
+      return getPrevYearValue(question) ?? prevYear?.value;
+    } else {
+      // may attempt to rerender string on page load, so both answer || isInteger
+      return answer || Number.isInteger(answer) ? answer : "";
+    }
+  };
   return (
     <TextField
       className="ds-c-input"
@@ -50,7 +84,7 @@ const Integer = ({ onChange, question, prevYear, ...props }) => {
       name={question.id}
       numeric
       onChange={change}
-      value={answer != null ? renderAnswer(answer) : prevYear && prevYear.value}
+      value={renderAnswer()}
       {...props}
     />
   );
@@ -61,5 +95,4 @@ Integer.propTypes = {
   prevYear: PropTypes.object,
 };
 
-export { Integer };
 export default Integer;

--- a/services/ui-src/src/components/fields/Integer.jsx
+++ b/services/ui-src/src/components/fields/Integer.jsx
@@ -4,7 +4,7 @@ import { TextField } from "@cmsgov/design-system";
 import { useSelector } from "react-redux";
 import { generateQuestionNumber } from "../utils/helperFunctions";
 
-const getPrevYearValue = (question) => {
+const getPrevYearValue = (question, lastYearFormData) => {
   let prevYearValue;
 
   // Split and create array from id
@@ -22,7 +22,6 @@ const getPrevYearValue = (question) => {
     parseInt(splitID[4]) > 2 &&
     parseInt(splitID[4]) < 10
   ) {
-    const lastYearFormData = useSelector((state) => state.lastYearFormData);
     // Set year to last year
     splitID[0] = parseInt(splitID[0]) - 1;
     splitID.pop();
@@ -51,6 +50,7 @@ const getPrevYearValue = (question) => {
 const Integer = ({ onChange, question, prevYear, ...props }) => {
   const [error, setError] = useState(false);
   const [answer, setAnswer] = useState(question.answer.entry);
+  const lastYearFormData = useSelector((state) => state.lastYearFormData);
 
   const change = ({ target: { name, value } }) => {
     const stripped = value.replace(/[^0-9]+/g, "");
@@ -69,7 +69,7 @@ const Integer = ({ onChange, question, prevYear, ...props }) => {
 
   const renderAnswer = () => {
     if (answer === null) {
-      return getPrevYearValue(question) ?? prevYear?.value;
+      return getPrevYearValue(question, lastYearFormData) ?? prevYear?.value;
     } else {
       // may attempt to rerender string on page load, so both answer || isInteger
       return answer || Number.isInteger(answer) ? answer : "";

--- a/services/ui-src/src/components/fields/Integer.test.jsx
+++ b/services/ui-src/src/components/fields/Integer.test.jsx
@@ -119,5 +119,8 @@ describe("<Integer />", () => {
     render(buildInteger(props));
 
     expect(screen.getByDisplayValue("3000")).toBeInTheDocument();
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: 234 } });
+    expect(screen.getByDisplayValue("234")).toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/components/fields/Integer.test.jsx
+++ b/services/ui-src/src/components/fields/Integer.test.jsx
@@ -6,7 +6,40 @@ import Integer from "./Integer";
 import { screen, render, fireEvent } from "@testing-library/react";
 
 const mockStore = configureMockStore();
-const store = mockStore({ lastYearTotals: { 2022: [] } });
+const lastYearFormData = [
+  {},
+  {},
+  {},
+  {
+    contents: {
+      section: {
+        subsections: [
+          {},
+          {},
+          {
+            parts: [
+              {},
+              {},
+              {},
+              {},
+              {
+                questions: [
+                  {
+                    fieldset_info: {
+                      id: "2022-03-c-05-03",
+                    },
+                    questions: [{ answer: { entry: 3000 } }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+];
+const store = mockStore({ lastYearTotals: { 2022: [] }, lastYearFormData });
 const buildInteger = (intProps) => {
   return (
     <Provider store={store}>
@@ -72,5 +105,19 @@ describe("<Integer />", () => {
     fireEvent.change(input, { target: { value: "raw text" } });
     expect(screen.queryByDisplayValue("raw text")).not.toBeInTheDocument();
     expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("should render previous year value for appropriate 3c part 5 or 6 questions", () => {
+    const props = {
+      question: {
+        id: "2023-03-c-05-03-a",
+        label: "How much?",
+        answer: { entry: null },
+      },
+    };
+
+    render(buildInteger(props));
+
+    expect(screen.getByDisplayValue("3000")).toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/components/fields/Money.jsx
+++ b/services/ui-src/src/components/fields/Money.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Integer } from "./Integer";
+import Integer from "./Integer";
 
 const Money = ({ ...props }) => {
   return <Integer {...props} inputMode="currency" mask="currency" />;

--- a/services/ui-src/src/components/fields/Question.jsx
+++ b/services/ui-src/src/components/fields/Question.jsx
@@ -9,7 +9,7 @@ import { DateRange } from "./DateRange";
 import { Email } from "./Email";
 import { Fieldset } from "./Fieldset";
 import UploadComponent from "../layout/UploadComponent";
-import { Integer } from "./Integer";
+import Integer from "./Integer";
 import { MailingAddress } from "./MailingAddress";
 import { Money } from "./Money";
 import { Objectives } from "./Objectives";


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Add fetch for last year's values to section 3c parts 5 and 6 when "No" is selected (such that we show subquestion `-a` with the totals)
  - This came from similar logic we have in `DataGrid`
- Consolidate Integer component returns
- Remove structured export (and fix dependent imports)
- Add test!

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3915

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[CARTS dev](https://mdctcartsdev.cms.gov/)
- Log in as `stateuser2@test.com`
- Enter AL 2022
- Go to section 3c, part 5
- Select “No” to the question 2
- Verify there are values in the totals, or else enter values
- Leave report and go to AL 2023
- Go to section 3c, part 5
- Select “No” to the question 2
- Verify the values from the previous year do _not_ show up

https://d2qk4vlw7n97j8.cloudfront.net/
- Repeat the above steps
- Verify the values from the previous year _do_ show up
- Verify you can still modify them
- Verify any modified value takes precedence over previous year value

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary
---
