### PR TITLE
CMDCT-4941, CMDCT-4949, CMDCT-4968: Make home page links more accessible

### DIFF
--- a/services/ui-src/src/components/layout/Header.jsx
+++ b/services/ui-src/src/components/layout/Header.jsx
@@ -136,7 +136,7 @@ export const Header = () => {
                         id="menu-block"
                       >
                         <li className="contact-us">
-                          <a href="mailto:mdct_help@cms.hhs.gov">Contact Us</a>
+                          <a href="/get-help">Contact Us</a>
                         </li>
                         <li className="manage-account">
                           <Link to="/user/profile">Manage Account</Link>

--- a/services/ui-src/src/components/layout/Header.test.jsx
+++ b/services/ui-src/src/components/layout/Header.test.jsx
@@ -123,6 +123,7 @@ describe("<Header />", () => {
     const headerDropDownLinks = screen.getByTestId("headerDropDownLinks");
     expect(headerDropDownMenuButton).toContainElement(chevUp);
     expect(headerDropDownMenu).toContainElement(headerDropDownLinks);
+    expect(screen.getByRole("link", { name: "Contact Us" })).toBeVisible();
   });
 
   test("should open and close the dropdown menu on click", () => {

--- a/services/ui-src/src/components/sections/homepage/ReportItem.jsx
+++ b/services/ui-src/src/components/sections/homepage/ReportItem.jsx
@@ -77,7 +77,7 @@ const ReportItem = ({
             <Link
               to={link1URL}
               target={anchorTarget}
-              aria-label={`${link1Text} ${name} ${year}`}
+              aria-label={`${link1Text} ${stateAbbr} ${year} report`}
             >
               {link1Text}
             </Link>
@@ -87,6 +87,7 @@ const ReportItem = ({
                   {" "}
                   <button
                     data-testid={"uncertifyButton"}
+                    aria-label={`Uncertify ${stateAbbr} ${year} report`}
                     className="link"
                     onClick={toggleModal}
                   >
@@ -99,7 +100,7 @@ const ReportItem = ({
               <Link
                 className="ds-c-button--solid ds-c-button--small"
                 to={printFormUrl(year)}
-                title={`Print ${stateAbbr} ${year} form`}
+                aria-label={`Print ${stateAbbr} ${year} report`}
                 target="_blank"
                 data-testid="print-form"
               >
@@ -113,13 +114,13 @@ const ReportItem = ({
               data-testid={"uncertifyModal"}
               isShowing={isShowing}
               onExit={toggleModal}
-              heading="Uncertify this Report?"
+              heading={`Uncertify ${stateAbbr} ${year} report?`}
               actions={[
                 <button
                   className="ds-c-button ds-c-button--solid ds-u-margin-right--1"
                   key="primary"
                   onClick={uncertify}
-                  aria-label="Uncertify this Report"
+                  aria-label={`Uncertify ${stateAbbr} ${year} report`}
                 >
                   Yes, Uncertify
                 </button>,
@@ -141,13 +142,14 @@ const ReportItem = ({
               to={link1URL}
               target={anchorTarget}
               data-testid="report-action-button"
+              aria-label={`${link1Text} ${stateAbbr} ${year} report`}
             >
               {link1Text}
             </Link>{" "}
             <Link
               className="ds-c-button--solid ds-c-button--small"
               to={printFormUrl(year)}
-              title={`Print ${stateAbbr} ${year} form`}
+              aria-label={`Print ${stateAbbr} ${year} report`}
               target="_blank"
               data-testid="print-form"
             >

--- a/services/ui-src/src/components/sections/homepage/ReportItem.jsx
+++ b/services/ui-src/src/components/sections/homepage/ReportItem.jsx
@@ -9,6 +9,12 @@ import useModal from "../../../hooks/useModal";
 // types
 import { AppRoles } from "../../../types";
 
+const rolesThatUncertify = [
+  AppRoles.CMS_ADMIN,
+  AppRoles.CMS_USER,
+  AppRoles.CMS_APPROVER,
+];
+
 const ReportItem = ({
   link1Text = "View",
   link1URL = "#",
@@ -22,13 +28,11 @@ const ReportItem = ({
   stateAbbr,
 }) => {
   const dispatch = useDispatch();
-  const anchorTarget = "_self";
-  const stateCode = link1URL.toString().split("/")[3];
-  const stateYear = link1URL.toString().split("/")[4];
   const { isShowing, toggleModal } = useModal();
-  let lastEditedNote = "";
+
   const isStateUser = userRole === AppRoles.STATE_USER;
 
+  let lastEditedNote = "";
   if (lastChanged) {
     const date = new Date(lastChanged);
     // Using en-CA as they format the date to YYYY-MM-DD, HH:MM:SS where as en-US formats to DD/MM/YYYY, HH:MM:SS
@@ -50,115 +54,73 @@ const ReportItem = ({
   }
 
   const uncertify = async () => {
-    await dispatch(uncertifyReport(stateCode, stateYear));
+    await dispatch(uncertifyReport(stateAbbr, year));
     toggleModal();
     window.location.reload(false);
   };
 
-  const rolesThatUncertify = [
-    AppRoles.CMS_ADMIN,
-    AppRoles.CMS_USER,
-    AppRoles.CMS_APPROVER,
-  ];
-
-  const printFormUrl = (formYear) => {
-    return `/print?year=${formYear}&state=${stateAbbr}`;
-  };
+  const printFormUrl = `/print?year=${year}&state=${stateAbbr}`;
 
   return (
-    <>
-      {!isStateUser && (
-        <div className="report-item ds-l-row">
-          <div className="name ds-l-col--1">{year}</div>
-          <div className="name ds-l-col--2">{name}</div>
-          <div className="status ds-l-col--2">{statusText}</div>
-          <div className="actions ds-l-col--3">{lastEditedNote}</div>
-          <div className="actions ds-l-col--auto">
-            <Link
-              to={link1URL}
-              target={anchorTarget}
-              aria-label={`${link1Text} ${stateAbbr} ${year} report`}
-            >
-              {link1Text}
-            </Link>
-            {statusText === "Certified and Submitted" &&
-              rolesThatUncertify.includes(userRole) && (
-                <span>
-                  {" "}
-                  <button
-                    data-testid={"uncertifyButton"}
-                    aria-label={`Uncertify ${stateAbbr} ${year} report`}
-                    className="link"
-                    onClick={toggleModal}
-                  >
-                    Uncertify
-                  </button>
-                </span>
-              )}
-            <span>
-              {" "}
-              <Link
-                className="ds-c-button--solid ds-c-button--small"
-                to={printFormUrl(year)}
-                aria-label={`Print ${stateAbbr} ${year} report`}
-                target="_blank"
-                data-testid="print-form"
+    <div className="report-item ds-l-row">
+      {!isStateUser && <div className="name ds-l-col--1">{year}</div>}
+      <div className="name ds-l-col--2">{name}</div>
+      <div className="status ds-l-col--2">{statusText}</div>
+      <div className="actions ds-l-col--3">{lastEditedNote}</div>
+      <div className="actions ds-l-col--auto">
+        <Link
+          to={link1URL}
+          aria-label={`${link1Text} ${stateAbbr} ${year} report`}
+          data-testid="report-action-button"
+        >
+          {link1Text}
+        </Link>{" "}
+        {statusText === "Certified and Submitted" &&
+          rolesThatUncertify.includes(userRole) && (
+            <>
+              <button
+                data-testid="uncertifyButton"
+                aria-label={`Uncertify ${stateAbbr} ${year} report`}
+                className="link"
+                onClick={toggleModal}
               >
-                Print
-              </Link>
-            </span>
-          </div>
-
-          {isShowing && (
-            <Dialog
-              data-testid={"uncertifyModal"}
-              isShowing={isShowing}
-              onExit={toggleModal}
-              heading={`Uncertify ${stateAbbr} ${year} report?`}
-              actions={[
-                <button
-                  className="ds-c-button ds-c-button--solid ds-u-margin-right--1"
-                  key="primary"
-                  onClick={uncertify}
-                  aria-label={`Uncertify ${stateAbbr} ${year} report`}
-                >
-                  Yes, Uncertify
-                </button>,
-              ]}
-            >
-              Uncertifying will send this CARTS report back to the state user
-              who submitted it
-            </Dialog>
+                Uncertify
+              </button>{" "}
+            </>
           )}
-        </div>
-      )}
-      {isStateUser && (
-        <div className="report-item ds-l-row">
-          <div className="name ds-l-col--2">{name}</div>
-          <div className="status ds-l-col--2">{statusText}</div>
-          <div className="actions ds-l-col--3">{lastEditedNote}</div>
-          <div className="actions ds-l-col--auto">
-            <Link
-              to={link1URL}
-              target={anchorTarget}
-              data-testid="report-action-button"
-              aria-label={`${link1Text} ${stateAbbr} ${year} report`}
+        <Link
+          className="ds-c-button--solid ds-c-button--small"
+          to={printFormUrl}
+          aria-label={`Print ${stateAbbr} ${year} report`}
+          target="_blank"
+          data-testid="print-form"
+        >
+          Print
+        </Link>
+      </div>
+
+      {isShowing && (
+        <Dialog
+          data-testid="uncertifyModal"
+          isShowing={isShowing}
+          onExit={toggleModal}
+          heading={`Uncertify ${stateAbbr} ${year} report?`}
+          actions={[
+            <button
+              className="ds-c-button ds-c-button--solid ds-u-margin-right--1"
+              key="primary"
+              onClick={uncertify}
+              aria-label={`Uncertify ${stateAbbr} ${year} report`}
             >
-              {link1Text}
-            </Link>{" "}
-            <Link
-              className="ds-c-button--solid ds-c-button--small"
-              to={printFormUrl(year)}
-              aria-label={`Print ${stateAbbr} ${year} report`}
-              target="_blank"
-              data-testid="print-form"
-            >
-              Print
-            </Link>
-          </div>
-        </div>
+              Yes, Uncertify
+            </button>,
+          ]}
+        >
+          Uncertifying will send this CARTS report back to the state user who
+          submitted it
+        </Dialog>
       )}
-    </>
+    </div>
   );
 };
 

--- a/services/ui-src/src/components/sections/homepage/ReportItem.test.jsx
+++ b/services/ui-src/src/components/sections/homepage/ReportItem.test.jsx
@@ -32,6 +32,7 @@ const HomepageStateUserInProgProps = {
   userRole: "STATE_USER",
   year: 2021,
   timeZone: "America/New_York",
+  stateAbbr: "AL",
 };
 
 const HomepageStateUserCertProps = {
@@ -43,6 +44,7 @@ const HomepageStateUserCertProps = {
   userRole: "STATE_USER",
   year: 2020,
   timeZone: "America/New_York",
+  stateAbbr: "AL",
 };
 
 describe("<ReportItem />", () => {
@@ -68,7 +70,12 @@ describe("<ReportItem />", () => {
       expect(screen.getByText("2021")).toBeVisible();
       expect(screen.getByText("In Progress")).toBeVisible();
       expect(screen.getByText("2021-01-04 at 1:28:18 p.m.")).toBeVisible();
-      expect(screen.getByRole("link", { name: "Edit" })).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "Edit AL 2021 report" })
+      ).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "Print AL 2021 report" })
+      ).toBeVisible();
     });
 
     test("should render other reports statuses and time stamps properly", () => {
@@ -76,7 +83,12 @@ describe("<ReportItem />", () => {
       expect(screen.getByText("2020")).toBeVisible();
       expect(screen.getByText("Certified and Submitted")).toBeVisible();
       expect(screen.getByText("2022-06-27 at 2:43:08 p.m.")).toBeVisible();
-      expect(screen.getByRole("link", { name: "View" })).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "View AL 2020 report" })
+      ).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "Print AL 2020 report" })
+      ).toBeVisible();
     });
 
     test("In Progress report items should not have basic accessibility issues", async () => {
@@ -108,6 +120,7 @@ describe("<ReportItem />", () => {
     username: "Frank States",
     lastChanged: "Mon Jun 27 2022 14:43:08 GMT-0400 (Eastern Daylight Time)",
     timeZone: "America/New_York",
+    stateAbbr: "AL",
   };
 
   const CMSHomepageCMSUserAL2021Props = {
@@ -119,6 +132,7 @@ describe("<ReportItem />", () => {
     username: "al@test.com",
     lastChanged: "2021-01-04 18:28:18.524133+00",
     timeZone: "America/New_York",
+    stateAbbr: "AL",
   };
 
   describe("ReportItem viewed by a CMS User", () => {
@@ -146,7 +160,12 @@ describe("<ReportItem />", () => {
       expect(
         screen.getByText("2021-01-04 at 1:28:18 p.m. by al@test.com")
       ).toBeVisible();
-      expect(screen.getByRole("link", { name: /View/ })).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "View AL 2021 report" })
+      ).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "Print AL 2021 report" })
+      ).toBeVisible();
     });
 
     test("should render other reports statuses and time stamps properly", () => {
@@ -157,8 +176,12 @@ describe("<ReportItem />", () => {
       expect(
         screen.getByText("2022-06-27 at 2:43:08 p.m. by Frank States")
       ).toBeVisible();
-      expect(screen.getByRole("link", { name: /View/ })).toBeVisible();
-      expect(screen.getByRole("button", { name: "Uncertify" })).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "View AL 2020 report" })
+      ).toBeVisible();
+      expect(
+        screen.getByRole("button", { name: "Uncertify AL 2020 report" })
+      ).toBeVisible();
     });
 
     test("should handle uncertify being clicked and show new modal", () => {
@@ -198,6 +221,7 @@ describe("<ReportItem />", () => {
     username: "Frank States",
     lastChanged: "Mon Jun 27 2022 14:43:08 GMT-0400 (Eastern Daylight Time)",
     timeZone: "America/New_York",
+    stateAbbr: "AL",
   };
 
   const CMSHomepageAdminAL2021Props = {
@@ -209,6 +233,7 @@ describe("<ReportItem />", () => {
     username: "al@test.com",
     lastChanged: "2021-01-04 18:28:18.524133+00",
     timeZone: "America/New_York",
+    stateAbbr: "AL",
   };
 
   describe("ReportItem viewed by an Admin User", () => {
@@ -236,7 +261,12 @@ describe("<ReportItem />", () => {
       expect(
         screen.getByText("2021-01-04 at 1:28:18 p.m. by al@test.com")
       ).toBeVisible();
-      expect(screen.getByRole("link", { name: /View/ })).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "View AL 2021 report" })
+      ).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "Print AL 2021 report" })
+      ).toBeVisible();
     });
 
     test("should render other reports statuses and time stamps properly", () => {
@@ -247,8 +277,12 @@ describe("<ReportItem />", () => {
       expect(
         screen.getByText("2022-06-27 at 2:43:08 p.m. by Frank States")
       ).toBeVisible();
-      expect(screen.getByRole("link", { name: /View/ })).toBeVisible();
-      expect(screen.getByRole("button", { name: "Uncertify" })).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "View AL 2020 report" })
+      ).toBeVisible();
+      expect(
+        screen.getByRole("button", { name: "Uncertify AL 2020 report" })
+      ).toBeVisible();
     });
 
     test("In Progress report items should not have basic accessibility issues", async () => {
@@ -280,6 +314,7 @@ describe("<ReportItem />", () => {
     username: "Frank States",
     lastChanged: "Mon Jun 27 2022 14:43:08 GMT-0400 (Eastern Daylight Time)",
     timeZone: "America/New_York",
+    stateAbbr: "AL",
   };
 
   const CMSHomepageHelpdeskAL2021Props = {
@@ -291,6 +326,7 @@ describe("<ReportItem />", () => {
     username: "al@test.com",
     lastChanged: "2021-01-04 18:28:18.524133+00",
     timeZone: "America/New_York",
+    stateAbbr: "AL",
   };
 
   describe("ReportItem viewed by an Help Desk User", () => {
@@ -318,7 +354,12 @@ describe("<ReportItem />", () => {
       expect(
         screen.getByText("2021-01-04 at 1:28:18 p.m. by al@test.com")
       ).toBeVisible();
-      expect(screen.getByRole("link", { name: /View/ })).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "View AL 2021 report" })
+      ).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "Print AL 2021 report" })
+      ).toBeVisible();
     });
 
     test("should render other reports statuses and time stamps properly", () => {
@@ -329,7 +370,15 @@ describe("<ReportItem />", () => {
       expect(
         screen.getByText("2022-06-27 at 2:43:08 p.m. by Frank States")
       ).toBeVisible();
-      expect(screen.getByRole("link", { name: /View/ })).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "View AL 2020 report" })
+      ).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "Print AL 2020 report" })
+      ).toBeVisible();
+      expect(
+        screen.queryByRole("button", { name: /Uncertify/ })
+      ).not.toBeInTheDocument();
     });
 
     test("In Progress report items should not have basic accessibility issues", async () => {
@@ -361,6 +410,7 @@ describe("<ReportItem />", () => {
     username: "Frank States",
     lastChanged: "Mon Jun 27 2022 14:43:08 GMT-0400 (Eastern Daylight Time)",
     timeZone: "America/New_York",
+    stateAbbr: "AL",
   };
 
   const CMSHomepageApproverAL2021Props = {
@@ -372,6 +422,7 @@ describe("<ReportItem />", () => {
     username: "al@test.com",
     lastChanged: "2021-01-04 18:28:18.524133+00",
     timeZone: "America/New_York",
+    stateAbbr: "AL",
   };
 
   describe("ReportItem viewed by an Admin User", () => {
@@ -399,7 +450,12 @@ describe("<ReportItem />", () => {
       expect(
         screen.getByText("2021-01-04 at 1:28:18 p.m. by al@test.com")
       ).toBeVisible();
-      expect(screen.getByRole("link", { name: /View/ })).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "View AL 2021 report" })
+      ).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "Print AL 2021 report" })
+      ).toBeVisible();
     });
 
     test("should render other reports statuses and time stamps properly", () => {
@@ -410,7 +466,15 @@ describe("<ReportItem />", () => {
       expect(
         screen.getByText("2022-06-27 at 2:43:08 p.m. by Frank States")
       ).toBeVisible();
-      expect(screen.getByRole("link", { name: /View/ })).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "View AL 2020 report" })
+      ).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: "Print AL 2020 report" })
+      ).toBeVisible();
+      expect(
+        screen.getByRole("button", { name: "Uncertify AL 2020 report" })
+      ).toBeVisible();
     });
 
     test("In Progress report items should not have basic accessibility issues", async () => {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
I recommend reviewing by commit since one of the commits is just a component refactor and should have no impact on the other changes.

- Add more descriptive aria labels for homepage report buttons and uncertify modal
- Change Contact Us link in header dropdown to lead to help page


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4941, CMDCT-4949, CMDCT-4968

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- verify unit and integration tests pass
- open [deployed env](https://drtwdjd9f3o52.cloudfront.net/) and verify:
  - as a state user: "Edit" and "Print" buttons on the homepage have descriptive aria labels
  - as an admin user: "View", "Uncertify", and "Print" buttons on the homepage have descriptive aria labels
  - as an admin user: Uncertify modal header has more descriptive text and uncertify modal button has more descriptive aria label
  - as any user: in the header dropdown "Contact Us" leads to the /get-help page

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
