### PR TITLE
Don't bundle jsdom in app-api serverless file

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -110,7 +110,17 @@ provider:
     uploadsTableName: ${self:custom.uploadsTableName}
     uploadS3BucketName: !Sub ${env:attachmentsBucketName, "uploads-${self:custom.stage}-attachments-${AWS::AccountId}"}
     stage: ${self:custom.stage}
-
+build:
+  esbuild:
+    bundle: true
+    # NPM packages to not be bundled, and instead be available in node_modules, and the zip file uploaded to Lambda.
+    #
+    # We specify jsdom here, to avoid issues with its internal `require.relative`
+    # Without this, we get the error "Cannot find module './xhr-sync-worker.js'"
+    # This solution adapted from https://stackoverflow.com/a/78865792
+    # See also this issue: https://github.com/evanw/esbuild/issues/1311
+    external:
+      - 'jsdom'
 functions:
   getStates:
     handler: handlers/state/get.getStates


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Getting an error noted as:

```
2025-03-12T15:03:13.916Z	undefined	ERROR	Uncaught Exception 	
{
    "errorType": "Runtime.ImportModuleError",
    "errorMessage": "Error: Cannot find module './xhr-sync-worker.js'\nRequire stack:\n- /var/task/handlers/prince/pdf.js\n- /var/runtime/index.mjs",
    "stack": [
        "Runtime.ImportModuleError: Error: Cannot find module './xhr-sync-worker.js'",
        "Require stack:",
        "- /var/task/handlers/prince/pdf.js",
        "- /var/runtime/index.mjs",
        "    at _loadUserApp (file:///var/runtime/index.mjs:1087:17)",
        "    at async UserFunction.js.module.exports.load (file:///var/runtime/index.mjs:1119:21)",
        "    at async start (file:///var/runtime/index.mjs:1282:23)",
        "    at async file:///var/runtime/index.mjs:1288:1"
    ]
}
```
This seems to be related to JSDOM, and a fix in QMR is being passed along here: https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/2578

This is an attempt to fix the issue and will be rolled back if the deploy shows the fix did not work.

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Enter a report in the deployed instance, click print (can be section or full file), and click print again at the top of the page.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment
