### PR TITLE
Fix bigmac service lambda 500 errors

### DIFF
--- a/services/carts-bigmac-streams/handlers/kafka/post/postKafkaData.js
+++ b/services/carts-bigmac-streams/handlers/kafka/post/postKafkaData.js
@@ -1,4 +1,4 @@
-import KafkaSourceLib from "../../../libs/kafka-source-lib";
+const KafkaSourceLib = require("../../../libs/kafka-source-lib");
 /**
  * Binds the topics for Kafka output to a handler, triggered by data streams
  */

--- a/services/carts-bigmac-streams/handlers/kafka/post/postKafkaData.js
+++ b/services/carts-bigmac-streams/handlers/kafka/post/postKafkaData.js
@@ -1,4 +1,4 @@
-const KafkaSourceLib = require("../../../libs/kafka-source-lib");
+import { KafkaSourceLib } from "../../../libs/kafka-source-lib";
 /**
  * Binds the topics for Kafka output to a handler, triggered by data streams
  */
@@ -10,4 +10,4 @@ class PostKafkaData extends KafkaSourceLib {
 
 const postKafkaData = new PostKafkaData();
 
-exports.handler = postKafkaData.handler.bind(postKafkaData);
+export const handler = postKafkaData.handler.bind(postKafkaData);

--- a/services/carts-bigmac-streams/handlers/kafka/post/postKafkaData.js
+++ b/services/carts-bigmac-streams/handlers/kafka/post/postKafkaData.js
@@ -1,4 +1,4 @@
-import { KafkaSourceLib } from "../../../libs/kafka-source-lib";
+import { KafkaSourceLib } from "../../../libs/kafka-source-lib.js";
 /**
  * Binds the topics for Kafka output to a handler, triggered by data streams
  */

--- a/services/carts-bigmac-streams/handlers/sinkEnrollmentCounts.js
+++ b/services/carts-bigmac-streams/handlers/sinkEnrollmentCounts.js
@@ -1,8 +1,5 @@
-const { UpdateCommand } = require("@aws-sdk/lib-dynamodb");
-const {
-  buildClient,
-  convertToDynamoExpression,
-} = require("../libs/dynamo-lib");
+import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { buildClient, convertToDynamoExpression } from "../libs/dynamo-lib";
 
 /**
  * Handler for enrollment count events that come across kafka from SEDS
@@ -13,7 +10,7 @@ const {
  * @param {*} _context
  * @param {*} _callback
  */
-async function myHandler(event, _context, _callback) {
+export async function handler(event, _context, _callback) {
   const sedsTopicKey = `${process.env.sedsTopic}-0`;
   if (!event?.records?.[sedsTopicKey]) {
     return;
@@ -93,5 +90,3 @@ const getReportingYear = () => {
   if (month < 10) fiscalyear -= 1;
   return fiscalyear;
 };
-
-exports.handler = myHandler;

--- a/services/carts-bigmac-streams/handlers/sinkEnrollmentCounts.js
+++ b/services/carts-bigmac-streams/handlers/sinkEnrollmentCounts.js
@@ -1,5 +1,5 @@
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
-import { buildClient, convertToDynamoExpression } from "../libs/dynamo-lib";
+import { buildClient, convertToDynamoExpression } from "../libs/dynamo-lib.js";
 
 /**
  * Handler for enrollment count events that come across kafka from SEDS

--- a/services/carts-bigmac-streams/libs/dynamo-lib.js
+++ b/services/carts-bigmac-streams/libs/dynamo-lib.js
@@ -1,5 +1,5 @@
-const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
-const { DynamoDBDocumentClient } = require("@aws-sdk/lib-dynamodb");
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 
 let dynamoClient;
 

--- a/services/carts-bigmac-streams/libs/kafka-source-lib.js
+++ b/services/carts-bigmac-streams/libs/kafka-source-lib.js
@@ -1,5 +1,5 @@
-const { unmarshall } = require("@aws-sdk/util-dynamodb");
-const { Kafka } = require("kafkajs");
+import { unmarshall } from "@aws-sdk/util-dynamodb";
+import { Kafka } from "kafkajs";
 
 const STAGE = process.env.STAGE;
 const kafka = new Kafka({

--- a/services/carts-bigmac-streams/libs/kafka-source-lib.js
+++ b/services/carts-bigmac-streams/libs/kafka-source-lib.js
@@ -27,7 +27,7 @@ signalTraps.map((type) => {
   process.once(type, producer.disconnect);
 });
 
-class KafkaSourceLib {
+export class KafkaSourceLib {
   /*
    *Event types:
    *cmd – command; restful publish
@@ -130,5 +130,3 @@ class KafkaSourceLib {
     console.log(`Successfully processed ${event.Records.length} records.`);
   }
 }
-
-export default KafkaSourceLib;

--- a/services/carts-bigmac-streams/package.json
+++ b/services/carts-bigmac-streams/package.json
@@ -1,6 +1,7 @@
 {
   "name": "carts-bigmac-streams",
   "version": "1.0.0",
+  "type": "module",
   "description": "",
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.758.0",

--- a/services/carts-bigmac-streams/package.json
+++ b/services/carts-bigmac-streams/package.json
@@ -1,6 +1,7 @@
 {
   "name": "carts-bigmac-streams",
   "version": "1.0.0",
+  "main": "index.js",
   "type": "module",
   "description": "",
   "dependencies": {

--- a/src/run.ts
+++ b/src/run.ts
@@ -163,9 +163,7 @@ async function deploy(options: { stage: string }) {
   await runner.run_command_and_output("SLS Deploy", deployCmd, ".");
   await addSlsBucketPolicies();
   // Only deploy resources for kafka ingestion in real envs
-  if (stage === "main" || stage === "val" || stage === "production") {
-    await deploy_kafka_service(runner, stage);
-  }
+  await deploy_kafka_service(runner, stage);
 }
 
 async function destroy_stage(options: {

--- a/src/run.ts
+++ b/src/run.ts
@@ -163,7 +163,9 @@ async function deploy(options: { stage: string }) {
   await runner.run_command_and_output("SLS Deploy", deployCmd, ".");
   await addSlsBucketPolicies();
   // Only deploy resources for kafka ingestion in real envs
-  await deploy_kafka_service(runner, stage);
+  if (stage === "main" || stage === "val" || stage === "production") {
+    await deploy_kafka_service(runner, stage);
+  }
 }
 
 async function destroy_stage(options: {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Our bigmac kafka stream lambdas were failing due to nodejs require/import commonjs/ecma etc. issues.

I converted them to ecma. There are probably more improvements we could make but I thought it'd be best to get it working for now.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4492
CMDCT-4493

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in to the AWS console
- Go to cloudwatch and open logs for
  - `/aws/lambda/carts-bigmac-streams-fix-lambda-errors-sinkEnrollmentCounts`
  - `/aws/lambda/carts-bigmac-streams-fix-lambda-errors-postKafkaData`
- See it fail:
  - Go to the earliest logs in these groups (before I pushed any changes) and verify the error matches the ticket/dev/prod/whatever you like
- See it pass:
  - View the latest logs in these groups and verify they don't throw errors, and the processing all looks good
    - `sinkEnrollmentCounts` should complete with no errors and no custom logs
    - `postKafkaData` should complete with no errors and have some logs about the batches of data it sends to kafka


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
To deploy kafka in this branch I had to [remove the conditional in the run script](https://github.com/Enterprise-CMCS/macpro-mdct-carts/pull/139923/commits/de22d572669b474ad473b6ea74c71328da7582a3)

I've added it back in with [this commit](https://github.com/Enterprise-CMCS/macpro-mdct-carts/pull/139923/commits/344f62a06103400418361d6afa6d3710efdbcc1c)

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment