### PR TITLE
CMDCT-5038: remove unhelpful aria label in sidebar

### DIFF
--- a/services/ui-src/src/components/layout/TableOfContents.jsx
+++ b/services/ui-src/src/components/layout/TableOfContents.jsx
@@ -112,7 +112,6 @@ const TableOfContents = () => {
     <div className="toc" data-testid="toc" aria-label="Table of Contents">
       <VerticalNav
         selectedId={foundSelectedId}
-        ariaNavLabel="Vertical Navigation Element"
         items={items}
       />
     </div>

--- a/services/ui-src/src/components/layout/TableOfContents.jsx
+++ b/services/ui-src/src/components/layout/TableOfContents.jsx
@@ -110,10 +110,7 @@ const TableOfContents = () => {
   const foundSelectedId = items.find((item) => item.selected)?.id;
   return (
     <div className="toc" data-testid="toc" aria-label="Table of Contents">
-      <VerticalNav
-        selectedId={foundSelectedId}
-        items={items}
-      />
+      <VerticalNav selectedId={foundSelectedId} items={items} />
     </div>
   );
 };

--- a/tests/cypress/tests/integration/section1Fill.spec.js
+++ b/tests/cypress/tests/integration/section1Fill.spec.js
@@ -1,6 +1,6 @@
 // element selectors
 const actionButton = "[data-testid='report-action-button']";
-const navigationLink = "[aria-label='Vertical Navigation Element'] a";
+const navigationLink = "[aria-label='Table of Contents'] a";
 
 describe("CARTS Report Fill Tests", () => {
   before(() => {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
remove unhelpful aria label in sidebar

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5038

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Verify the `<nav>` element on report pages doesn't have an aria label

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
