### PR TITLE
Skip topic delete in ephemeral branches since we don't deploy them

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -56,14 +56,14 @@ jobs:
         with:
           role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
-      - name: Delete topics from bigmac
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: Delete Topics
-          repo: Enterprise-CMCS/bigmac
-          token: ${{ secrets.AUTOMATION_ACCESS_TOKEN }}
-          inputs: '{ "topics": "mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.config,mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.offsets,mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.status"}'
-          ref: refs/heads/master # Otherwise workflow-dispatch tries to operate off of our default name
+      # - name: Delete topics from bigmac
+      #   uses: benc-uk/workflow-dispatch@v1
+      #   with:
+      #     workflow: Delete Topics
+      #     repo: Enterprise-CMCS/bigmac
+      #     token: ${{ secrets.AUTOMATION_ACCESS_TOKEN }}
+      #     inputs: '{ "topics": "mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.config,mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.offsets,mgmt.connect.cms-carts-seds.carts-bigmac-streams-${{env.BRANCH_NAME}}.status"}'
+      #     ref: refs/heads/master # Otherwise workflow-dispatch tries to operate off of our default name
       - name: Destroy
         run: ./run destroy --stage $STAGE_PREFIX$branch_name --verify false
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Branch destroys are failing because it can't find/fire the topic delete function. At the moment we don't deploy topics/kafka infra to ephemeral branches and in the future we can improve this with CDK so for now ignore :)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-none

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Tested [here](https://github.com/Enterprise-CMCS/macpro-mdct-carts/actions/runs/11578247751)

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment
