### PR TITLE
cmdct-5801 - add role to alert components

### DIFF
--- a/services/ui-src/src/components/layout/Part.jsx
+++ b/services/ui-src/src/components/layout/Part.jsx
@@ -74,7 +74,7 @@ const Part = ({ partId, partNumber, nestedSubsectionTitle, printView }) => {
     } else {
       if (contextData) {
         return (
-          <Alert>
+          <Alert role="">
             <div className="ds-c-alert__text" data-testid="part-alert">
               {contextData.skip_text && <p>{contextData.skip_text}</p>}
             </div>

--- a/services/ui-src/src/components/sections/login/LocalLogins.jsx
+++ b/services/ui-src/src/components/sections/login/LocalLogins.jsx
@@ -33,6 +33,7 @@ const LocalLogin = () => {
           variation={loginError.variation}
           title={loginError.title}
           description={loginError.description}
+          role=""
         />
       )}
       <form onSubmit={(event) => handleLogin(event)}>


### PR DESCRIPTION
### Description
On the section 01 page, there can be multiple `<Alert>`s on the page base on the status of the report. These alerts have the attribute role="region" that clutter the amount of `landmarks`

<img width="2945" height="1982" alt="CARTS section 01 multiple region landmarks" src="https://github.com/user-attachments/assets/629b6e6f-9f0a-4194-92f9-b98937490d83" />


note from Cypress:
Looks like [Alert](https://design.cms.gov/v/5.0.2/components/alert?theme=core#:~:text=the%20Alert%20icon-,role,-'alert'%20%7C%20'alertdialog'%20%7C%20'region) has role="region" set by default if nothing is passed, you might have to pass role="" to stop the region from being set

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5801

---

### How to test
Login, go to section 1 of a report and open Voice Over, then open the rotor and set it to `Landmarks` and see that there are no more `alert`s getting set to `region`

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [val release](?expand=1&template=val-deployment.md)_ | _[production release](?expand=1&template=production-deployment.md)_
