### PR TITLE
Move import from dom library to standard react testing library

### DIFF
--- a/logs/todos.log
+++ b/logs/todos.log
@@ -6,7 +6,6 @@
 ./services/ui-src/serverless.yml:57: TODO: [MDCT-300] handle react hooks warnings then remove CI=false
 ./services/ui-src/src/components/fields/NoninteractiveTable.jsx:49: TODO Remove this custom logic when rewriting backend
 ./services/ui-src/src/components/layout/UploadComponent.jsx:132: TODO: when one file errors, the others are loaded but the error stays
-./services/ui-src/src/components/layout/UploadComponent.test.jsx:11: TODO remove direct dependency on @testing-library/dom ?
 ./services/ui-src/src/store/formData.js:242: TODO: account for objectives/repeatables here.
 ./services/ui-src/src/store/lastYearFormData.js:146: TODO: account for objectives/repeatables here.
 ./services/ui-src/src/util/synthesize.test.js:1: TODO: Fix this testing suite, it is outdated

--- a/services/ui-src/src/components/layout/UploadComponent.test.jsx
+++ b/services/ui-src/src/components/layout/UploadComponent.test.jsx
@@ -1,14 +1,11 @@
 import React from "react";
-import { screen, render } from "@testing-library/react";
+import { screen, render, within } from "@testing-library/react";
 import userEventLib from "@testing-library/user-event";
-import { within } from "@testing-library/dom";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
 import UploadComponent from "./UploadComponent";
 import { AppRoles, REPORT_STATUS } from "../../types";
 import fileApi from "../../util/fileApi";
-
-// TODO remove direct dependency on @testing-library/dom ?
 
 /**
  * When applyAccept is true, `user-event` will refuse to upload files whose


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Knockout one small TODO!

The [within](https://testing-library.com/docs/dom-testing-library/api-within/) function exists in react testing library, which we are already importing, so we can import from there.

Note: I tried removing the testing-library/dom import from the package but the tests failed so we still need it, we just don't need to import `within` from it

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- unit tests still pass


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment