### PR TITLE
e2e bug: add wait after submitting

### DIFF
--- a/tests/cypress/tests/integration/submitAndUncertify.spec.js
+++ b/tests/cypress/tests/integration/submitAndUncertify.spec.js
@@ -21,6 +21,7 @@ describe("CARTS Submit and Uncertify Integration Tests", () => {
 
     cy.get(certifySubmitButton).click();
     cy.get("button").contains("Confirm Certify and Submit").click();
+    cy.wait(3000);
     cy.get("button").contains("Return Home").click();
 
     // log in as CMS Admin (user who can uncertify)


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Our submit and uncertify tests flake out on main and val sometimes. After reviewing the videos they both get to the certify page, rapidly go through the buttons, and then re-auth as an admin. Once logged in as an admin, the expected report is still in progress. I'm wondering if the API call needs more time to get fired off. This PR simply adds a wait after hitting the button that triggers the certify call.

Failed run examples:
https://github.com/Enterprise-CMCS/macpro-mdct-carts/actions/runs/10942276801/attempts/1
https://github.com/Enterprise-CMCS/macpro-mdct-carts/actions/runs/10961006339/attempts/1

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4012

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
You can run it locally but it will pass locally even without the wait.

Merging to main/val and letting it run a few times is the best way to test.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
