### PR TITLE
Redux: put functions formerly in mapState back in useSelector

### DIFF
--- a/services/ui-src/src/components/fields/Question.jsx
+++ b/services/ui-src/src/components/fields/Question.jsx
@@ -70,10 +70,8 @@ const Question = ({
   }
 
   const readonly = useSelector((state) => {
-    const stateUser = state.stateUser;
-    const formData = state.formData;
+    const { stateUser, formData, reportStatus } = state;
     const formYear = state.global.formYear;
-    const reportStatus = state.reportStatus;
     return !selectIsFormEditable(reportStatus, formData, stateUser, formYear);
   }, shallowEqual);
   const dispatch = useDispatch();

--- a/services/ui-src/src/components/fields/Question.jsx
+++ b/services/ui-src/src/components/fields/Question.jsx
@@ -53,7 +53,6 @@ const Container = ({ children }) => (
   <fieldset className="ds-c-fieldset">{children}</fieldset>
 );
 Container.propTypes = {
-  question: PropTypes.object.isRequired,
   children: PropTypes.node.isRequired,
 };
 
@@ -70,23 +69,14 @@ const Question = ({
     Component = questionTypes.get(question.type);
   }
 
-  const [stateUser, formData, formYear, reportStatus] = useSelector(
-    (state) => [
-      state.stateUser,
-      state.formData,
-      state.global.formYear,
-      state.reportStatus,
-    ],
-    shallowEqual
-  );
+  const readonly = useSelector((state) => {
+    const stateUser = state.stateUser;
+    const formData = state.formData;
+    const formYear = state.global.formYear;
+    const reportStatus = state.reportStatus;
+    return !selectIsFormEditable(reportStatus, formData, stateUser, formYear);
+  }, shallowEqual);
   const dispatch = useDispatch();
-
-  const readonly = !selectIsFormEditable(
-    reportStatus,
-    formData,
-    stateUser,
-    formYear
-  );
 
   const prevYearDisabled = prevYear ? prevYear.disabled : false;
 
@@ -155,9 +145,9 @@ const Question = ({
         />
 
         {/* If there are subquestions, wrap them so they are indented with the
-             blue line. But don't do it for the subquestions of a fieldset. If
-             the fieldset is a subchild, it will already be indented; if it's
-             not, then its children shouldn't be indented either. */}
+            blue line. But don't do it for the subquestions of a fieldset. If
+            the fieldset is a subchild, it will already be indented; if it's
+            not, then its children shouldn't be indented either. */}
         {shouldRenderChildren && (
           <div className="ds-c-choice__checkedChild">
             {question.questions.map((q) => (

--- a/services/ui-src/src/components/fields/Question.test.jsx
+++ b/services/ui-src/src/components/fields/Question.test.jsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { Provider } from "react-redux";
+import { screen, render } from "@testing-library/react";
+import configureMockStore from "redux-mock-store";
+import Question from "./Question";
+
+const mockStore = configureMockStore();
+const store = mockStore({
+  formData: [
+    {
+      contents: {
+        section: {
+          year: 2023,
+          state: "AL",
+        },
+      },
+    },
+  ],
+  stateUser: {
+    abbr: "CMS",
+    currentUser: {
+      role: "test role",
+    },
+  },
+  global: {
+    formYear: 2023,
+  },
+  reportStatus: {
+    status: "in_progress",
+    AL2023: {
+      status: "in_progress",
+      username: "my_user@name.com",
+      lastChanged: new Date(),
+    },
+  },
+  enrollmentCounts: {
+    chipEnrollments: {},
+  },
+});
+
+const defaultProps = {
+  tableTitle: "Managed Care Costs",
+  question: {
+    questions: [],
+    fieldset_info: {
+      rows: [
+        [
+          {
+            contents: "Eligible children",
+          },
+          {
+            actions: ["identity"],
+            targets: ["$..*[?(@ && @.id=='2023-05-a-03-01-a')].answer.entry"],
+          },
+          {
+            actions: ["identity"],
+            targets: ["$..*[?(@ && @.id=='2023-05-a-03-01-b')].answer.entry"],
+          },
+        ],
+      ],
+      headers: [
+        {
+          contents: "",
+        },
+        {
+          contents: "FFY 2023",
+        },
+        {
+          contents: "FFY 2024",
+        },
+      ],
+    },
+    fieldset_type: "synthesized_table",
+    type: "fieldset",
+  },
+};
+
+const QuestionComponentWithProps = () => {
+  return (
+    <Provider store={store}>
+      <Question {...defaultProps} />
+    </Provider>
+  );
+};
+
+describe("Question component", () => {
+  test("render question", () => {
+    render(QuestionComponentWithProps());
+    expect(screen.getByText("Eligible children")).toBeVisible();
+  });
+});

--- a/services/ui-src/src/components/fields/SynthesizedTable.jsx
+++ b/services/ui-src/src/components/fields/SynthesizedTable.jsx
@@ -7,38 +7,36 @@ import { lteMask } from "../../util/constants";
 import PropTypes from "prop-types";
 
 const SynthesizedTable = ({ question, tableTitle, printView }) => {
-  const [allStatesData, stateName, stateUserAbbr, chipEnrollments, formData] =
-    useSelector(
-      (state) => [
-        state.allStatesData,
-        state.global.stateName,
-        state.stateUser.abbr,
-        state.enrollmentCounts.chipEnrollments,
-        state.formData,
-      ],
-      shallowEqual
-    );
+  const rows = useSelector((state) => {
+    const allStatesData = state.allStatesData;
+    const stateName = state.global.stateName;
+    const stateUserAbbr = state.stateUser.abbr;
+    const chipEnrollments = state.enrollmentCounts.chipEnrollments;
+    const formData = state.formData;
 
-  const rows = question.fieldset_info.rows.map((row) => {
-    let contents = row;
-    if (printView) {
-      contents = row.filter((cell) => cell?.mask !== lteMask);
-    }
-    return contents.map((cell) => {
-      const value = synthesizeValue(
-        cell,
-        allStatesData,
-        stateName,
-        stateUserAbbr,
-        chipEnrollments,
-        formData
-      );
+    const rows = question.fieldset_info.rows.map((row) => {
+      let contents = row;
+      if (printView) {
+        contents = row.filter((cell) => cell?.mask !== lteMask);
+      }
+      return contents.map((cell) => {
+        const value = synthesizeValue(
+          cell,
+          allStatesData,
+          stateName,
+          stateUserAbbr,
+          chipEnrollments,
+          formData
+        );
 
-      return typeof value.contents === "number" && Number.isNaN(value.contents)
-        ? { contents: "Not Available" }
-        : value;
+        return typeof value.contents === "number" &&
+          Number.isNaN(value.contents)
+          ? { contents: "Not Available" }
+          : value;
+      });
     });
-  });
+    return rows;
+  }, shallowEqual);
 
   const headers = printView
     ? question.fieldset_info.headers.filter(

--- a/services/ui-src/src/components/fields/SynthesizedTable.jsx
+++ b/services/ui-src/src/components/fields/SynthesizedTable.jsx
@@ -7,42 +7,10 @@ import { lteMask } from "../../util/constants";
 import PropTypes from "prop-types";
 
 const SynthesizedTable = ({ question, tableTitle, printView }) => {
-  const rows = useSelector((state) => {
-    const allStatesData = state.allStatesData;
-    const stateName = state.global.stateName;
-    const stateUserAbbr = state.stateUser.abbr;
-    const chipEnrollments = state.enrollmentCounts.chipEnrollments;
-    const formData = state.formData;
-
-    const rows = question.fieldset_info.rows.map((row) => {
-      let contents = row;
-      if (printView) {
-        contents = row.filter((cell) => cell?.mask !== lteMask);
-      }
-      return contents.map((cell) => {
-        const value = synthesizeValue(
-          cell,
-          allStatesData,
-          stateName,
-          stateUserAbbr,
-          chipEnrollments,
-          formData
-        );
-
-        return typeof value.contents === "number" &&
-          Number.isNaN(value.contents)
-          ? { contents: "Not Available" }
-          : value;
-      });
-    });
-    return rows;
-  }, shallowEqual);
-
-  const headers = printView
-    ? question.fieldset_info.headers.filter(
-        (header) => header?.mask !== lteMask
-      )
-    : question.fieldset_info.headers;
+  const { headers, rows } = useSelector(
+    (state) => getTableContents(state, question, printView),
+    shallowEqual
+  );
 
   return (
     <div className="synthesized-table ds-u-margin-top--2">
@@ -101,6 +69,40 @@ const SynthesizedTable = ({ question, tableTitle, printView }) => {
 SynthesizedTable.propTypes = {
   question: PropTypes.object.isRequired,
   tableTitle: PropTypes.string.isOptional,
+};
+
+const getTableContents = (state, question, printView) => {
+  const { allStatesData, formData } = state;
+  const stateName = state.global.stateName;
+  const stateUserAbbr = state.stateUser.abbr;
+  const chipEnrollments = state.enrollmentCounts.chipEnrollments;
+  const { headers: questionHeaders, rows: questionRows } =
+    question.fieldset_info;
+
+  const rows = questionRows.map((row) => {
+    let contents = row;
+    if (printView) {
+      contents = row.filter((cell) => cell?.mask !== lteMask);
+    }
+    return contents.map((cell) => {
+      const value = synthesizeValue(
+        cell,
+        allStatesData,
+        stateName,
+        stateUserAbbr,
+        chipEnrollments,
+        formData
+      );
+
+      return typeof value.contents === "number" && Number.isNaN(value.contents)
+        ? { contents: "Not Available" }
+        : value;
+    });
+  });
+  const headers = printView
+    ? questionHeaders.filter((header) => header?.mask !== lteMask)
+    : questionHeaders;
+  return { headers, rows };
 };
 
 export default SynthesizedTable;

--- a/services/ui-src/src/components/fields/SynthesizedValue.jsx
+++ b/services/ui-src/src/components/fields/SynthesizedValue.jsx
@@ -9,23 +9,10 @@ import { lteMask } from "../../util/constants";
 import PropTypes from "prop-types";
 
 const SynthesizedValue = ({ question, printView, ...props }) => {
-  const value = useSelector((state) => {
-    const allStatesData = state.allStatesData;
-    const stateName = state.global.stateName;
-    const stateUserAbbr = state.stateUser.abbr;
-    const chipEnrollments = state.enrollmentCounts.chipEnrollments;
-    const formData = state.formData;
-    return synthesizeValue(
-      question.fieldset_info,
-      allStatesData,
-      stateName,
-      stateUserAbbr,
-      chipEnrollments,
-      formData
-    ).contents;
-  }, shallowEqual);
-
-  const showValue = !(printView && question.fieldset_info.mask === lteMask);
+  const { value, showValue } = useSelector(
+    (state) => getValue(state, question, printView),
+    shallowEqual
+  );
 
   return (
     showValue && (
@@ -41,6 +28,23 @@ const SynthesizedValue = ({ question, printView, ...props }) => {
 };
 SynthesizedValue.propTypes = {
   question: PropTypes.object.isRequired,
+};
+
+const getValue = (state, question, printView) => {
+  const { allStatesData, formData } = state;
+  const stateName = state.global.stateName;
+  const stateUserAbbr = state.stateUser.abbr;
+  const chipEnrollments = state.enrollmentCounts.chipEnrollments;
+  const value = synthesizeValue(
+    question.fieldset_info,
+    allStatesData,
+    stateName,
+    stateUserAbbr,
+    chipEnrollments,
+    formData
+  ).contents;
+  const showValue = !(printView && question.fieldset_info.mask === lteMask);
+  return { value, showValue };
 };
 
 export default SynthesizedValue;

--- a/services/ui-src/src/components/fields/SynthesizedValue.jsx
+++ b/services/ui-src/src/components/fields/SynthesizedValue.jsx
@@ -9,20 +9,12 @@ import { lteMask } from "../../util/constants";
 import PropTypes from "prop-types";
 
 const SynthesizedValue = ({ question, printView, ...props }) => {
-  const [allStatesData, stateName, stateUserAbbr, chipEnrollments, formData] =
-    useSelector(
-      (state) => [
-        state.allStatesData,
-        state.global.stateName,
-        state.stateUser.abbr,
-        state.enrollmentCounts.chipEnrollments,
-        state.formData,
-      ],
-      shallowEqual
-    );
-
-  const showValue = !(printView && question.fieldset_info.mask === lteMask);
-  const renderValue = () => {
+  const value = useSelector((state) => {
+    const allStatesData = state.allStatesData;
+    const stateName = state.global.stateName;
+    const stateUserAbbr = state.stateUser.abbr;
+    const chipEnrollments = state.enrollmentCounts.chipEnrollments;
+    const formData = state.formData;
     return synthesizeValue(
       question.fieldset_info,
       allStatesData,
@@ -31,12 +23,14 @@ const SynthesizedValue = ({ question, printView, ...props }) => {
       chipEnrollments,
       formData
     ).contents;
-  };
+  }, shallowEqual);
+
+  const showValue = !(printView && question.fieldset_info.mask === lteMask);
 
   return (
     showValue && (
       <div>
-        <strong>Computed:</strong> {renderValue()}
+        <strong>Computed:</strong> {value}
         {question.questions &&
           question.questions.map((q) => (
             <Question key={q.id} question={q} {...props} />

--- a/services/ui-src/src/components/layout/FormNavigation.jsx
+++ b/services/ui-src/src/components/layout/FormNavigation.jsx
@@ -17,12 +17,13 @@ const FormNavigation = () => {
   const history = useHistory();
   const location = useLocation();
 
-  const [formData, role] = useSelector(
-    (state) => [state.formData, state.stateUser?.currentUser?.role],
+  const [sections, role] = useSelector(
+    (state) => [
+      selectSectionsForNav(state.formData),
+      state.stateUser?.currentUser?.role,
+    ],
     shallowEqual
   );
-
-  const sections = selectSectionsForNav(formData);
 
   const items = [];
   sections.forEach((section) => {

--- a/services/ui-src/src/components/layout/Header.jsx
+++ b/services/ui-src/src/components/layout/Header.jsx
@@ -17,22 +17,20 @@ import appLogo from "../../assets/images/MDCT_CARTS_2x.png";
 export const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  const [stateUser, formData, formYear, reportStatus] = useSelector(
-    (state) => [
-      state.stateUser,
-      state.formData,
-      state.global.formYear,
-      state.reportStatus,
-    ],
-    shallowEqual
-  );
-  const { currentUser } = stateUser;
-  const currentReportStatus = getCurrentReportStatus(
-    reportStatus,
-    formData,
-    stateUser,
-    formYear
-  );
+  const { currentReportStatus, currentUser } = useSelector((state) => {
+    const stateUser = state.stateUser;
+    const formData = state.formData;
+    const formYear = state.global.formYear;
+    const reportStatus = state.reportStatus;
+    const currentReportStatus = getCurrentReportStatus(
+      reportStatus,
+      formData,
+      stateUser,
+      formYear
+    );
+    const currentUser = stateUser.currentUser;
+    return { currentReportStatus, currentUser };
+  }, shallowEqual);
   const location = useLocation();
 
   const showAutoSaveOnReport = (location, currentUser, currentReportStatus) => {

--- a/services/ui-src/src/components/layout/Header.jsx
+++ b/services/ui-src/src/components/layout/Header.jsx
@@ -18,10 +18,8 @@ export const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const { currentReportStatus, currentUser } = useSelector((state) => {
-    const stateUser = state.stateUser;
-    const formData = state.formData;
+    const { stateUser, formData, reportStatus } = state;
     const formYear = state.global.formYear;
-    const reportStatus = state.reportStatus;
     const currentReportStatus = getCurrentReportStatus(
       reportStatus,
       formData,

--- a/services/ui-src/src/components/layout/Part.jsx
+++ b/services/ui-src/src/components/layout/Part.jsx
@@ -12,49 +12,10 @@ import { shouldDisplay } from "../../util/shouldDisplay";
 const Part = ({ partId, partNumber, nestedSubsectionTitle, printView }) => {
   const [, section] = partId.split("-");
 
-  const [
-    formData,
-    currentUserRole,
-    reportStatus,
-    allStatesData,
-    stateUserAbbr,
-    chipEnrollments,
-  ] = useSelector(
-    (state) => [
-      state.formData,
-      state.stateUser.currentUser.role,
-      state.reportStatus,
-      state.allStatesData,
-      state.stateUser.abbr,
-      state.enrollmentCounts.chipEnrollments,
-    ],
+  const { contextData, questions, show, text, title } = useSelector(
+    (state) => getPartInfo(state, partId),
     shallowEqual
   );
-
-  const part = selectFragment(formData, partId);
-  const partContextData = part.context_data;
-
-  const contextData = partContextData;
-  const questions = selectQuestionsForPart(
-    formData,
-    currentUserRole,
-    reportStatus,
-    allStatesData,
-    stateUserAbbr,
-    chipEnrollments,
-    partId
-  );
-  const show = shouldDisplay(
-    currentUserRole,
-    formData,
-    reportStatus,
-    allStatesData,
-    stateUserAbbr,
-    chipEnrollments,
-    partContextData
-  );
-  const text = part ? part.text : null;
-  const title = part ? part.title : null;
 
   const getPartContent = () => {
     if (show) {
@@ -103,4 +64,46 @@ const Part = ({ partId, partNumber, nestedSubsectionTitle, printView }) => {
     </div>
   );
 };
+
+const getPartInfo = (state, partId) => {
+  const formData = state.formData;
+  const currentUserRole = state.stateUser.currentUser.role;
+  const reportStatus = state.reportStatus;
+  const allStatesData = state.allStatesData;
+  const stateUserAbbr = state.stateUser.abbr;
+  const chipEnrollments = state.enrollmentCounts.chipEnrollments;
+
+  const part = selectFragment(formData, partId);
+  const partContextData = part.context_data;
+
+  const questions = selectQuestionsForPart(
+    formData,
+    currentUserRole,
+    reportStatus,
+    allStatesData,
+    stateUserAbbr,
+    chipEnrollments,
+    partId
+  );
+  const show = shouldDisplay(
+    currentUserRole,
+    formData,
+    reportStatus,
+    allStatesData,
+    stateUserAbbr,
+    chipEnrollments,
+    partContextData
+  );
+  const text = part ? part.text : null;
+  const title = part ? part.title : null;
+
+  return {
+    contextData: partContextData,
+    questions,
+    show,
+    text,
+    title,
+  };
+};
+
 export default Part;

--- a/services/ui-src/src/components/layout/Part.jsx
+++ b/services/ui-src/src/components/layout/Part.jsx
@@ -66,10 +66,8 @@ const Part = ({ partId, partNumber, nestedSubsectionTitle, printView }) => {
 };
 
 const getPartInfo = (state, partId) => {
-  const formData = state.formData;
+  const { formData, reportStatus, allStatesData } = state;
   const currentUserRole = state.stateUser.currentUser.role;
-  const reportStatus = state.reportStatus;
-  const allStatesData = state.allStatesData;
   const stateUserAbbr = state.stateUser.abbr;
   const chipEnrollments = state.enrollmentCounts.chipEnrollments;
 

--- a/services/ui-src/src/components/layout/Section.jsx
+++ b/services/ui-src/src/components/layout/Section.jsx
@@ -9,8 +9,9 @@ import FormActions from "./FormActions";
 import Autosave from "../fields/Autosave";
 
 const Section = ({ subsectionId, sectionId, printView }) => {
-  const formData = useSelector((state) => state.formData);
-  const title = selectSectionTitle(formData, sectionId);
+  const title = useSelector((state) =>
+    selectSectionTitle(state.formData, sectionId)
+  );
 
   return (
     <div className="section-basic-info ds-l-col--9 content">

--- a/services/ui-src/src/components/layout/Subsection.jsx
+++ b/services/ui-src/src/components/layout/Subsection.jsx
@@ -9,13 +9,16 @@ import { selectSubsectionTitleAndPartIDs } from "../../store/selectors";
 import PropTypes from "prop-types";
 
 const Subsection = ({ subsectionId, printView }) => {
-  const formData = useSelector((state) => state.formData);
-
-  const subsection = selectSubsectionTitleAndPartIDs(formData, subsectionId);
-
-  const partIds = subsection ? subsection.parts : [];
-  const title = subsection ? subsection.title : null;
-  const text = subsection ? subsection.text : null;
+  const { partIds, title, text } = useSelector((state) => {
+    const subsection = selectSubsectionTitleAndPartIDs(
+      state.formData,
+      subsectionId
+    );
+    const partIds = subsection ? subsection.parts : [];
+    const title = subsection ? subsection.title : null;
+    const text = subsection ? subsection.text : null;
+    return { partIds, title, text };
+  });
 
   return (
     <div id={subsectionId}>

--- a/services/ui-src/src/components/layout/TableOfContents.jsx
+++ b/services/ui-src/src/components/layout/TableOfContents.jsx
@@ -31,8 +31,7 @@ const getSections = (formData) => {
   if (!formData) {
     return [];
   }
-  const sections = formData;
-  return sections.map(
+  return formData.map(
     ({
       contents: {
         section: { id: sectionId, ordinal, subsections, title: sectionTitle },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
In comparing our prior redux configurations to the new one, I noticed there were many instances where we formerly had a function within the state function that was then moved into the component, outside of the selector. I wonder if this causes our renders and re-renders to be more costly. `useSelector` is supposed to limit re-renders to only when the relevant state updates. By moving these functions back into our selector, we may be able to save on costly renders.

Ex: SynthesizeValue.jsx
```js
// formerly we had a map function like this
...
const mapStateToProps = (state, { question: { fieldset_info: fsInfo } }) => {
  return {
    value: synthesizeValue(fsInfo, state).contents,
  };
};
...

// that was converted into this
...
const [allStatesData, stateName, stateUserAbbr, chipEnrollments, formData] =
    useSelector(
      (state) => [
        state.allStatesData,
        state.global.stateName,
        state.stateUser.abbr,
        state.enrollmentCounts.chipEnrollments,
        state.formData,
      ],
      shallowEqual
    );

const value = synthesizeValue(
  question.fieldset_info,
  allStatesData,
  stateName,
  stateUserAbbr,
  chipEnrollments,
  formData
).contents;
...

// now it looks like this
...
const value = useSelector((state) => {
    const allStatesData = state.allStatesData;
    const stateName = state.global.stateName;
    const stateUserAbbr = state.stateUser.abbr;
    const chipEnrollments = state.enrollmentCounts.chipEnrollments;
    const formData = state.formData;
    return synthesizeValue(
      question.fieldset_info,
      allStatesData,
      stateName,
      stateUserAbbr,
      chipEnrollments,
      formData
    ).contents;
  }, shallowEqual);
...
```

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
part of CMDCT-4011

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
App works as expected

Merge to main and check if older reports are faster.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment