### PR TITLE
CMDCT-5067 - delete logs after three years

### DIFF
--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -49,35 +49,48 @@ export function createUiComponents(props: CreateUiComponentsProps) {
   let loggingConfig:
     | { enableLogging: boolean; logBucket: s3.Bucket; logFilePrefix: string }
     | undefined;
-  if (!isDev) {
-    // this bucket is not created for ephemeral environments because the delete of the bucket often fails because it doesn't decouple from the distribution gracefully
-    // should you need to test these parts of the infrastructure out the easiest method is to add your branch's name to the isDev definition in deployment-config.ts
-    const logBucket = new s3.Bucket(scope, "CloudfrontLogBucket", {
-      bucketName: `ui-${stage}-cloudfront-logs-${Aws.ACCOUNT_ID}`,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      publicReadAccess: false,
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
-      removalPolicy: RemovalPolicy.RETAIN,
-      enforceSSL: true,
-      versioned: true,
-    });
+  // if (!isDev) {
+  // this bucket is not created for ephemeral environments because the delete of the bucket often fails because it doesn't decouple from the distribution gracefully
+  // should you need to test these parts of the infrastructure out the easiest method is to add your branch's name to the isDev definition in deployment-config.ts
+  const logBucket = new s3.Bucket(scope, "CloudfrontLogBucket", {
+    bucketName: `ui-${stage}-cloudfront-logs-${Aws.ACCOUNT_ID}`,
+    encryption: s3.BucketEncryption.S3_MANAGED,
+    publicReadAccess: false,
+    blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+    objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
+    removalPolicy: RemovalPolicy.RETAIN,
+    enforceSSL: true,
+    versioned: true,
+  });
 
-    logBucket.addToResourcePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        principals: [new iam.ServicePrincipal("cloudfront.amazonaws.com")],
-        actions: ["s3:PutObject"],
-        resources: [`${logBucket.bucketArn}/*`],
-      })
-    );
+  logBucket.addLifecycleRule({
+    id: "ExpiredLogs",
+    expiration: Duration.days(1),
+    noncurrentVersionExpiration: Duration.days(1),
+    abortIncompleteMultipartUploadAfter: Duration.days(1),
+  });
 
