### PR TITLE
Swap to using index for key on certain elements

### DIFF
--- a/services/ui-src/src/components/fields/Fieldset.jsx
+++ b/services/ui-src/src/components/fields/Fieldset.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-
 import Question from "./Question";
 import DataGrid from "./DataGrid";
 import SynthesizedTable from "./SynthesizedTable";
@@ -26,8 +25,8 @@ const Fieldset = ({ question, ...props }) => {
     case "noninteractive_table":
       return <NoninteractiveTable question={question} {...props} />;
     default:
-      return question.questions.map((q) => (
-        <Question key={q.id} question={q} {...props} />
+      return question.questions.map((q, index) => (
+        <Question key={q.id || index} question={q} {...props} />
       ));
   }
 };

--- a/services/ui-src/src/components/fields/Question.jsx
+++ b/services/ui-src/src/components/fields/Question.jsx
@@ -186,9 +186,9 @@ const Question = ({
              not, then its children shouldn't be indented either. */}
         {shouldRenderChildren && (
           <div className="ds-c-choice__checkedChild">
-            {question.questions.map((q) => (
+            {question.questions.map((q, index) => (
               <Question
-                key={q.id}
+                key={q.id || `question-${index}`}
                 question={q}
                 setAnswer={setAnswerEntry}
                 printView={printView}

--- a/services/ui-src/src/components/fields/Repeatable.jsx
+++ b/services/ui-src/src/components/fields/Repeatable.jsx
@@ -19,8 +19,8 @@ const Repeatable = ({ headerRef, number, question, type, printView }) => {
         </span>
       </div>
       <AccordionPanel>
-        {children.map((q) => (
-          <Question key={q.id} question={q} printView={printView} />
+        {children.map((q, index) => (
+          <Question key={q.id || index} question={q} printView={printView} />
         ))}
       </AccordionPanel>
     </>

--- a/services/ui-src/src/components/layout/Part.jsx
+++ b/services/ui-src/src/components/layout/Part.jsx
@@ -61,9 +61,9 @@ const Part = ({ partId, partNumber, nestedSubsectionTitle, printView }) => {
       return (
         <>
           {text && <Text data-testid="part-text">{text}</Text>}
-          {questions.map((question) => (
+          {questions.map((question, index) => (
             <Question
-              key={question.id}
+              key={question.id || index}
               question={question}
               data-testid="part-question"
               printView={printView}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The uuids on the keys were causing a re-render of the component anytime a change to the component happened. This is because the uuid would update itself on each render creating an endless cycle. While the best practice _is_ to have unique keys, thats for the usecase of having a reorderable array. We don't have that in CARTS. So we'll settle with having the index as our key in cases where there is no id to go off of.

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Load up a CARTS Report and try entering data into random fields!
The first page is great, but Section 3c or Section 5 are also good candidates to try.

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment