### PR TITLE
Amplify debugging: Remove force refresh flag

### DIFF
--- a/services/ui-src/src/hooks/authHooks/authLifecycle.js
+++ b/services/ui-src/src/hooks/authHooks/authLifecycle.js
@@ -57,7 +57,7 @@ class AuthManager {
    * Manual refresh of credentials paired with an instant timer clear
    */
   async refreshCredentials() {
-    await fetchAuthSession({ forceRefresh: true }); // Force a token refresh
+    await fetchAuthSession(); // Look for an active session (indirectly refreshes?)
     this.setTimer();
   }
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Our refresh flow checks for the current user, which we are thinking indirectly does a refresh of the tokens. We currently have a flag enabled to check Cognito directly for the user. Let's try removing that flag and see what it does with our local session (which will be cleared on logout).

[Docs](https://docs.amplify.aws/gen1/react/build-a-backend/auth/manage-user-session/#refreshing-sessions)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Merge to main and see if auth flow works?

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
Guess

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment
