### PR TITLE
Admin view is same as state user for hidden fields

### DIFF
--- a/services/ui-src/src/util/shouldDisplay.js
+++ b/services/ui-src/src/util/shouldDisplay.js
@@ -1,5 +1,4 @@
 import { selectFragmentById } from "../store/formData";
-import { AppRoles } from "../types";
 import jsonpath from "./jsonpath";
 import {
   compareACS,
@@ -218,8 +217,6 @@ const shouldDisplay = (
   chipEnrollments,
   context
 ) => {
-  if (currentUserRole === AppRoles.CMS_ADMIN) return true;
-
   if (
     !context ||
     (!context.conditional_display && !context.show_if_state_program_type_in)
@@ -238,7 +235,7 @@ const shouldDisplay = (
 
   /*
    * hide_if: there is just one target (question) with a single answer
-   * displaying relies on that answer being incldued in the hide_if.values.interactive array
+   * displaying relies on that answer being included in the hide_if.values.interactive array
    */
   if (context.conditional_display.hide_if) {
     return !hideIf(formData, context.conditional_display.hide_if);

--- a/services/ui-src/src/util/shouldDisplay.test.js
+++ b/services/ui-src/src/util/shouldDisplay.test.js
@@ -1,5 +1,4 @@
 import { shouldDisplay } from "./shouldDisplay";
-import { AppRoles } from "../types";
 import { selectFragmentById } from "../store/formData";
 
 const mockFragmentResult = {
@@ -13,18 +12,6 @@ jest.mock("../store/formData", () => ({
 
 describe("shouldDisplay", () => {
   beforeEach(() => jest.clearAllMocks());
-
-  it("should display everything for CMS Admins", () => {
-    const state = {
-      stateUser: {
-        currentUser: {
-          role: AppRoles.CMS_ADMIN,
-        },
-      },
-    };
-    const result = shouldDisplay(state, null);
-    expect(result).toBe(true);
-  });
 
   it("should display everything if no context is provided", () => {
     const state = {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Section 3c Part 5 Questions 2 and 3
- If a user selects "Yes" for question 2
  - Question 3 shows b-e (split age groups)
- If a user selects "No" for question 2
  - Question 3 shows a (total for age range)

The admin user was seeing a/b-e when the state user was not because of this logic in the conditional rendering function to let admins see everything. The problem was the total integer (a) was not calculating based on b-e because they are never meant to show at the same time. Now they don't!

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3917

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Go to any report, 3c, Part 5
- Toggle between "Yes" and "No" for question 2
- Verify question 3 responds as described above
- Verify you cannot see `3a` or `3b-e` when the other is showing
- Log in as an admin user
- Verify you only see what the state user could see for the selected option

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
Does this have unintended consequences elsewhere?

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary
---