### PR TITLE
CMDCT-4855 Use a dl on the userprofile for better semantics

### DIFF
--- a/services/ui-src/src/components/sections/UserProfile.jsx
+++ b/services/ui-src/src/components/sections/UserProfile.jsx
@@ -7,32 +7,30 @@ const UserProfile = () => {
     <div className="page-info ds-l-container">
       <div className="ds-l-row">
         <div className="ds-l-col--12">
-          <header>
-            <h1>User Profile</h1>
-          </header>
           <main className="main">
+            <h1>User Profile</h1>
             If any information is incorrect, please contact the{" "}
             <a href="mailto:mdct_help@cms.hhs.gov">mdct_help@cms.hhs.gov</a>.
-            <div className="profile-information">
+            <dl className="profile-information">
               <div>
-                <div>EUA Id: </div>
-                <div>{currentUser.username}</div>
+                <dt>EUA Id:</dt>
+                <dd>{currentUser.username}</dd>
               </div>
               <div>
-                <div>Name: </div>
-                <div>
+                <dt>Name:</dt>
+                <dd>
                   {currentUser.firstname} {currentUser.lastname}
-                </div>
+                </dd>
               </div>
               <div>
-                <div>Email: </div>
-                <div>{currentUser.email}</div>
+                <dt>Email:</dt>
+                <dd>{currentUser.email}</dd>
               </div>
               <div>
-                <div>Role: </div>
-                <div>{currentUser.role}</div>
+                <dt>Role:</dt>
+                <dd>{currentUser.role}</dd>
               </div>
-            </div>
+            </dl>
           </main>
         </div>
       </div>

--- a/services/ui-src/src/components/sections/UserProfile.test.jsx
+++ b/services/ui-src/src/components/sections/UserProfile.test.jsx
@@ -9,13 +9,13 @@ const mockStore = configureMockStore();
 const store = mockStore({
   stateUser: {
     currentUser: {
-      email: "",
-      username: "",
-      firstname: "",
-      lastname: "",
-      role: "",
+      email: "test.user@example.com",
+      username: "testuser123",
+      firstname: "Test",
+      lastname: "User",
+      role: "State User",
       state: {
-        id: "",
+        id: "AL",
       },
     },
   },
@@ -31,6 +31,29 @@ describe("<UserProfile />", () => {
   test("should render the UserProfile Component correctly", () => {
     render(userProfile);
     expect(screen.getByRole("heading", { name: "User Profile" })).toBeVisible();
+  });
+
+  test("should render description terms and values", () => {
+    render(userProfile);
+    const euaIdTerm = screen.getByText("EUA Id:");
+    expect(euaIdTerm.tagName).toBe("DT");
+    const euaIdValue = screen.getByText("testuser123");
+    expect(euaIdValue.tagName).toBe("DD");
+
+    const nameTerm = screen.getByText("Name:");
+    expect(nameTerm.tagName).toBe("DT");
+    const nameValue = screen.getByText("Test User");
+    expect(nameValue.tagName).toBe("DD");
+
+    const emailTerm = screen.getByText("Email:");
+    expect(emailTerm.tagName).toBe("DT");
+    const emailValue = screen.getByText("test.user@example.com");
+    expect(emailValue.tagName).toBe("DD");
+
+    const roleTerm = screen.getByText("Role:");
+    expect(roleTerm.tagName).toBe("DT");
+    const roleValue = screen.getByText("State User");
+    expect(roleValue.tagName).toBe("DD");
   });
 
   testA11y(userProfile);

--- a/services/ui-src/src/styles/_main.scss
+++ b/services/ui-src/src/styles/_main.scss
@@ -253,7 +253,7 @@ img {
     }
   }
 
-  .page-title { 
+  .page-title {
     font-size: 2em;
     margin-top: (variables.$margin * 4);
     margin-bottom: variables.$margin;
@@ -264,7 +264,7 @@ img {
   }
 
   .preamble {
-    max-width: 730px; 
+    max-width: 730px;
     margin-bottom: 2rem;
   }
 
@@ -543,22 +543,21 @@ div[data-state="open"] .accordion-header .arrow:before {
 }
 
 .profile-information {
-  margin: 1.2rem 0;
+  margin-block: 1.2rem;
 
   & > div:nth-child(even) {
     background-color: #efefef;
   }
 
-  & > div {
-    div:first-of-type {
-      display: inline-block;
-      margin: 0.4rem 0.6rem 0.4rem 0.4rem;
-      min-width: 55px;
-    }
+  & dt {
+    display: inline-block;
+    margin: 0.4rem 0.6rem 0.4rem 0.4rem;
+    min-width: 55px;
+  }
 
-    div:last-of-type {
-      display: inline-block;
-    }
+  & dd {
+    margin-inline-start: 0;
+    display: inline-block;
   }
 }
 


### PR DESCRIPTION
### Description
Use a `<dl>` for better semantics on the user profile page.

There are not style differences:
![CARTS Styling is the same](https://github.com/user-attachments/assets/f27277fa-94f5-46db-8851-b39d310e8463)

However, now if you use a screen reader, you can traverse the data as a list, here is an example using Safari and VoiceOver:

(🔊 Volume up to hear VoiceOver)

https://github.com/user-attachments/assets/e586a285-3e6b-4e78-b442-d5e83a490f36

### Related ticket(s)
CMDCT-4855

---

### How to test
- Run the application locally
- Navigate to `/user/profile`
- Review the `<dl>` on the page

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment
