### PR TITLE
tableTitle console error

### DIFF
--- a/services/ui-src/src/components/fields/NoninteractiveTable.jsx
+++ b/services/ui-src/src/components/fields/NoninteractiveTable.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { v4 as uuidv4 } from "uuid";
 
-const NoninteractiveTable = ({ question, tableTitle }) => {
+const NoninteractiveTable = ({ question }) => {
   const columnWidth = 100 / question.fieldset_info.headers.length;
   // eslint-disable-next-line
   let percentLocation = [];
@@ -12,11 +12,7 @@ const NoninteractiveTable = ({ question, tableTitle }) => {
       <table
         className="ds-c-table"
         width="100%"
-        summary={
-          question.label ||
-          tableTitle ||
-          "This is a table for the CARTS Application"
-        }
+        summary={question.label || "This is a table for the CARTS Application"}
       >
         <thead>
           <tr>
@@ -150,7 +146,6 @@ const NoninteractiveTable = ({ question, tableTitle }) => {
 };
 NoninteractiveTable.propTypes = {
   question: PropTypes.object.isRequired,
-  tableTitle: PropTypes.string,
 };
 export { NoninteractiveTable };
 export default NoninteractiveTable;

--- a/services/ui-src/src/components/fields/NoninteractiveTable.test.jsx
+++ b/services/ui-src/src/components/fields/NoninteractiveTable.test.jsx
@@ -5,7 +5,6 @@ import NoninteractiveTable from "./NoninteractiveTable";
 describe("<NoninteractiveTable />", () => {
   test("should render data in a proper table structure", () => {
     const props = {
-      tableTitle: "Mock Table Title",
       question: {
         fieldset_info: {
           headers: ["Header1", "Header2"],
@@ -19,7 +18,10 @@ describe("<NoninteractiveTable />", () => {
     const { container } = render(<NoninteractiveTable {...props} />);
 
     const table = container.querySelector("table");
-    expect(table).toHaveAttribute("summary", "Mock Table Title");
+    expect(table).toHaveAttribute(
+      "summary",
+      "This is a table for the CARTS Application"
+    );
 
     const columnHeaders = container.querySelectorAll("table > thead > tr > th");
     expect(columnHeaders[0]).toHaveTextContent("Header1");
@@ -40,7 +42,6 @@ describe("<NoninteractiveTable />", () => {
 
   test("should render percentages nicely", () => {
     const props = {
-      tableTitle: "Mock Table Title",
       question: {
         fieldset_info: {
           headers: ["Foo Percent", "Percent of Bar"],
@@ -56,7 +57,6 @@ describe("<NoninteractiveTable />", () => {
 
   test("should contain special logic for CHIP enrollment", () => {
     const props = {
-      tableTitle: "Mock Table Title",
       question: {
         fieldset_info: {
           headers: [

--- a/services/ui-src/src/components/fields/Question.jsx
+++ b/services/ui-src/src/components/fields/Question.jsx
@@ -57,7 +57,7 @@ Container.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const Question = ({ hideNumber, question, prevYear, printView }) => {
+const Question = ({ hideNumber, question, prevYear, printView, ...props }) => {
   let Component = Text;
   if (questionTypes.has(question.type)) {
     Component = questionTypes.get(question.type);
@@ -127,7 +127,8 @@ const Question = ({ hideNumber, question, prevYear, printView }) => {
           />
         )}
         <Component
-          id={question?.id}
+          {...props}
+          id={props?.id || question?.id}
           label={""}
           hint={undefined}
           question={question}
@@ -170,7 +171,6 @@ Question.propTypes = {
   hideNumber: PropTypes.bool,
   question: PropTypes.object.isRequired,
   prevYear: PropTypes.object,
-  tableTitle: PropTypes.string,
   printView: PropTypes.bool,
 };
 Question.defaultProps = {

--- a/services/ui-src/src/components/fields/Question.jsx
+++ b/services/ui-src/src/components/fields/Question.jsx
@@ -57,14 +57,7 @@ Container.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const Question = ({
-  hideNumber,
-  question,
-  prevYear,
-  tableTitle,
-  printView,
-  ...props
-}) => {
+const Question = ({ hideNumber, question, prevYear, printView }) => {
   let Component = Text;
   if (questionTypes.has(question.type)) {
     Component = questionTypes.get(question.type);
@@ -134,15 +127,13 @@ const Question = ({
           />
         )}
         <Component
-          {...props}
-          id={props?.id || question?.id}
+          id={question?.id}
           label={""}
           hint={undefined}
           question={question}
           name={question.id}
           onChange={onChange}
           onClick={onClick}
-          tableTitle={tableTitle}
           disabled={
             prevYearDisabled ||
             pageDisable ||

--- a/services/ui-src/src/components/fields/SynthesizedTable.jsx
+++ b/services/ui-src/src/components/fields/SynthesizedTable.jsx
@@ -102,7 +102,7 @@ const SynthesizedTable = ({ question, tableTitle, printView }) => {
 };
 SynthesizedTable.propTypes = {
   question: PropTypes.object.isRequired,
-  tableTitle: PropTypes.string.isOptional,
+  tableTitle: PropTypes.string,
 };
 
 export default SynthesizedTable;

--- a/services/ui-src/src/components/fields/SynthesizedTable.jsx
+++ b/services/ui-src/src/components/fields/SynthesizedTable.jsx
@@ -6,7 +6,7 @@ import { lteMask } from "../../util/constants";
 //types
 import PropTypes from "prop-types";
 
-const SynthesizedTable = ({ question, tableTitle, printView }) => {
+const SynthesizedTable = ({ question, printView }) => {
   const [allStatesData, stateName, stateUserAbbr, chipEnrollments, formData] =
     useSelector(
       (state) => [
@@ -51,11 +51,7 @@ const SynthesizedTable = ({ question, tableTitle, printView }) => {
       <table
         className="ds-c-table ds-u-margin-top--2"
         id="synthesized-table-1"
-        summary={
-          question.label ||
-          tableTitle ||
-          "This is a table for the CARTS Application"
-        }
+        summary={question.label || "This is a table for the CARTS Application"}
       >
         <thead>
           <tr>
@@ -102,7 +98,6 @@ const SynthesizedTable = ({ question, tableTitle, printView }) => {
 };
 SynthesizedTable.propTypes = {
   question: PropTypes.object.isRequired,
-  tableTitle: PropTypes.string,
 };
 
 export default SynthesizedTable;

--- a/services/ui-src/src/components/fields/SynthesizedTable.test.jsx
+++ b/services/ui-src/src/components/fields/SynthesizedTable.test.jsx
@@ -31,7 +31,6 @@ const store = mockStore({
 });
 
 const defaultProps = {
-  tableTitle: "Managed Care Costs",
   question: {
     questions: [],
     fieldset_info: {

--- a/services/ui-src/src/components/layout/Part.jsx
+++ b/services/ui-src/src/components/layout/Part.jsx
@@ -65,7 +65,6 @@ const Part = ({ partId, partNumber, nestedSubsectionTitle, printView }) => {
             <Question
               key={question.id}
               question={question}
-              tableTitle={title}
               data-testid="part-question"
               printView={printView}
             />


### PR DESCRIPTION
### Description
Gets rid of this console error:
`Warning: React does not recognize the `tableTitle` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `tabletitle` instead. If you accidentally passed it from a parent component, remove it from the DOM element. `

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4765

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [val release](?expand=1&template=val-deployment.md)_ | _[production release](?expand=1&template=production-deployment.md)_
