### PR TITLE
Remove section 1's question 9 accidental carryover

### DIFF
--- a/services/database/data/seed/seed-section-base-2024.json
+++ b/services/database/data/seed/seed-section-base-2024.json
@@ -704,6 +704,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -725,6 +729,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -747,6 +755,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -769,6 +781,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -790,6 +806,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -812,6 +832,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -834,6 +858,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -856,6 +884,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -877,6 +909,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -899,6 +935,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -921,6 +961,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -942,6 +986,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -963,6 +1011,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -984,6 +1036,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1005,6 +1061,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1017,14 +1077,6 @@
                     "questions": [
                       {
                         "id": "2024-01-a-03-16",
-                        "type": "text_multiline",
-                        "label": "Briefly describe why you made changes to your Medicaid expansion CHIP program (if applicable).",
-                        "answer": {
-                          "entry": null
-                        }
-                      },
-                      {
-                        "id": "2024-01-a-03-17",
                         "type": "radio",
                         "label": "Have you already submitted a State Plan Amendment (SPA) to reflect any changes that require a SPA?",
                         "answer": {
@@ -1037,8 +1089,20 @@
                             {
                               "label": "No",
                               "value": "no"
+                            },
+                            {
+                              "label": "N/A",
+                              "value": "n/a"
                             }
                           ]
+                        }
+                      },
+                      {
+                        "id": "2024-01-a-03-17",
+                        "type": "text_multiline",
+                        "label": "Briefly describe why you made changes to your Medicaid expansion CHIP program (if applicable).",
+                        "answer": {
+                          "entry": null
                         }
                       }
                     ],
@@ -1102,6 +1166,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1123,6 +1191,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1145,6 +1217,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1156,7 +1232,7 @@
                     "id": "2024-01-a-04-04",
                     "hint": "For example: adding benefits or removing benefit limits.",
                     "type": "radio",
-                    "label": "Have you made any changes to the benefits available to enrolees?",
+                    "label": "Have you made any changes to the benefits available to enrollees?",
                     "answer": {
                       "entry": null,
                       "options": [
@@ -1167,6 +1243,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1188,6 +1268,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1210,6 +1294,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1232,6 +1320,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1243,7 +1335,7 @@
                     "id": "2024-01-a-04-08",
                     "hint": "For example: changing amounts, populations, or the collection process.",
                     "type": "radio",
-                    "label": "Have you made any changes to your cost sharing requirements?",
+                    "label": "Have you made any changes to cost sharing requirements?",
                     "answer": {
                       "entry": null,
                       "options": [
@@ -1254,6 +1346,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1276,6 +1372,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1286,7 +1386,7 @@
                   {
                     "id": "2024-01-a-04-10",
                     "type": "radio",
-                    "label": "Have you made any changes to an enrollment freeze and/or enrollment cap?",
+                    "label": "Have you made any changes to the implementation of an enrollment freeze and/or enrollment cap?",
                     "answer": {
                       "entry": null,
                       "options": [
@@ -1297,6 +1397,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1318,6 +1422,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1340,6 +1448,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1362,6 +1474,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1372,7 +1488,7 @@
                   {
                     "id": "2024-01-a-04-14",
                     "type": "radio",
-                    "label": "Have you made any changes to the methods and procedures for preventing, investigating, or referring fraud or abuse cases?",
+                    "label": "Have you made any changes to the methods/procedures for the prevention, investigation, or referral of fraud or abuse cases?",
                     "answer": {
                       "entry": null,
                       "options": [
@@ -1383,6 +1499,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1405,6 +1525,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1427,6 +1551,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1448,6 +1576,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1469,6 +1601,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1490,6 +1626,10 @@
                         {
                           "label": "No",
                           "value": "no"
+                        },
+                        {
+                          "label": "N/A",
+                          "value": "n/a"
                         }
                       ]
                     },
@@ -1502,16 +1642,8 @@
                     "questions": [
                       {
                         "id": "2024-01-a-04-20",
-                        "type": "text_multiline",
-                        "label": "Briefly describe why you made these changes to your separate CHIP program (if applicable).",
-                        "answer": {
-                          "entry": null
-                        }
-                      },
-                      {
-                        "id": "2024-01-a-04-21",
                         "type": "radio",
-                        "label": "Have you already submitted a State Plan Amendment (SPA) to reflect any changes that require a SPA?",
+                        "label": "Have you already submitted a SPA to reflect any of the changes addressed in this section that require a SPA?",
                         "answer": {
                           "entry": null,
                           "options": [
@@ -1522,8 +1654,20 @@
                             {
                               "label": "No",
                               "value": "no"
+                            },
+                            {
+                              "label": "N/A",
+                              "value": "n/a"
                             }
                           ]
+                        }
+                      },
+                      {
+                        "id": "2024-01-a-04-21",
+                        "type": "text_multiline",
+                        "label": "Briefly describe why you made changes to your separate CHIP program (if applicable).",
+                        "answer": {
+                          "entry": null
                         }
                       }
                     ],

--- a/services/database/data/seed/seed-section-base-2024.json
+++ b/services/database/data/seed/seed-section-base-2024.json
@@ -864,29 +864,7 @@
                     }
                   },
                   {
-                    "id": "2024-01-a-03-09",
-                    "hint": "For example: removing a waiting period.",
-                    "type": "radio",
-                    "label": "Have you made any changes to the substitution of coverage policies?",
-                    "answer": {
-                      "entry": null,
-                      "options": [
-                        {
-                          "label": "Yes",
-                          "value": "yes"
-                        },
-                        {
-                          "label": "No",
-                          "value": "no"
-                        }
-                      ]
-                    },
-                    "context_data": {
-                      "bullet_text": "Subsitution of coverage policies"
-                    }
-                  },
-                  {
-                    "id": "2024-01-a-03-10",
+                    "id": "2024-01-a-03-9",
                     "type": "radio",
                     "label": "Have you made any changes to the enrollment process for health plan selection?",
                     "answer": {
@@ -907,7 +885,7 @@
                     }
                   },
                   {
-                    "id": "2024-01-a-03-11",
+                    "id": "2024-01-a-03-10",
                     "hint": "For example: changing from the Medicaid Fair Hearing process to the review process used by all health insurance issuers statewide.",
                     "type": "radio",
                     "label": "Have you made any changes to the protections for applicants and enrollees?",
@@ -929,7 +907,7 @@
                     }
                   },
                   {
-                    "id": "2024-01-a-03-12",
+                    "id": "2024-01-a-03-11",
                     "hint": "For example: adding premium assistance or changing the population that receives premium assistance.",
                     "type": "radio",
                     "label": "Have you made any changes to premium assistance?",
@@ -951,7 +929,7 @@
                     }
                   },
                   {
-                    "id": "2024-01-a-03-13",
+                    "id": "2024-01-a-03-12",
                     "type": "radio",
                     "label": "Have you made any changes to the methods and procedures for preventing, investigating, or referring fraud or abuse cases?",
                     "answer": {
@@ -972,7 +950,7 @@
                     }
                   },
                   {
-                    "id": "2024-01-a-03-14",
+                    "id": "2024-01-a-03-13",
                     "type": "radio",
                     "label": "Have you made any changes to eligibility for “lawfully residing pregnant individuals”?",
                     "answer": {
@@ -993,7 +971,7 @@
                     }
                   },
                   {
-                    "id": "2024-01-a-03-15",
+                    "id": "2024-01-a-03-14",
                     "type": "radio",
                     "label": "Have you made any changes to eligibility for “lawfully residing” children?",
                     "answer": {
@@ -1014,7 +992,7 @@
                     }
                   },
                   {
-                    "id": "2024-01-a-03-16",
+                    "id": "2024-01-a-03-15",
                     "type": "radio",
                     "label": "Have you made changes to any other policy or program areas?",
                     "answer": {
@@ -1038,7 +1016,7 @@
                     "type": "fieldset",
                     "questions": [
                       {
-                        "id": "2024-01-a-03-17",
+                        "id": "2024-01-a-03-16",
                         "type": "text_multiline",
                         "label": "Briefly describe why you made changes to your Medicaid expansion CHIP program (if applicable).",
                         "answer": {
@@ -1046,7 +1024,7 @@
                         }
                       },
                       {
-                        "id": "2024-01-a-03-18",
+                        "id": "2024-01-a-03-17",
                         "type": "radio",
                         "label": "Have you already submitted a State Plan Amendment (SPA) to reflect any changes that require a SPA?",
                         "answer": {
@@ -1087,13 +1065,12 @@
                             "$..[?(@ && @.id=='2024-01-a-03-12')].answer.entry",
                             "$..[?(@ && @.id=='2024-01-a-03-13')].answer.entry",
                             "$..[?(@ && @.id=='2024-01-a-03-14')].answer.entry",
-                            "$..[?(@ && @.id=='2024-01-a-03-15')].answer.entry",
-                            "$..[?(@ && @.id=='2024-01-a-03-16')].answer.entry"
+                            "$..[?(@ && @.id=='2024-01-a-03-15')].answer.entry"
                           ]
                         }
                       },
-                      "interactive_conditional": "Show if any 2024-01-a-03 questions 1–16 has a yes answer, hide otherwise.",
-                      "noninteractive_conditional": "Show if any 2024-01-a-03 questions 1–16 has a yes answer, hide otherwise."
+                      "interactive_conditional": "Show if any 2024-01-a-03 questions 1–15 has a yes answer, hide otherwise.",
+                      "noninteractive_conditional": "Show if any 2024-01-a-03 questions 1–15 has a yes answer, hide otherwise."
                     }
                   }
                 ],

--- a/services/database/data/seed/seed-section-base-2024.json
+++ b/services/database/data/seed/seed-section-base-2024.json
@@ -896,7 +896,7 @@
                     }
                   },
                   {
-                    "id": "2024-01-a-03-9",
+                    "id": "2024-01-a-03-09",
                     "type": "radio",
                     "label": "Have you made any changes to the enrollment process for health plan selection?",
                     "answer": {

--- a/services/ui-src/src/store/formData.js
+++ b/services/ui-src/src/store/formData.js
@@ -47,45 +47,48 @@ export default (state = initialState, action) => {
         }
       }
 
-      var chgsection1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
-      for (let x in chgsection1) {
-        updatedData[1].contents.section.subsections[0].parts[2].questions[
-          x
-        ].answer.options = [
-          {
-            label: "Yes",
-            value: "yes",
-          },
-          { label: "No", value: "no" },
-          { label: "N/A", value: "n/a" },
+      if (updatedData[1].year < 2024) {
+        var chgsection1 = [
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
         ];
-      }
-      updatedData[1].contents.section.subsections[0].parts[2].questions[16].questions[1].answer.options =
-        [
-          {
-            label: "Yes",
-            value: "yes",
-          },
-          { label: "No", value: "no" },
-          { label: "N/A", value: "n/a" },
-        ];
+        for (let x in chgsection1) {
+          updatedData[1].contents.section.subsections[0].parts[2].questions[
+            x
+          ].answer.options = [
+            {
+              label: "Yes",
+              value: "yes",
+            },
+            { label: "No", value: "no" },
+            { label: "N/A", value: "n/a" },
+          ];
+        }
+        updatedData[1].contents.section.subsections[0].parts[2].questions[16].questions[1].answer.options =
+          [
+            {
+              label: "Yes",
+              value: "yes",
+            },
+            { label: "No", value: "no" },
+            { label: "N/A", value: "n/a" },
+          ];
 
-      var chgsection2 = [
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
-      ];
-      for (let x in chgsection2) {
-        updatedData[1].contents.section.subsections[0].parts[3].questions[
-          x
-        ].answer.options = [
-          {
-            label: "Yes",
-            value: "yes",
-          },
-          { label: "No", value: "no" },
-          { label: "N/A", value: "n/a" },
+        var chgsection2 = [
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
         ];
+        for (let x in chgsection2) {
+          updatedData[1].contents.section.subsections[0].parts[3].questions[
+            x
+          ].answer.options = [
+            {
+              label: "Yes",
+              value: "yes",
+            },
+            { label: "No", value: "no" },
+            { label: "N/A", value: "n/a" },
+          ];
+        }
       }
-
       return updatedData;
     case QUESTION_ANSWERED: {
       const fragment = selectQuestion({ formData: state }, action.fragmentId);


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
We found that Section 1 Question 9 was not supposed to be in the 2023 report. We've thus removed it from the upcoming 2024 report. I also went through and did some quick typo fixes, as well as properly added N/A to the Parts 3 and 4 Questions that were being added at run time.

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
In the deployed instance, checkout the 2024 report
See that the old question 9 was removed and the questions following have been moved down and taken its place.
See that N/A is in all the radio questions of Parts 3 and 4 in Section 1
Checkout the 2023 Report
See that the old question 9 is still there
See that N/A is in all the radio questions of Parts 3 and 4 in Section 1

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary
