### PR TITLE
fix admin print section bug

### DIFF
--- a/services/ui-src/src/components/layout/FormActions.jsx
+++ b/services/ui-src/src/components/layout/FormActions.jsx
@@ -25,9 +25,9 @@ const FormActions = () => {
   // Get section IDs and subsection IDs for printing single section
   let searchParams = "";
   let sectionId = "";
+
   if (currentUser.role === AppRoles.CMS_ADMIN) {
     const stateId = window.location.href.split("/")[5];
-
     searchParams = document.location.pathname
       .toString()
       .replace(`views/sections/${stateId}/`, "")

--- a/services/ui-src/src/components/layout/FormActions.jsx
+++ b/services/ui-src/src/components/layout/FormActions.jsx
@@ -23,14 +23,27 @@ const FormActions = () => {
   const printDialogeRef = useRef(null);
 
   // Get section IDs and subsection IDs for printing single section
-  let searchParams = document.location.pathname
-    .toString()
-    .replace("/sections/", "")
-    .replace(formYear + "/", "");
+  let searchParams = "";
+  let sectionId = "";
+  if (currentUser.role === AppRoles.CMS_ADMIN) {
+    const stateId = window.location.href.split("/")[5];
 
-  const sectionId = formYear + "-" + searchParams.substring(0, 2);
+    searchParams = document.location.pathname
+      .toString()
+      .replace(`views/sections/${stateId}/`, "")
+      .replace(formYear + "/", "");
+
+    sectionId = formYear + "-" + searchParams.substring(1, 3);
+  } else {
+    searchParams = document.location.pathname
+      .toString()
+      .replace("/sections/", "")
+      .replace(formYear + "/", "");
+
+    sectionId = formYear + "-" + searchParams.substring(0, 2);
+  }
+
   let subsectionId = sectionId + "-";
-
   if (sectionId.slice(-2) === "03") {
     subsectionId += searchParams.slice(-1);
   } else {

--- a/services/ui-src/src/components/layout/FormActions.test.jsx
+++ b/services/ui-src/src/components/layout/FormActions.test.jsx
@@ -28,10 +28,10 @@ const adminFormActions = (
   </Provider>
 );
 describe("Fill Form Component", () => {
-  it("should render correctly", () => {
+  test("should render correctly", () => {
     expect(shallow(formActions).exists()).toBe(true);
   });
-  it("should add hrefs given a section and subsection", () => {
+  test("should add hrefs given a section and subsection", () => {
     render(formActions);
     const printShowButton = screen.getByTestId("print-show");
     fireEvent.click(printShowButton);
@@ -40,8 +40,7 @@ describe("Fill Form Component", () => {
     expect(printPageButton).toHaveAttribute("href");
     expect(printFormButton).toHaveAttribute("href");
   });
-  it("should build the component when looking at section 3 subsections", () => {
-    window.history.pushState({}, "Title", "/sections/03");
+  test("should build the component when looking at section 3 subsections", () => {
     render(adminFormActions);
     window.history.pushState({}, "Title", "/sections/03");
     const printShowButton = screen.getByTestId("print-show");
@@ -51,16 +50,17 @@ describe("Fill Form Component", () => {
     expect(printPageButton).toHaveAttribute("href");
     expect(printFormButton).toHaveAttribute("href");
   });
-  it("should display print section or page on click", () => {
+  test("should display print section or page on click", () => {
     render(formActions);
     const printShowButton = screen.getByTestId("print-show");
     fireEvent.click(printShowButton);
     const printFormButton = screen.getByTestId("print-form");
     const printPageButton = screen.getByTestId("print-page");
+
     expect(printPageButton).toHaveTextContent("This Section");
     expect(printFormButton).toHaveTextContent("Entire Form");
   });
-  it("should clear on click", () => {
+  test("should clear on click", () => {
     render(formActions);
     const printShowButton = screen.getByTestId("print-show");
     fireEvent.click(printShowButton);
@@ -72,7 +72,7 @@ describe("Fill Form Component", () => {
     expect(printPageButton).toBeNull();
     expect(printFormButton).toBeNull();
   });
-  it("should not clear on internal click, then clear on outside click", () => {
+  test("should not clear on internal click, then clear on outside click", () => {
     const map = {};
 
     document.addEventListener = jest.fn((event, cb) => {

--- a/services/ui-src/src/components/layout/FormActions.test.jsx
+++ b/services/ui-src/src/components/layout/FormActions.test.jsx
@@ -9,12 +9,14 @@ import {
   stateUserWithReportInProgress,
 } from "../../store/fakeStoreExamples";
 import { MemoryRouter } from "react-router";
+const firstLocation = "/sections/2021/00";
+const adminFirstLocation = "/views/sections/AL/2021/00";
 
 const mockStore = configureMockStore();
 const store = mockStore(stateUserWithReportInProgress);
 const formActions = (
   <Provider store={store}>
-    <MemoryRouter initialEntries={["/"]}>
+    <MemoryRouter initialEntries={[firstLocation]}>
       <FormActions />
     </MemoryRouter>
   </Provider>
@@ -22,33 +24,74 @@ const formActions = (
 const adminStore = mockStore(adminUserWithReportInProgress);
 const adminFormActions = (
   <Provider store={adminStore}>
-    <MemoryRouter initialEntries={["/"]}>
+    <MemoryRouter initialEntries={[adminFirstLocation]}>
       <FormActions />
     </MemoryRouter>
   </Provider>
 );
+
 describe("Fill Form Component", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   test("should render correctly", () => {
     expect(shallow(formActions).exists()).toBe(true);
   });
   test("should add hrefs given a section and subsection", () => {
     render(formActions);
+    window.history.pushState({}, "Title", "/sections/00");
     const printShowButton = screen.getByTestId("print-show");
     fireEvent.click(printShowButton);
     const printFormButton = screen.getByTestId("print-form");
     const printPageButton = screen.getByTestId("print-page");
-    expect(printPageButton).toHaveAttribute("href");
-    expect(printFormButton).toHaveAttribute("href");
+    expect(printPageButton).toHaveAttribute(
+      "href",
+      "/print?year=2021&state=AL&sectionId=2021-00&subsectionId=2021-00-a"
+    );
+    expect(printFormButton).toHaveAttribute(
+      "href",
+      "/print?year=2021&state=AL"
+    );
+  });
+
+  test("should add hrefs given a section and subsection for admin user", () => {
+    const setLocation = (path = "/") => {
+      delete window.location;
+      window.location = new URL("https://www.example.com" + path);
+    };
+
+    setLocation(adminFirstLocation);
+    render(adminFormActions);
+    window.history.pushState({}, "Title", "/00/a");
+    const printShowButton = screen.getByTestId("print-show");
+    fireEvent.click(printShowButton);
+    const printFormButton = screen.getByTestId("print-form");
+    const printPageButton = screen.getByTestId("print-page");
+    expect(printPageButton).toHaveAttribute(
+      "href",
+      "/print?year=2021&state=AL&sectionId=2021-00&subsectionId=2021-00-a"
+    );
+    expect(printFormButton).toHaveAttribute(
+      "href",
+      "/print?year=2021&state=AL"
+    );
   });
   test("should build the component when looking at section 3 subsections", () => {
     render(adminFormActions);
-    window.history.pushState({}, "Title", "/sections/03");
+    window.history.pushState({}, "Title", "/03/a");
     const printShowButton = screen.getByTestId("print-show");
     fireEvent.click(printShowButton);
     const printFormButton = screen.getByTestId("print-form");
     const printPageButton = screen.getByTestId("print-page");
-    expect(printPageButton).toHaveAttribute("href");
-    expect(printFormButton).toHaveAttribute("href");
+    expect(printPageButton).toHaveAttribute(
+      "href",
+      "/print?year=2021&state=AL&sectionId=2021-03&subsectionId=2021-03-a"
+    );
+    expect(printFormButton).toHaveAttribute(
+      "href",
+      "/print?year=2021&state=AL"
+    );
   });
   test("should display print section or page on click", () => {
     render(formActions);
@@ -56,7 +99,6 @@ describe("Fill Form Component", () => {
     fireEvent.click(printShowButton);
     const printFormButton = screen.getByTestId("print-form");
     const printPageButton = screen.getByTestId("print-page");
-
     expect(printPageButton).toHaveTextContent("This Section");
     expect(printFormButton).toHaveTextContent("Entire Form");
   });


### PR DESCRIPTION
### Description
Issue: Admin users are sent to a blank screen when they select to print a page of the form.


there is a mismatch in the logic when pulling `document.location.pathname`:
`document.location.pathname` for admin user = `views/sections/AL/2023/00`
`document.location.pathname`  for state user = `/sections/2023/00`

This PR adds an admin user flow to get the correct url.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3984

---
### How to test
Login as state and admin user, see that there is no change to a state user's print functionality. 
See that admin user is routed correctly when selecting to print the current page, and full form.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
