### PR TITLE
Try calling windowlocation inside timeout and after await

### DIFF
--- a/services/ui-src/src/hooks/authHooks/userProvider.jsx
+++ b/services/ui-src/src/hooks/authHooks/userProvider.jsx
@@ -35,12 +35,11 @@ export const UserProvider = ({ children }) => {
         setUser(null);
         localStorage.removeItem("mdctcarts_session_exp");
         await signOut();
-        window.location.href = "/admin";
+        window.location.href = config.POST_SIGNOUT_REDIRECT;
       } catch (error) {
         console.log("error signing out: ", error); // eslint-disable-line no-console
       }
     });
-    window.location.href = config.POST_SIGNOUT_REDIRECT;
   }, []);
 
   const checkAuthState = useCallback(async () => {

--- a/services/ui-src/src/hooks/authHooks/userProvider.jsx
+++ b/services/ui-src/src/hooks/authHooks/userProvider.jsx
@@ -35,7 +35,6 @@ export const UserProvider = ({ children }) => {
         setUser(null);
         localStorage.removeItem("mdctcarts_session_exp");
         await signOut();
-        window.location.href = config.POST_SIGNOUT_REDIRECT;
       } catch (error) {
         console.log("error signing out: ", error); // eslint-disable-line no-console
       }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

Feels like because the logout method is async, its calling the window.location.href at the same time as the logout is happening causing a race condition and making the logout get cancelled. Would this fix it if its specifically after the await call?
