### PR TITLE
Ticket CS2371782: Add global param to signout

### DIFF
--- a/services/ui-src/src/hooks/authHooks/authLifecycle.js
+++ b/services/ui-src/src/hooks/authHooks/authLifecycle.js
@@ -28,7 +28,7 @@ class AuthManager {
     const isExpired = expiration && new Date(expiration).valueOf() < Date.now();
     if (isExpired) {
       localStorage.removeItem("mdctcarts_session_exp");
-      signOut().then(() => {
+      signOut({ global: true }).then(() => {
         window.location.href = "/";
       });
     }
@@ -76,7 +76,7 @@ class AuthManager {
         this.promptTimeout(exp);
         this.timeoutForceId = setTimeout(() => {
           localStorage.removeItem("mdctcarts_session_exp");
-          signOut();
+          signOut({ global: true });
         }, IDLE_WINDOW - PROMPT_AT);
       },
       PROMPT_AT,

--- a/services/ui-src/src/hooks/authHooks/userProvider.jsx
+++ b/services/ui-src/src/hooks/authHooks/userProvider.jsx
@@ -32,7 +32,7 @@ export const UserProvider = ({ children }) => {
     try {
       setUser(null);
       localStorage.removeItem("mdctcarts_session_exp");
-      await signOut();
+      await signOut({ global: true });
     } catch (error) {
       console.log("error signing out: ", error); // eslint-disable-line no-console
     }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
[This user] selects the sign out link in CARTS and is taken to OKTA dashboard. He then selects the log out link from Okta and is routed to the IDM login screen, which suggests that he's logged out now from both CARTS and OKTA. But if the user enters the CARTS URL in the browser's address bar and presses Enter, he's taken right back into CARTS without being prompted to sign in. If the user then enters the IDM URL that shows that he is signed out of IDM because it prompted him to sign in, but if doesn't sign in at that point and then again enters the CARTS URL he's still able to access CARTS without another sign in. Same results after clearing cache in Chrome and same issue if using Firefox. Help desk is able to reproduce this behavior on multiple laptops in Chrome and Firefox.

We're going to attempt to fix this with the global signout param being passed. You can read more about that here: https://docs.amplify.aws/react/build-a-backend/auth/connect-your-frontend/sign-out/

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
See above. https://dmkyt4bm6nwc2.cloudfront.net/

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary
