### PR TITLE
Make header unsticky at small screen size/high zoom

### DIFF
--- a/services/ui-src/src/styles/_header.scss
+++ b/services/ui-src/src/styles/_header.scss
@@ -10,6 +10,9 @@
   top: 0;
   z-index: 1;
   background-color: variables.$color-gray-lightest;
+  @media only screen and (max-width: 767px) {
+    position: static;
+  }
 }
 
 .header {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Make app header position static at high zoom/small screen size

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4448

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[deployed env](https://d2hbrys66s74bb.cloudfront.net/)
- Log in as any user
- Click around few different pages and:
  - Zoom in past 200% and verify the header becomes fixed to the top
  - Shrink screen size to mobile or tablet at normal zoom and verify header becomes fixed to the top

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment