### PR TITLE
BUGFIG: Remove parseInt() for previous year value to allow non-numbers to display as empty

### DIFF
--- a/services/ui-src/src/components/fields/Integer.jsx
+++ b/services/ui-src/src/components/fields/Integer.jsx
@@ -41,7 +41,7 @@ const getPrevYearValue = (question, lastYearFormData) => {
 
     // The first will always be correct
     if (matchingQuestion[0]) {
-      prevYearValue = parseInt(matchingQuestion[0].questions[0].answer?.entry);
+      prevYearValue = matchingQuestion[0].questions[0].answer?.entry;
     }
   }
   return prevYearValue;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This bug showed up where null or empty string values were rendered as `NaN` in their cells

These values should (in priority order)
1. render user entered values
2. pull from previous year
3. show up blank if neither of the above

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3915 cont.

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[CARTS dev](https://mdctcartsdev.cms.gov/)
- Log in as stateuser2@test.com
- Enter AL 2021
- Go to section 3c, part 5
- Select “No” to the question 2
- Verify many values display as NaN

https://d2z1dvefrowpqq.cloudfront.net/
- Repeat the above steps
- Verify the previously NaN cells show up as empty cells
- Go to AL 2022, Section 3c, part 5
- Enter some numbers, delete some numbers
- Verify that in AL 2023 those show up as numbers or blank as appropriate
- Verify user entered values for each year take precedence over last year

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
This is how the Datagrid logic was avoiding the NaN problem—it never looked for numbers to begin with!

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary
---
