### PR TITLE
Make state homepage headings increase by 1

### DIFF
--- a/services/ui-src/src/components/sections/homepage/TemplateDownload.jsx
+++ b/services/ui-src/src/components/sections/homepage/TemplateDownload.jsx
@@ -51,9 +51,9 @@ const TemplateDownload = ({ getTemplate }) => {
           </div>
           <div className="update-contents ds-l-col--10">
             <div className="title">
-              <h3>
+              <h2>
                 Your fiscal year {currentYear} template is ready for download
-              </h3>
+              </h2>
             </div>
             <p>
               Download your template for the current reporting period below.

--- a/services/ui-src/src/styles/_main.scss
+++ b/services/ui-src/src/styles/_main.scss
@@ -283,7 +283,7 @@ img {
   }
 
   .updates {
-    h3 {
+    h2 {
       color: variables.$black;
       font-weight: variables.$font-weight-normal;
       font-size: 1.4rem;
@@ -306,7 +306,7 @@ img {
         text-align: left;
       }
 
-      h3 {
+      h2 {
         margin-bottom: 0;
         font-weight: bold;
       }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Change the `<h3>` on the state homepage to an `<h2>` for accessibility best practice

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4347

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Run locally or open [deployed env](https://dhoqdu21m2m0t.cloudfront.net/)
- Log in as a state user
- Verify the heading with text "Your fiscal year 2024 template is ready for download" is an h2 and looks the same as before
- You can verify by opening https://mdctcartsdev.cms.gov/ and comparing

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment