### PR TITLE
Create ACS 2023 and FMAP 2025 Seed

### DIFF
--- a/services/database/data/seed-local/seed-acs.json
+++ b/services/database/data/seed-local/seed-acs.json
@@ -32,6 +32,22 @@
     "percentUninsuredMoe": 0.3
   },
   {
+    "stateId": "AL",
+    "year": 2021,
+    "numberUninsured": 26000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 2.2,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "AL",
+    "year": 2022,
+    "numberUninsured": 22000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 1.9,
+    "percentUninsuredMoe": 0.3
+  },
+  {
     "stateId": "AK",
     "year": 2015,
     "numberUninsured": 8000,

--- a/services/database/data/seed/seed-acs-2023.json
+++ b/services/database/data/seed/seed-acs-2023.json
@@ -1,0 +1,418 @@
+[
+  {
+    "stateId": "US",
+    "year": 2023,
+    "numberUninsured": 1987000,
+    "numberUninsuredMoe": 44000,
+    "percentUninsured": 2.6,
+    "percentUninsuredMoe": 0.1
+  },
+  {
+    "stateId": "AL",
+    "year": 2023,
+    "numberUninsured": 24000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 2.0,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "AK",
+    "year": 2023,
+    "numberUninsured": 5000,
+    "numberUninsuredMoe": 1000,
+    "percentUninsured": 2.6,
+    "percentUninsuredMoe": 0.6
+  },
+  {
+    "stateId": "AZ",
+    "year": 2023,
+    "numberUninsured": 68000,
+    "numberUninsuredMoe": 9000,
+    "percentUninsured": 4.1,
+    "percentUninsuredMoe": 0.5
+  },
+  {
+    "stateId": "AR",
+    "year": 2023,
+    "numberUninsured": 31000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 4.3,
+    "percentUninsuredMoe": 0.7
+  },
+  {
+    "stateId": "CA",
+    "year": 2023,
+    "numberUninsured": 118000,
+    "numberUninsuredMoe": 10000,
+    "percentUninsured": 1.3,
+    "percentUninsuredMoe": 0.1
+  },
+  {
+    "stateId": "CO",
+    "year": 2023,
+    "numberUninsured": 18000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 1.5,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "CT",
+    "year": 2023,
+    "numberUninsured": 11000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 1.5,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "DE",
+    "year": 2023,
+    "numberUninsured": 6000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 2.7,
+    "percentUninsuredMoe": 1.3
+  },
+  {
+    "stateId": "DC",
+    "year": 2023,
+    "numberUninsured": 0,
+    "numberUninsuredMoe": 0,
+    "percentUninsured": 0.2,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "FL",
+    "year": 2023,
+    "numberUninsured": 157000,
+    "numberUninsuredMoe": 12000,
+    "percentUninsured": 3.5,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "GA",
+    "year": 2023,
+    "numberUninsured": 81000,
+    "numberUninsuredMoe": 7000,
+    "percentUninsured": 3.1,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "HI",
+    "year": 2023,
+    "numberUninsured": 3000,
+    "numberUninsuredMoe": 1000,
+    "percentUninsured": 1.1,
+    "percentUninsuredMoe": 0.5
+  },
+  {
+    "stateId": "ID",
+    "year": 2023,
+    "numberUninsured": 10000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 2.0,
+    "percentUninsuredMoe": 0.5
+  },
+  {
+    "stateId": "IL",
+    "year": 2023,
+    "numberUninsured": 41000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 1.4,
+    "percentUninsuredMoe": 0.2
+  },
+  {
+    "stateId": "IN",
+    "year": 2023,
+    "numberUninsured": 46000,
+    "numberUninsuredMoe": 9000,
+    "percentUninsured": 2.8,
+    "percentUninsuredMoe": 0.5
+  },
+  {
+    "stateId": "IA",
+    "year": 2023,
+    "numberUninsured": 15000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 2.0,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "KS",
+    "year": 2023,
+    "numberUninsured": 17000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 2.4,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "KY",
+    "year": 2023,
+    "numberUninsured": 19000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 1.9,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "LA",
+    "year": 2023,
+    "numberUninsured": 29000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 2.6,
+    "percentUninsuredMoe": 0.5
+  },
+  {
+    "stateId": "ME",
+    "year": 2023,
+    "numberUninsured": 4000,
+    "numberUninsuredMoe": 1000,
+    "percentUninsured": 1.6,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "MD",
+    "year": 2023,
+    "numberUninsured": 33000,
+    "numberUninsuredMoe": 6000,
+    "percentUninsured": 2.4,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "MA",
+    "year": 2023,
+    "numberUninsured": 10000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 0.7,
+    "percentUninsuredMoe": 0.2
+  },
+  {
+    "stateId": "MI",
+    "year": 2023,
+    "numberUninsured": 35000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 1.6,
+    "percentUninsuredMoe": 0.2
+  },
+  {
+    "stateId": "MN",
+    "year": 2023,
+    "numberUninsured": 18000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 1.3,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "MS",
+    "year": 2023,
+    "numberUninsured": 26000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 3.7,
+    "percentUninsuredMoe": 0.7
+  },
+  {
+    "stateId": "MO",
+    "year": 2023,
+    "numberUninsured": 39000,
+    "numberUninsuredMoe": 6000,
+    "percentUninsured": 2.8,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "MT",
+    "year": 2023,
+    "numberUninsured": 9000,
+    "numberUninsuredMoe": 2000,
+    "percentUninsured": 3.6,
+    "percentUninsuredMoe": 0.9
+  },
+  {
+    "stateId": "NE",
+    "year": 2023,
+    "numberUninsured": 10000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 1.9,
+    "percentUninsuredMoe": 0.5
+  },
+  {
+    "stateId": "NV",
+    "year": 2023,
+    "numberUninsured": 28000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 4.0,
+    "percentUninsuredMoe": 0.8
+  },
+  {
+    "stateId": "NH",
+    "year": 2023,
+    "numberUninsured": 3000,
+    "numberUninsuredMoe": 1000,
+    "percentUninsured": 1.0,
+    "percentUninsuredMoe": 0.5
+  },
+  {
+    "stateId": "NJ",
+    "year": 2023,
+    "numberUninsured": 40000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 1.9,
+    "percentUninsuredMoe": 0.2
+  },
+  {
+    "stateId": "NM",
+    "year": 2023,
+    "numberUninsured": 14000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 3.0,
+    "percentUninsuredMoe": 0.6
+  },
+  {
+    "stateId": "NY",
+    "year": 2023,
+    "numberUninsured": 51000,
+    "numberUninsuredMoe": 6000,
+    "percentUninsured": 1.3,
+    "percentUninsuredMoe": 0.1
+  },
+  {
+    "stateId": "NC",
+    "year": 2023,
+    "numberUninsured": 67000,
+    "numberUninsuredMoe": 8000,
+    "percentUninsured": 2.8,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "ND",
+    "year": 2023,
+    "numberUninsured": 2000,
+    "numberUninsuredMoe": 1000,
+    "percentUninsured": 1.3,
+    "percentUninsuredMoe": 0.6
+  },
+  {
+    "stateId": "OH",
+    "year": 2023,
+    "numberUninsured": 66000,
+    "numberUninsuredMoe": 9000,
+    "percentUninsured": 2.5,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "OK",
+    "year": 2023,
+    "numberUninsured": 38000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 3.8,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "OR",
+    "year": 2023,
+    "numberUninsured": 10000,
+    "numberUninsuredMoe": 2000,
+    "percentUninsured": 1.1,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "PA",
+    "year": 2023,
+    "numberUninsured": 71000,
+    "numberUninsuredMoe": 9000,
+    "percentUninsured": 2.6,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "RI",
+    "year": 2023,
+    "numberUninsured": 3000,
+    "numberUninsuredMoe": 2000,
+    "percentUninsured": 1.4,
+    "percentUninsuredMoe": 0.9
+  },
+  {
+    "stateId": "SC",
+    "year": 2023,
+    "numberUninsured": 39000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 3.3,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "SD",
+    "year": 2023,
+    "numberUninsured": 11000,
+    "numberUninsuredMoe": 3000,
+    "percentUninsured": 4.6,
+    "percentUninsuredMoe": 1.2
+  },
+  {
+    "stateId": "TN",
+    "year": 2023,
+    "numberUninsured": 49000,
+    "numberUninsuredMoe": 8000,
+    "percentUninsured": 3.0,
+    "percentUninsuredMoe": 0.5
+  },
+  {
+    "stateId": "TX",
+    "year": 2023,
+    "numberUninsured": 488000,
+    "numberUninsuredMoe": 23000,
+    "percentUninsured": 6.2,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "UT",
+    "year": 2023,
+    "numberUninsured": 29000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 2.9,
+    "percentUninsuredMoe": 0.5
+  },
+  {
+    "stateId": "VT",
+    "year": 2023,
+    "numberUninsured": 0,
+    "numberUninsuredMoe": 0,
+    "percentUninsured": 0.4,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "VA",
+    "year": 2023,
+    "numberUninsured": 35000,
+    "numberUninsuredMoe": 6000,
+    "percentUninsured": 1.8,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "WA",
+    "year": 2023,
+    "numberUninsured": 24000,
+    "numberUninsuredMoe": 5000,
+    "percentUninsured": 1.4,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "WV",
+    "year": 2023,
+    "numberUninsured": 5000,
+    "numberUninsuredMoe": 2000,
+    "percentUninsured": 1.3,
+    "percentUninsuredMoe": 0.4
+  },
+  {
+    "stateId": "WI",
+    "year": 2023,
+    "numberUninsured": 29000,
+    "numberUninsuredMoe": 4000,
+    "percentUninsured": 2.3,
+    "percentUninsuredMoe": 0.3
+  },
+  {
+    "stateId": "WY",
+    "year": 2023,
+    "numberUninsured": 4000,
+    "numberUninsuredMoe": 1000,
+    "percentUninsured": 2.8,
+    "percentUninsuredMoe": 1.0
+  }
+]

--- a/services/database/data/seed/seed-fmap.json
+++ b/services/database/data/seed/seed-fmap.json
@@ -12,7 +12,7 @@
   {
     "stateId": "AS",
     "fiscalYear": 2021,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "AZ",
@@ -62,7 +62,7 @@
   {
     "stateId": "GU",
     "fiscalYear": 2021,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "HI",
@@ -207,7 +207,7 @@
   {
     "stateId": "PR",
     "fiscalYear": 2021,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "RI",
@@ -247,7 +247,7 @@
   {
     "stateId": "VI",
     "fiscalYear": 2021,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "VA",
@@ -287,7 +287,7 @@
   {
     "stateId": "AS",
     "fiscalYear": 2022,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "AZ",
@@ -337,7 +337,7 @@
   {
     "stateId": "GU",
     "fiscalYear": 2022,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "HI",
@@ -482,7 +482,7 @@
   {
     "stateId": "PR",
     "fiscalYear": 2022,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "RI",
@@ -522,7 +522,7 @@
   {
     "stateId": "VI",
     "fiscalYear": 2022,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "VA",
@@ -562,7 +562,7 @@
   {
     "stateId": "AS",
     "fiscalYear": 2023,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "AZ",
@@ -612,7 +612,7 @@
   {
     "stateId": "GU",
     "fiscalYear": 2023,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "HI",
@@ -652,12 +652,12 @@
   {
     "stateId": "LA",
     "fiscalYear": 2023,
-    "enhancedFmap": 77.10
+    "enhancedFmap": 77.1
   },
   {
     "stateId": "ME",
     "fiscalYear": 2023,
-    "enhancedFmap": 74.30
+    "enhancedFmap": 74.3
   },
   {
     "stateId": "MD",
@@ -672,7 +672,7 @@
   {
     "stateId": "MI",
     "fiscalYear": 2023,
-    "enhancedFmap": 75.30
+    "enhancedFmap": 75.3
   },
   {
     "stateId": "MN",
@@ -682,7 +682,7 @@
   {
     "stateId": "MS",
     "fiscalYear": 2023,
-    "enhancedFmap": 84.50
+    "enhancedFmap": 84.5
   },
   {
     "stateId": "MO",
@@ -727,7 +727,7 @@
   {
     "stateId": "NC",
     "fiscalYear": 2023,
-    "enhancedFmap": 77.40
+    "enhancedFmap": 77.4
   },
   {
     "stateId": "ND",
@@ -752,12 +752,12 @@
   {
     "stateId": "PA",
     "fiscalYear": 2023,
-    "enhancedFmap": 66.40
+    "enhancedFmap": 66.4
   },
   {
     "stateId": "PR",
     "fiscalYear": 2023,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "RI",
@@ -797,7 +797,7 @@
   {
     "stateId": "VI",
     "fiscalYear": 2023,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "VA",
@@ -837,17 +837,17 @@
   {
     "stateId": "AS",
     "fiscalYear": 2024,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "AZ",
     "fiscalYear": 2024,
-    "enhancedFmap": 76.40
+    "enhancedFmap": 76.4
   },
   {
     "stateId": "AR",
     "fiscalYear": 2024,
-    "enhancedFmap": 80.40
+    "enhancedFmap": 80.4
   },
   {
     "stateId": "CA",
@@ -867,7 +867,7 @@
   {
     "stateId": "DE",
     "fiscalYear": 2024,
-    "enhancedFmap": 71.80
+    "enhancedFmap": 71.8
   },
   {
     "stateId": "DC",
@@ -887,7 +887,7 @@
   {
     "stateId": "GU",
     "fiscalYear": 2024,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "HI",
@@ -1032,7 +1032,7 @@
   {
     "stateId": "PR",
     "fiscalYear": 2024,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "RI",
@@ -1072,7 +1072,7 @@
   {
     "stateId": "VI",
     "fiscalYear": 2024,
-    "enhancedFmap": 68.50
+    "enhancedFmap": 68.5
   },
   {
     "stateId": "VA",
@@ -1097,6 +1097,281 @@
   {
     "stateId": "WY",
     "fiscalYear": 2024,
+    "enhancedFmap": 65.0
+  },
+  {
+    "stateId": "AL",
+    "fiscalYear": 2025,
+    "enhancedFmap": 80.99
+  },
+  {
+    "stateId": "AK",
+    "fiscalYear": 2025,
+    "enhancedFmap": 66.08
+  },
+  {
+    "stateId": "AS",
+    "fiscalYear": 2025,
+    "enhancedFmap": 85.0
+  },
+  {
+    "stateId": "AZ",
+    "fiscalYear": 2025,
+    "enhancedFmap": 75.42
+  },
+  {
+    "stateId": "AR",
+    "fiscalYear": 2025,
+    "enhancedFmap": 79.8
+  },
+  {
+    "stateId": "CA",
+    "fiscalYear": 2025,
+    "enhancedFmap": 65.0
+  },
+  {
+    "stateId": "CO",
+    "fiscalYear": 2025,
+    "enhancedFmap": 65.0
+  },
+  {
+    "stateId": "CT",
+    "fiscalYear": 2025,
+    "enhancedFmap": 65.0
+  },
+  {
+    "stateId": "DE",
+    "fiscalYear": 2025,
+    "enhancedFmap": 72.11
+  },
+  {
+    "stateId": "DC",
+    "fiscalYear": 2025,
+    "enhancedFmap": 79.0
+  },
+  {
+    "stateId": "FL",
+    "fiscalYear": 2025,
+    "enhancedFmap": 70.02
+  },
+  {
+    "stateId": "GA",
+    "fiscalYear": 2025,
+    "enhancedFmap": 76.23
+  },
+  {
+    "stateId": "GU",
+    "fiscalYear": 2025,
+    "enhancedFmap": 85.0
+  },
+  {
+    "stateId": "HI",
+    "fiscalYear": 2025,
+    "enhancedFmap": 71.36
+  },
+  {
+    "stateId": "ID",
+    "fiscalYear": 2025,
+    "enhancedFmap": 77.31
+  },
+  {
+    "stateId": "IL",
+    "fiscalYear": 2025,
+    "enhancedFmap": 65.97
+  },
+  {
+    "stateId": "IN",
+    "fiscalYear": 2025,
+    "enhancedFmap": 75.43
+  },
+  {
+    "stateId": "IA",
+    "fiscalYear": 2025,
+    "enhancedFmap": 74.28
+  },
+  {
+    "stateId": "KS",
+    "fiscalYear": 2025,
+    "enhancedFmap": 73.31
+  },
+  {
+    "stateId": "KY",
+    "fiscalYear": 2025,
+    "enhancedFmap": 80.04
+  },
+  {
+    "stateId": "LA",
+    "fiscalYear": 2025,
+    "enhancedFmap": 77.64
+  },
+  {
+    "stateId": "ME",
+    "fiscalYear": 2025,
+    "enhancedFmap": 73.44
+  },
+  {
+    "stateId": "MD",
+    "fiscalYear": 2025,
+    "enhancedFmap": 65.0
+  },
+  {
+    "stateId": "MA",
+    "fiscalYear": 2025,
+    "enhancedFmap": 65.0
+  },
+  {
+    "stateId": "MI",
+    "fiscalYear": 2025,
+    "enhancedFmap": 75.59
+  },
+  {
+    "stateId": "MN",
+    "fiscalYear": 2025,
+    "enhancedFmap": 65.81
+  },
+  {
+    "stateId": "MS",
+    "fiscalYear": 2025,
+    "enhancedFmap": 83.83
+  },
+  {
+    "stateId": "MO",
+    "fiscalYear": 2025,
+    "enhancedFmap": 75.72
+  },
+  {
+    "stateId": "MT",
+    "fiscalYear": 2025,
+    "enhancedFmap": 73.66
+  },
+  {
+    "stateId": "NE",
+    "fiscalYear": 2025,
+    "enhancedFmap": 70.26
+  },
+  {
+    "stateId": "NV",
+    "fiscalYear": 2025,
+    "enhancedFmap": 72.15
+  },
+  {
+    "stateId": "NH",
+    "fiscalYear": 2025,
+    "enhancedFmap": 65.0
+  },
+  {
+    "stateId": "NJ",
+    "fiscalYear": 2025,
+    "enhancedFmap": 65.0
+  },
+  {
+    "stateId": "NM",
+    "fiscalYear": 2025,
+    "enhancedFmap": 80.18
+  },
+  {
+    "stateId": "NY",
+    "fiscalYear": 2025,
+    "enhancedFmap": 65.0
+  },
+  {
+    "stateId": "NC",
+    "fiscalYear": 2025,
+    "enhancedFmap": 75.54
+  },
+  {
+    "stateId": "ND",
+    "fiscalYear": 2025,
+    "enhancedFmap": 65.68
+  },
+  {
+    "stateId": "OH",
+    "fiscalYear": 2025,
+    "enhancedFmap": 75.22
+  },
+  {
+    "stateId": "OK",
+    "fiscalYear": 2025,
+    "enhancedFmap": 76.96
+  },
+  {
+    "stateId": "OR",
+    "fiscalYear": 2025,
+    "enhancedFmap": 71.3
+  },
+  {
+    "stateId": "PA",
+    "fiscalYear": 2025,
+    "enhancedFmap": 68.56
+  },
+  {
+    "stateId": "PR",
+    "fiscalYear": 2025,
+    "enhancedFmap": 83.2
+  },
+  {
+    "stateId": "RI",
+    "fiscalYear": 2025,
+    "enhancedFmap": 69.42
+  },
+  {
+    "stateId": "SC",
+    "fiscalYear": 2025,
+    "enhancedFmap": 78.77
+  },
+  {
+    "stateId": "SD",
+    "fiscalYear": 2025,
+    "enhancedFmap": 67.15
+  },
+  {
+    "stateId": "TN",
+    "fiscalYear": 2025,
+    "enhancedFmap": 75.37
+  },
+  {
+    "stateId": "TX",
+    "fiscalYear": 2025,
+    "enhancedFmap": 72.0
+  },
+  {
+    "stateId": "UT",
+    "fiscalYear": 2025,
+    "enhancedFmap": 75.05
+  },
+  {
+    "stateId": "VT",
+    "fiscalYear": 2025,
+    "enhancedFmap": 70.73
+  },
+  {
+    "stateId": "VI",
+    "fiscalYear": 2025,
+    "enhancedFmap": 85.0
+  },
+  {
+    "stateId": "VA",
+    "fiscalYear": 2025,
+    "enhancedFmap": 65.69
+  },
+  {
+    "stateId": "WA",
+    "fiscalYear": 2025,
+    "enhancedFmap": 65.0
+  },
+  {
+    "stateId": "WV",
+    "fiscalYear": 2025,
+    "enhancedFmap": 81.69
+  },
+  {
+    "stateId": "WI",
+    "fiscalYear": 2025,
+    "enhancedFmap": 72.3
+  },
+  {
+    "stateId": "WY",
+    "fiscalYear": 2025,
     "enhancedFmap": 65.0
   }
 ]

--- a/services/database/handlers/seed/tables/acs-2023.js
+++ b/services/database/handlers/seed/tables/acs-2023.js
@@ -1,0 +1,8 @@
+const seed = {
+  name: "ACS 2023",
+  data: require("../../../data/seed/seed-acs-2023.json"),
+  tableNameBuilder: (stage) => `${stage}-acs`,
+  keys: ["stateId", "year"],
+};
+
+module.exports = seed;

--- a/services/database/handlers/seed/tables/index.js
+++ b/services/database/handlers/seed/tables/index.js
@@ -1,6 +1,7 @@
 const tables = [
   require("./acs-2021"),
   require("./acs-2022"),
+  require("./acs-2023"),
   require("./fmap"),
   require("./sectionBase"),
 ];

--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -49,6 +49,7 @@ custom:
                 ./data/seed-local/seed-acs.json,
                 ./data/seed/seed-acs-2021.json,
                 ./data/seed/seed-acs-2022.json,
+                ./data/seed/seed-acs-2023.json,
               ]
           - table: ${self:custom.fmapTableName}
             sources: [./data/seed-local/seed-fmap.json]


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Late Wednesday (Oct 23rd), A CARTS User reported that there was data not available for the Section 2 Part 2 table. Upon investigation, it looks like there is a separate seed process that needs to happen each year. Using last years tickets (See below) I followed the same steps and used [this sites HI-10_ACS.xcl file](https://www.census.gov/data/tables/time-series/demo/health-insurance/acs-hi.html) to file in the relevant numbers for 2023. This was confirmed by the BO's today (Friday, Oct 25th) to be correct.

In addition, the BO's let us know that the fmap numbers are also seeded and needed to be updated. They follow a similar process and the data can be grabbed from the [Federal Register for 2025](https://www.federalregister.gov/documents/2023/11/21/2023-25636/federal-financial-participation-in-state-assistance-expenditures-federal-matching-shares-for). We will need to follow up for 2026's numbers soon, but those numbers are not published yet.



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2919
CMDCT-2949

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Open the deployed instance (https://d3efzxo0yvx2p8.cloudfront.net/)
Open up a 2024 report
Navigate to Section 2, Part 2
Using the seed-acs-2023.json file, note that the table here has the exact same numbers for 2023 as the seed file.
Navigate to Section 5, Part 2 Table 3 (Federal and State Shares Table)
Using the seed-fmap.json file, note that the table here has the exact same numbers for 2025 as the seed file.

Extra credit:
Double check my numbers if you have the time. I'd owe ya big time 🤗. 

seed-acs-2023 gets its numbers from [this site](https://www.census.gov/data/tables/time-series/demo/health-insurance/acs-hi.html), under the link HI-10_ACS (It'll open a file called hi10_acs.xcl. We're using the numbers from columns D-G.

seed-fmap gets its numbers from [this site](https://www.federalregister.gov/documents/2023/11/21/2023-25636/federal-financial-participation-in-state-assistance-expenditures-federal-matching-shares-for), using the first tables right most column (The Enhanced federal medical assistance percentages). 


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Product: This work has been reviewed and approved by product owner, if necessary
