### PR TITLE
CMDCT-4341 Add WCAG 2.1 and 2.2

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -125,7 +125,14 @@ Cypress.Commands.add("checkA11yOfPage", () => {
   cy.checkA11y(
     null,
     {
-      values: ["wcag2a", "wcag2aa"],
+      values: [
+        "wcag2a",
+        "wcag2aa",
+        "wcag21a",
+        "wcag21aa",
+        "wcag22aa",
+        "best-practice",
+      ],
       includedImpacts: ["minor", "moderate", "serious", "critical"], // options: "minor", "moderate", "serious", "critical"
     },
     terminalLog,


### PR DESCRIPTION
### Description
Add WCAG 2.1 AA and WCAG 2.2 AA [rules to axe-core](https://www.deque.com/axe/core-documentation/api-documentation/#:~:text=the%20analysis%20again.-,axe-core%20tags,-Each%20rule%20in).


### Related ticket(s)
CMDCT-4341
CMDCT-4336 (the same work in MCR)

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
