### PR TITLE
Wrap synthesize value calls in useEffect

### DIFF
--- a/services/ui-src/src/components/fields/SynthesizedTable.jsx
+++ b/services/ui-src/src/components/fields/SynthesizedTable.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useSelector, shallowEqual } from "react-redux";
 //utils
 import synthesizeValue from "../../util/synthesize";
@@ -6,6 +6,7 @@ import synthesizeValue from "../../util/synthesize";
 import PropTypes from "prop-types";
 
 const SynthesizedTable = ({ question, tableTitle }) => {
+  const [rows, setRows] = useState([]);
   const [allStatesData, stateName, stateUserAbbr, chipEnrollments, formData] =
     useSelector(
       (state) => [
@@ -18,22 +19,26 @@ const SynthesizedTable = ({ question, tableTitle }) => {
       shallowEqual
     );
 
-  const rows = question.fieldset_info.rows.map((row) =>
-    row.map((cell) => {
-      const value = synthesizeValue(
-        cell,
-        allStatesData,
-        stateName,
-        stateUserAbbr,
-        chipEnrollments,
-        formData
-      );
+  useEffect(() => {
+    const rows = question.fieldset_info.rows.map((row) =>
+      row.map((cell) => {
+        const value = synthesizeValue(
+          cell,
+          allStatesData,
+          stateName,
+          stateUserAbbr,
+          chipEnrollments,
+          formData
+        );
 
-      return typeof value.contents === "number" && Number.isNaN(value.contents)
-        ? { contents: "Not Available" }
-        : value;
-    })
-  );
+        return typeof value.contents === "number" &&
+          Number.isNaN(value.contents)
+          ? { contents: "Not Available" }
+          : value;
+      })
+    );
+    setRows(rows);
+  }, [allStatesData, stateName, stateUserAbbr, chipEnrollments, formData]);
 
   return (
     <div className="synthesized-table ds-u-margin-top--2">

--- a/services/ui-src/src/components/fields/SynthesizedValue.jsx
+++ b/services/ui-src/src/components/fields/SynthesizedValue.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useSelector, shallowEqual } from "react-redux";
 //components
 import Question from "./Question";
@@ -8,6 +8,7 @@ import synthesizeValue from "../../util/synthesize";
 import PropTypes from "prop-types";
 
 const SynthesizedValue = ({ question, ...props }) => {
+  const [displayValue, setDisplayValue] = useState();
   const [allStatesData, stateName, stateUserAbbr, chipEnrollments, formData] =
     useSelector(
       (state) => [
@@ -20,18 +21,22 @@ const SynthesizedValue = ({ question, ...props }) => {
       shallowEqual
     );
 
-  const value = synthesizeValue(
-    question.fieldset_info,
-    allStatesData,
-    stateName,
-    stateUserAbbr,
-    chipEnrollments,
-    formData
-  ).contents;
+  useEffect(() => {
+    setDisplayValue(
+      synthesizeValue(
+        question.fieldset_info,
+        allStatesData,
+        stateName,
+        stateUserAbbr,
+        chipEnrollments,
+        formData
+      ).contents
+    );
+  }, [allStatesData, stateName, stateUserAbbr, chipEnrollments, formData]);
 
   return (
     <div>
-      <strong>Computed:</strong> {value}
+      <strong>Computed:</strong> {displayValue}
       {question.questions &&
         question.questions.map((q) => (
           <Question key={q.id} question={q} {...props} />


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
These `synthesizeValue` calls are resource intensive and and we're hoping that by wrapping them in useEffect we can cut down on their re-rendering.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4011 maybe

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Merge to main and check 2021 form load times

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- ~[ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment