### PR TITLE
CMDCT-4814 fixes download template button by Jon

### DIFF
--- a/deployment/stacks/api.ts
+++ b/deployment/stacks/api.ts
@@ -15,7 +15,7 @@ import { DynamoDBTableIdentifiers } from "../constructs/dynamodb-table";
 
 interface CreateApiComponentsProps {
   docraptorApiKey: string;
-  fiscalYearTemplateS3BucketName?: string;
+  fiscalYearTemplateS3BucketName: string;
   isDev: boolean;
   project: string;
   scope: Construct;
@@ -132,6 +132,13 @@ export function createApiComponents(props: CreateApiComponentsProps) {
     method: "GET",
     requestParameters: ["year"],
     ...commonProps,
+    additionalPolicies: [
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["s3:GetObject"],
+        resources: [`arn:aws:s3:::${fiscalYearTemplateS3BucketName}/*`],
+      }),
+    ],
   });
 
   new Lambda(scope, "getStateStatus", {

--- a/deployment/stacks/parent.ts
+++ b/deployment/stacks/parent.ts
@@ -62,19 +62,18 @@ export class ParentStack extends Stack {
       return;
     }
 
-    const { attachmentsBucket, fiscalYearTemplateBucket } =
-      createUploadsComponents({
-        ...commonProps,
-        loggingBucket,
-        attachmentsBucketName,
-        fiscalYearTemplateBucketName,
-      });
+    const { attachmentsBucket } = createUploadsComponents({
+      ...commonProps,
+      loggingBucket,
+      attachmentsBucketName,
+      fiscalYearTemplateBucketName,
+    });
 
     const { apiGatewayRestApiUrl, restApiId } = createApiComponents({
       ...commonProps,
       tables,
       uploadS3BucketName: attachmentsBucketName,
-      fiscalYearTemplateS3BucketName: fiscalYearTemplateBucket?.bucketName,
+      fiscalYearTemplateS3BucketName: fiscalYearTemplateBucketName,
     });
 
     const { applicationEndpointUrl, distribution, uiBucket } =

--- a/deployment/stacks/uploads.ts
+++ b/deployment/stacks/uploads.ts
@@ -62,7 +62,6 @@ export function createUploadsComponents(props: CreateUploadsComponentsProps) {
     serverAccessLogsPrefix: `AWSLogs/${Aws.ACCOUNT_ID}/s3/`,
   });
 
-  // TODO: one or some of the lambdas need s3:GetObject permissions to this bucket
   let fiscalYearTemplateBucket: s3.IBucket | undefined;
   if (!isDev) {
     fiscalYearTemplateBucket = new s3.Bucket(


### PR DESCRIPTION
### Description
Quick fix of the download template button.

### Related ticket(s)
CMDCT-4814

---

### How to test
Fiscal Year Template is the button on the homepage that says “Your fiscal year 2024 template is ready for download
Download your template for the current reporting period below. Please contact [mdct_help@cms.hhs.gov](mailto:mdct_help@cms.hhs.gov) with any questions.”  with the “Download Template” button there.
If you click that button and something downloads, it worked!

### Notes
More comprehensive overhaul coming soon...
---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [val release](?expand=1&template=val-deployment.md)_ | _[production release](?expand=1&template=production-deployment.md)_
