### PR TITLE
Upgrade kafkajs package

### DIFF
--- a/services/carts-bigmac-streams/libs/kafka-source-lib.js
+++ b/services/carts-bigmac-streams/libs/kafka-source-lib.js
@@ -5,6 +5,7 @@ const STAGE = process.env.STAGE;
 const kafka = new Kafka({
   clientId: `carts-${STAGE}`,
   brokers: process.env.BOOTSTRAP_BROKER_STRING_TLS.split(","),
+  enforceRequestTimeout: false,
   retry: {
     initialRetryTime: 300,
     retries: 8,
@@ -49,7 +50,7 @@ class KafkaSourceLib {
     }
   }
 
-  doUnmarshall(r) {
+  dynamoUnmarshall(r) {
     return unmarshall(r);
   }
 
@@ -61,9 +62,9 @@ class KafkaSourceLib {
     const dynamodb = record.dynamodb;
     const { eventID, eventName } = record;
     const dynamoRecord = {
-      NewImage: this.doUnmarshall(dynamodb.NewImage),
-      OldImage: this.doUnmarshall(dynamodb.OldImage ?? {}),
-      Keys: this.doUnmarshall(dynamodb.Keys),
+      NewImage: this.dynamoUnmarshall(dynamodb.NewImage),
+      OldImage: this.dynamoUnmarshall(dynamodb.OldImage ?? {}),
+      Keys: this.dynamoUnmarshall(dynamodb.Keys),
     };
     return {
       key: Object.values(dynamoRecord.Keys).join("#"),

--- a/services/carts-bigmac-streams/package.json
+++ b/services/carts-bigmac-streams/package.json
@@ -6,6 +6,6 @@
     "@aws-sdk/client-dynamodb": "^3.687.0",
     "@aws-sdk/lib-dynamodb": "^3.687.0",
     "@aws-sdk/util-dynamodb": "^3.687.0",
-    "kafkajs": "^1.16.0"
+    "kafkajs": "^2.2.4"
   }
 }

--- a/services/carts-bigmac-streams/yarn.lock
+++ b/services/carts-bigmac-streams/yarn.lock
@@ -1004,10 +1004,10 @@ fast-xml-parser@4.4.1:
   dependencies:
     strnum "^1.0.5"
 
-kafkajs@^1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/kafkajs/-/kafkajs-1.16.0.tgz#bfcc3ae2b69265ca8435b53a01ee9e8787b9fee5"
-  integrity sha512-+Rcfu2hyQ/jv5skqRY8xA7Ra+mmRkDAzCaLDYbkGtgsNKpzxPWiLbk8ub0dgr4EbWrN1Zb4BCXHUkD6+zYfdWg==
+kafkajs@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/kafkajs/-/kafkajs-2.2.4.tgz#59e6e16459d87fdf8b64be73970ed5aa42370a5b"
+  integrity sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==
 
 mnemonist@0.38.3:
   version "0.38.3"

--- a/src/run.ts
+++ b/src/run.ts
@@ -161,10 +161,9 @@ async function deploy(options: { stage: string }) {
   const deployCmd = ["sls", "deploy", "--stage", stage];
   await runner.run_command_and_output("SLS Deploy", deployCmd, ".");
   // Only deploy resources for kafka ingestion in real envs
-
-  // if (stage === "main" || stage === "val" || stage === "production") {
-  await deploy_kafka_service(runner, stage);
-  // }
+  if (stage === "main" || stage === "val" || stage === "production") {
+    await deploy_kafka_service(runner, stage);
+  }
 }
 
 async function destroy_stage(options: {

--- a/src/run.ts
+++ b/src/run.ts
@@ -161,9 +161,10 @@ async function deploy(options: { stage: string }) {
   const deployCmd = ["sls", "deploy", "--stage", stage];
   await runner.run_command_and_output("SLS Deploy", deployCmd, ".");
   // Only deploy resources for kafka ingestion in real envs
-  if (stage === "main" || stage === "val" || stage === "production") {
-    await deploy_kafka_service(runner, stage);
-  }
+
+  // if (stage === "main" || stage === "val" || stage === "production") {
+  await deploy_kafka_service(runner, stage);
+  // }
 }
 
 async function destroy_stage(options: {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Upgrade kafkajs package to major version 2
- Rename unmarshall function for clarity
  - although we could just use this function directly, I think the wrapper at least allows future updates to be easier. I believe when we went from v2 to v3 in aws-sdk we had to remove a configuration parameter on the unmarshaller

Resources:
[Release log](https://github.com/tulios/kafkajs/releases)
[Official migration guide](https://kafka.js.org/docs/migration-guide-v2.0.0)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4174

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Perform actions that update the DB
- Check the kafka lambda logs to ensure they update (`carts-bigmac-streams-cmdct-4174-postKafkaData`)

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
I matched functionality from v1. For example: timeouts are now default, but I disabled them in our config to match what we did before `enforceRequestTimeout: false`

The new functionality allows headers to be arrays, and expects us to check for them. Nowhere in our code do we use `.headers` so I think we are ok. I verified our lambda logs can process arrays of messages as well.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment