### PR TITLE
[CMDCT-4374] Enable dependabot automerge on success

### DIFF
--- a/.github/setBranchName.sh
+++ b/.github/setBranchName.sh
@@ -7,6 +7,9 @@ GITHUB_REFNAME="${1}"
 [ -z "${GITHUB_REFNAME}" ] && echo "Error setting branch name.  No input given." && exit 1
 
 case ${GITHUB_REFNAME} in
+  $([[ "$GITHUB_REFNAME" =~ ^dependabot/.* ]] && echo ${GITHUB_REFNAME}))
+    echo ${GITHUB_REFNAME} | md5sum | head -c 10 | sed 's/^/x/'
+    ;;
   $([[ "$GITHUB_REFNAME" =~ ^snyk-* ]] && echo ${GITHUB_REFNAME}))
     echo ${GITHUB_REFNAME##*-} | head -c 10 | sed 's/^/s/'
     ;;

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+# Adapted from https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+name: Dependabot auto-merge
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabotbot Gather Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major'}}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "*"
+      - "dependabot/**"
       - "!skipci*"
       - "!code-json-*"
 
@@ -22,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: set branch_name # Some integrations (Snyk) build very long branch names. This is a switch to make long branch names shorter.
+      - name: set branch_name # Some integrations (Dependabot & Snyk) build very long branch names. This is a switch to make long branch names shorter.
         run: |
           BRANCH_NAME=$(./.github/setBranchName.sh ${{ github.ref_name }})
           echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Undo the removal of dependabot:
https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/507/files

This PR reenables the following:
- Branch names for dependabot are converted to an md5sum and shortened
- Dependabot branches deploy
- Dependabot branches auto-merge assuming required checks pass

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4374

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Once this is merged, monitor future PRs

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
