### PR TITLE
Form Fix - Remove UUID for ID

### DIFF
--- a/services/ui-src/src/components/fields/Fieldset.jsx
+++ b/services/ui-src/src/components/fields/Fieldset.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { v4 as uuidv4 } from "uuid";
 
 import Question from "./Question";
 import DataGrid from "./DataGrid";
@@ -28,7 +27,7 @@ const Fieldset = ({ question, ...props }) => {
       return <NoninteractiveTable question={question} {...props} />;
     default:
       return question.questions.map((q) => (
-        <Question key={q.id || uuidv4()} question={q} {...props} />
+        <Question key={q.id} question={q} {...props} />
       ));
   }
 };

--- a/services/ui-src/src/components/fields/Question.jsx
+++ b/services/ui-src/src/components/fields/Question.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { v4 as uuidv4 } from "uuid";
 import PropTypes from "prop-types";
 import { useSelector, shallowEqual, useDispatch } from "react-redux";
 // components
@@ -175,7 +174,7 @@ const Question = ({
           <div className="ds-c-choice__checkedChild">
             {question.questions.map((q) => (
               <Question
-                key={q.id || `question-${uuidv4()}`}
+                key={q.id}
                 question={q}
                 setAnswer={setAnswerEntry}
                 printView={printView}

--- a/services/ui-src/src/components/fields/Repeatable.jsx
+++ b/services/ui-src/src/components/fields/Repeatable.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { AccordionButton, AccordionPanel } from "@reach/accordion";
-import { v4 as uuidv4 } from "uuid";
 
 import Question from "./Question";
 
@@ -21,7 +20,7 @@ const Repeatable = ({ headerRef, number, question, type, printView }) => {
       </div>
       <AccordionPanel>
         {children.map((q) => (
-          <Question key={q.id || uuidv4()} question={q} printView={printView} />
+          <Question key={q.id} question={q} printView={printView} />
         ))}
       </AccordionPanel>
     </>

--- a/services/ui-src/src/components/layout/Part.jsx
+++ b/services/ui-src/src/components/layout/Part.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { v4 as uuidv4 } from "uuid";
 import { shallowEqual, useSelector } from "react-redux";
 import { Alert } from "@cmsgov/design-system";
 // components
@@ -64,7 +63,7 @@ const Part = ({ partId, partNumber, nestedSubsectionTitle, printView }) => {
           {text && <Text data-testid="part-text">{text}</Text>}
           {questions.map((question) => (
             <Question
-              key={question.id || uuidv4()}
+              key={question.id}
               question={question}
               data-testid="part-question"
               printView={printView}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Bangbay noted that you were unable to enter data into fields because of the uuid fix we recently implemented. Looking into this Bangbay is 100% right. The key being a uuid **is** messing with these components. How? I believe its something to do with the way rendering is done through jsonpath, our form renderer. Which is a little wild btw. Running through the rest of the app but I’ll live with the console error on not having a key for now

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

Open a report
start entering data. Its best to click on a field because you'll know immediately if it fails if it loses focus immediately.
You should be able to enter data throughout the app

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
