### PR TITLE
Add concurrency to release PR workflow

### DIFF
--- a/.github/workflows/create-main-to-val-pr.yml
+++ b/.github/workflows/create-main-to-val-pr.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: "1 5 * * 1-5" # weekdays at 05:01 UTC (12:01 AM EST)
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/create-main-to-val-pr.yml
+++ b/.github/workflows/create-main-to-val-pr.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: "1 5 * * 1-5" # weekdays at 05:01 UTC (12:01 AM EST)
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -13,6 +13,9 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.ref_name }}
+
 permissions:
   contents: write
   pull-requests: write

--- a/scripts/yarn-lock-diff.cjs
+++ b/scripts/yarn-lock-diff.cjs
@@ -106,5 +106,13 @@ const filteredDiff = diff.filter((pkg) =>
   packageJsonDependencies.has(pkg.package)
 );
 
+/** 
+ * Filter to only changed versions. This can happen if package.json
+ * and yarn.lock are synced and the package was not actually updated.
+ */ 
+const filteredPackages = filteredDiff.filter((pkg) =>
+  pkg.priorVersion !== pkg.upgradedVersion
+);
+
 // Print diff
-console.log(JSON.stringify(filteredDiff, null, 2));
+console.log(JSON.stringify(filteredPackages, null, 2));


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Update the release PR workflow with concurrency
- Filter dependency table to show only updates and not syncs

<!-- ### Related ticket(s) -->
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
<!-- CMDCT- -->

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. https://github.com/Enterprise-CMCS/macpro-mdct-carts/pull/139978 updates and looks good

<!-- ### Notes -->
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->

<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->

<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [val release](?expand=1&template=val-deployment.md)_ | _[production release](?expand=1&template=production-deployment.md)_ -->