-    loggingConfig = {
-      enableLogging: true,
-      logBucket,
-      logFilePrefix: `AWSLogs/CLOUDFRONT/${stage}/`,
-    };
-  }
+  logBucket.addLifecycleRule({
+    id: "CleanUpDeleteMarkers",
+    noncurrentVersionExpiration: Duration.days(1),
+    expiredObjectDeleteMarker: false,
+  });
+
+  logBucket.addToResourcePolicy(
+    new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ServicePrincipal("cloudfront.amazonaws.com")],
+      actions: ["s3:PutObject"],
+      resources: [`${logBucket.bucketArn}/*`],
+    })
+  );
+
+  loggingConfig = {
+    enableLogging: true,
+    logBucket,
+    logFilePrefix: `AWSLogs/CLOUDFRONT/${stage}/`,
+  };
+  // }
 
   const securityHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
     scope,

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -61,6 +61,12 @@ export function createUiComponents(props: CreateUiComponentsProps) {
     removalPolicy: RemovalPolicy.RETAIN,
     enforceSSL: true,
     versioned: true,
+    lifecycleRules: [
+      {
+        expiration: Duration.days(1),
+        noncurrentVersionExpiration: Duration.days(1),
+      },
+    ],
   });
 
   logBucket.addLifecycleRule({

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -63,8 +63,8 @@ export function createUiComponents(props: CreateUiComponentsProps) {
       versioned: true,
       lifecycleRules: [
         {
-          expiration: Duration.days(1),
-          noncurrentVersionExpiration: Duration.days(1),
+          expiration: Duration.days(1095),
+          noncurrentVersionExpiration: Duration.days(1095),
         },
       ],
     });
@@ -72,15 +72,15 @@ export function createUiComponents(props: CreateUiComponentsProps) {
     logBucket.addLifecycleRule({
       id: "ExpiredLogs",
       enabled: true,
-      expiration: Duration.days(1),
-      noncurrentVersionExpiration: Duration.days(1),
-      abortIncompleteMultipartUploadAfter: Duration.days(1),
+      expiration: Duration.days(1095),
+      noncurrentVersionExpiration: Duration.days(1095),
+      abortIncompleteMultipartUploadAfter: Duration.days(1095),
     });
 
     logBucket.addLifecycleRule({
       id: "CleanUpDeleteMarkers",
       enabled: true,
-      noncurrentVersionExpiration: Duration.days(1),
+      noncurrentVersionExpiration: Duration.days(1095),
     });
 
     logBucket.addToResourcePolicy(

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -69,20 +69,6 @@ export function createUiComponents(props: CreateUiComponentsProps) {
       ],
     });
 
-    logBucket.addLifecycleRule({
-      id: "ExpiredLogs",
-      enabled: true,
-      expiration: Duration.days(1095),
-      noncurrentVersionExpiration: Duration.days(1095),
-      abortIncompleteMultipartUploadAfter: Duration.days(1095),
-    });
-
-    logBucket.addLifecycleRule({
-      id: "CleanUpDeleteMarkers",
-      enabled: true,
-      noncurrentVersionExpiration: Duration.days(1095),
-    });
-
     logBucket.addToResourcePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -49,55 +49,55 @@ export function createUiComponents(props: CreateUiComponentsProps) {
   let loggingConfig:
     | { enableLogging: boolean; logBucket: s3.Bucket; logFilePrefix: string }
     | undefined;
-  // if (!isDev) {
-  // this bucket is not created for ephemeral environments because the delete of the bucket often fails because it doesn't decouple from the distribution gracefully
-  // should you need to test these parts of the infrastructure out the easiest method is to add your branch's name to the isDev definition in deployment-config.ts
-  const logBucket = new s3.Bucket(scope, "CloudfrontLogBucket", {
-    bucketName: `ui-${stage}-cloudfront-logs-${Aws.ACCOUNT_ID}`,
-    encryption: s3.BucketEncryption.S3_MANAGED,
-    publicReadAccess: false,
-    blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-    objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
-    removalPolicy: RemovalPolicy.RETAIN,
-    enforceSSL: true,
-    versioned: true,
-    lifecycleRules: [
-      {
-        expiration: Duration.days(1),
-        noncurrentVersionExpiration: Duration.days(1),
-      },
-    ],
-  });
+  if (!isDev) {
+    // this bucket is not created for ephemeral environments because the delete of the bucket often fails because it doesn't decouple from the distribution gracefully
+    // should you need to test these parts of the infrastructure out the easiest method is to add your branch's name to the isDev definition in deployment-config.ts
+    const logBucket = new s3.Bucket(scope, "CloudfrontLogBucket", {
+      bucketName: `ui-${stage}-cloudfront-logs-${Aws.ACCOUNT_ID}`,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      publicReadAccess: false,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
+      removalPolicy: RemovalPolicy.RETAIN,
+      enforceSSL: true,
+      versioned: true,
+      lifecycleRules: [
+        {
+          expiration: Duration.days(1),
+          noncurrentVersionExpiration: Duration.days(1),
+        },
+      ],
+    });
 
-  logBucket.addLifecycleRule({
-    id: "ExpiredLogs",
-    enabled: true,
-    expiration: Duration.days(1),
-    noncurrentVersionExpiration: Duration.days(1),
-    abortIncompleteMultipartUploadAfter: Duration.days(1),
-  });
+    logBucket.addLifecycleRule({
+      id: "ExpiredLogs",
+      enabled: true,
+      expiration: Duration.days(1),
+      noncurrentVersionExpiration: Duration.days(1),
+      abortIncompleteMultipartUploadAfter: Duration.days(1),
+    });
 
-  logBucket.addLifecycleRule({
-    id: "CleanUpDeleteMarkers",
-    enabled: true,
-    noncurrentVersionExpiration: Duration.days(1),
-  });
+    logBucket.addLifecycleRule({
+      id: "CleanUpDeleteMarkers",
+      enabled: true,
+      noncurrentVersionExpiration: Duration.days(1),
+    });
 
-  logBucket.addToResourcePolicy(
-    new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      principals: [new iam.ServicePrincipal("cloudfront.amazonaws.com")],
-      actions: ["s3:PutObject"],
-      resources: [`${logBucket.bucketArn}/*`],
-    })
-  );
+    logBucket.addToResourcePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        principals: [new iam.ServicePrincipal("cloudfront.amazonaws.com")],
+        actions: ["s3:PutObject"],
+        resources: [`${logBucket.bucketArn}/*`],
+      })
+    );
 
-  loggingConfig = {
-    enableLogging: true,
-    logBucket,
-    logFilePrefix: `AWSLogs/CLOUDFRONT/${stage}/`,
-  };
-  // }
+    loggingConfig = {
+      enableLogging: true,
+      logBucket,
+      logFilePrefix: `AWSLogs/CLOUDFRONT/${stage}/`,
+    };
+  }
 
   const securityHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
     scope,

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -65,6 +65,7 @@ export function createUiComponents(props: CreateUiComponentsProps) {
 
   logBucket.addLifecycleRule({
     id: "ExpiredLogs",
+    enabled: true,
     expiration: Duration.days(1),
     noncurrentVersionExpiration: Duration.days(1),
     abortIncompleteMultipartUploadAfter: Duration.days(1),
@@ -72,8 +73,8 @@ export function createUiComponents(props: CreateUiComponentsProps) {
 
   logBucket.addLifecycleRule({
     id: "CleanUpDeleteMarkers",
+    enabled: true,
     noncurrentVersionExpiration: Duration.days(1),
-    expiredObjectDeleteMarker: false,
   });
 
   logBucket.addToResourcePolicy(


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

All apps should retain cloudfront logs for 30 months or 3 years. Since buckets are versioned we also need to make sure that the lifecycle rule doesn't add a delete marker to the file but actually totally removes it.
I initially set the lifecycle policy to 1 day and commented out the `!isDev` check and confirmed that the logs created after the deployment of my branch were deleted. Then I updated the duration to 1095 days.

### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-5067

---

### How to test

<!-- Step-by-step instructions on how to test, if necessary -->

### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->

_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
