### PR TITLE
Fix console error about missing label prop (CMDCT-4761, CMDCT-4762)

### DIFF
--- a/services/ui-src/src/components/fields/Question.jsx
+++ b/services/ui-src/src/components/fields/Question.jsx
@@ -136,7 +136,7 @@ const Question = ({
         <Component
           {...props}
           id={props?.id || question?.id}
-          label={question.label}
+          label={""}
           hint={undefined}
           question={question}
           name={question.id}

--- a/services/ui-src/src/components/fields/Question.jsx
+++ b/services/ui-src/src/components/fields/Question.jsx
@@ -136,7 +136,7 @@ const Question = ({
         <Component
           {...props}
           id={props?.id || question?.id}
-          label={undefined}
+          label={question.label}
           hint={undefined}
           question={question}
           name={question.id}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Fix missing label prop for cmsds text component

We were explicitly setting the "label" prop to `undefined` in our Question component, which renders all questions. We manually set labels on our end for all the questions, so we don't want this to be defined. Setting it to empty string eliminates the console error while causing no interference to our app.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4761, CMDCT-4762

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Run CARTS `main` locally
- Login as stateuser2
- Open up the developer console and clear it
- Open the 2024 CARTS Report and verify you're on the Basic State Information page
- Check the console for a missing label prop error from the TextField2 and FormControl2 components (from CMSDS)
- Switch to this branch while still running CARTS `cmdct-4761`
- Refresh the page and verify those errors don't show

Compare a few pages with [CARTS dev](https://mdctcartsdev.cms.gov/) to verify there are no visual or functional changes to the form

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
~- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~
~- [ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
~- [ ] I have manually tested this PR in the deployed cloud environment~
