### PR TITLE
[CMDCT-4770] Fix proptypes ID being required for CMSLegends

### DIFF
--- a/services/ui-src/src/components/fields/CMSLegend.jsx
+++ b/services/ui-src/src/components/fields/CMSLegend.jsx
@@ -39,7 +39,7 @@ const CMSLegend = ({ hideNumber, hint, id, label, questionType }) => {
 CMSLegend.propTypes = {
   hideNumber: PropTypes.bool,
   hint: PropTypes.string,
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string,
   label: PropTypes.string.isRequired,
   questionType: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
CMSLegends defines the proptypes it recieves as requiring the ID to be passed to it as a string. However, the 2024 template doesn't have id's for somethings. For instance, 

```
"type": "fieldset",
"label": "Who should we contact if we have any questions about your report?",
"questions": [...]
```

has no id. And further in the file when it actually uses the ID, it doesn't require the id to be passed. In fact, its important an ID _isnt_ passed. The function in question is generateQuestionNumber (See below this paragraph for that code). The above fieldset doesn't want a question number. Thus, lets mark this prop what it is - An optional prop that's passed.

```
const generateQuestionNumber = (id) => {
  let labelBits = "";

  if (id) {
    const lastHunk = Number.parseInt(id.substring(id.length - 2), 10);
    if (Number.isNaN(lastHunk)) {
      const numberBit = Number.parseInt(
        id.substring(id.length - 4, id.length - 2),
        10
      );
      labelBits = `${numberBit}${id.substring(id.length - 1)}. `;
    } else {
      labelBits = `${lastHunk}. `;
    }
  }

  return labelBits;
};
```

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4770

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Login as stateuser2
Open up the developer console and clear it
Open the 2024 CARTS Report
Ensure you're on the Basic State Information Page:
Check the console for the error and see its gone!

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
