### PR TITLE
Print section fix for additional user types

### DIFF
--- a/services/ui-src/src/components/layout/FormActions.jsx
+++ b/services/ui-src/src/components/layout/FormActions.jsx
@@ -27,13 +27,7 @@ const FormActions = () => {
   let sectionId = "";
 
   const role = currentUser.role;
-  if (
-    role !== AppRoles.CMS_ADMIN &&
-    role !== AppRoles.INTERNAL_USER &&
-    role !== AppRoles.HELP_DESK &&
-    role !== AppRoles.CMS_APPROVER &&
-    role !== AppRoles.CMS_USER
-  ) {
+  if (role == AppRoles.STATE_USER ) {
     searchParams = document.location.pathname
       .toString()
       .replace("/sections/", "")

--- a/services/ui-src/src/components/layout/FormActions.jsx
+++ b/services/ui-src/src/components/layout/FormActions.jsx
@@ -27,7 +27,7 @@ const FormActions = () => {
   let sectionId = "";
 
   const role = currentUser.role;
-  if (role == AppRoles.STATE_USER ) {
+  if (role == AppRoles.STATE_USER) {
     searchParams = document.location.pathname
       .toString()
       .replace("/sections/", "")

--- a/services/ui-src/src/components/layout/FormActions.jsx
+++ b/services/ui-src/src/components/layout/FormActions.jsx
@@ -26,7 +26,21 @@ const FormActions = () => {
   let searchParams = "";
   let sectionId = "";
 
-  if (currentUser.role === AppRoles.CMS_ADMIN) {
+  const role = currentUser.role;
+  if (
+    role !== AppRoles.CMS_ADMIN &&
+    role !== AppRoles.INTERNAL_USER &&
+    role !== AppRoles.HELP_DESK &&
+    role !== AppRoles.CMS_APPROVER &&
+    role !== AppRoles.CMS_USER
+  ) {
+    searchParams = document.location.pathname
+      .toString()
+      .replace("/sections/", "")
+      .replace(formYear + "/", "");
+
+    sectionId = formYear + "-" + searchParams.substring(0, 2);
+  } else {
     const stateId = window.location.href.split("/")[5];
     searchParams = document.location.pathname
       .toString()
@@ -34,13 +48,6 @@ const FormActions = () => {
       .replace(formYear + "/", "");
 
     sectionId = formYear + "-" + searchParams.substring(1, 3);
-  } else {
-    searchParams = document.location.pathname
-      .toString()
-      .replace("/sections/", "")
-      .replace(formYear + "/", "");
-
-    sectionId = formYear + "-" + searchParams.substring(0, 2);
   }
 
   let subsectionId = sectionId + "-";


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
In [CMDCT-3984](https://jiraent.cms.gov/browse/CMDCT-3984) we fixed it so that admins could see the print section view. I didn't realize, however, that there are additional user types that have to get the specific URL type. Therefor I've updated the list so that those users dont have the site crash when attempting to print a particular form section.

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Using cms.admin@test.com, internaluser@test.com, help.desk@test.com, stateuser2@test.com, help.approver@test.com, and cms.user@test.com, login to carts and enter a report. 
Click on the print button on the bottom and click this section
See that the page loads correctly
Back out and click on the print button on the bottom and click this form
See that the page loads correctly

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

