### PR TITLE
Bugfix: Section 3c Part 5 Question 2

### DIFF
--- a/services/ui-src/src/components/fields/Integer.jsx
+++ b/services/ui-src/src/components/fields/Integer.jsx
@@ -31,16 +31,16 @@ const getPrevYearValue = (question, lastYearFormData) => {
 
     // Get questions from last years JSON
     const questions =
-      lastYearFormData[3].contents.section.subsections[2].parts[partIndex]
+      lastYearFormData?.[3]?.contents.section.subsections[2].parts[partIndex]
         .questions;
 
     // Filter down to this question
-    const matchingQuestion = questions.filter(
+    const matchingQuestion = questions?.filter(
       (question) => fieldsetId === question?.fieldset_info?.id
     );
 
     // The first will always be correct
-    if (matchingQuestion[0]) {
+    if (matchingQuestion?.[0]) {
       prevYearValue = matchingQuestion[0].questions[0].answer?.entry;
     }
   }

--- a/services/ui-src/src/components/fields/Integer.jsx
+++ b/services/ui-src/src/components/fields/Integer.jsx
@@ -41,7 +41,7 @@ const getPrevYearValue = (question, lastYearFormData) => {
 
     // The first will always be correct
     if (matchingQuestion[0]) {
-      prevYearValue = parseInt(matchingQuestion[0].questions[0].answer?.entry);
+      prevYearValue = matchingQuestion[0].questions[0].answer?.entry;
     }
   }
   return prevYearValue;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
If you go to the oldest form and navigate to Section 3c Part 5 Question 2 and select No, the page will crash and forever stay broken. This is because its doing a lookup of the prior year but there is no prior year for this form. Thus this PR adds null checks so that it can return gracefully.


---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Open 2020 Form
Navigate to Section 3c Part 5 Question 2
Answer No
See that the form doesn't crash
Add answer to child questions
Select Yes
See that its still good
Select No
Open 2021 Form
Navigate to Section 3c Part 5 Question 2
See that your values carried over from 2020

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
