### PR TITLE
CMDCT-5115 moves github actions oidc template into prerequisite stack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy CARTSv3
+name: Deploy
 
 on: [push]
 
@@ -28,7 +28,7 @@ jobs:
       - name: set variable values
         run: ./.github/buildVars.sh set_values
         env:
-          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
       - name: Configure AWS credentials for GitHub Actions
@@ -78,7 +78,6 @@ jobs:
           echo "<$APPLICATION_ENDPOINT>" >> $GITHUB_STEP_SUMMARY
     outputs:
       application_endpoint: ${{ steps.endpoint.outputs.application_endpoint }}
-      BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION: ${{ steps.set_names.outputs.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION }}
       BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME: ${{ steps.set_names.outputs.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME }}
 
   # register-runner:
@@ -103,14 +102,14 @@ jobs:
   #       id: set_values
   #       run: ./.github/buildVars.sh set_values
   #       env:
-  #         AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+  #         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
   #         AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
 
   #     - name: Configure AWS credentials for GitHub Actions
   #       uses: aws-actions/configure-aws-credentials@v4
   #       with:
   #         role-to-assume: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
-  #         aws-region: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+  #         aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
   #     - name: output account id
   #       id: output_account_id
@@ -246,7 +245,7 @@ jobs:
   #       uses: aws-actions/configure-aws-credentials@v4
   #       with:
   #         role-to-assume: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
-  #         aws-region: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+  #         aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
   #     - name: output account id
   #       id: output_account_id
   #       run: |

--- a/deployment/local/prerequisites.ts
+++ b/deployment/local/prerequisites.ts
@@ -6,6 +6,7 @@ import {
   Stack,
   StackProps,
   aws_ec2 as ec2,
+  aws_iam as iam,
   aws_secretsmanager as secretsmanager,
 } from "aws-cdk-lib";
 import { Construct } from "constructs";
@@ -42,6 +43,28 @@ export class LocalPrerequisiteStack extends Stack {
         ),
         sedsTopic: SecretValue.unsafePlainText("localstack"),
       },
+    });
+
+    new iam.ManagedPolicy(this, "ADORestrictionPolicy", {
+      managedPolicyName: "ADO-Restriction-Policy",
+      statements: [
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ["*"],
+          resources: ["*"],
+        }),
+      ],
+    });
+
+    new iam.ManagedPolicy(this, "CMSApprovedAWSServicesPolicy", {
+      managedPolicyName: "CMSApprovedAWSServices",
+      statements: [
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ["*"],
+          resources: ["*"],
+        }),
+      ],
     });
   }
 }

--- a/deployment/prerequisites.ts
+++ b/deployment/prerequisites.ts
@@ -2,6 +2,7 @@
 import "source-map-support/register";
 import {
   App,
+  Aws,
   aws_apigateway as apigateway,
   aws_iam as iam,
   DefaultStackSynthesizer,
@@ -15,6 +16,7 @@ import { Construct } from "constructs";
 
 interface PrerequisiteConfigProps {
   project: string;
+  branchFilter: string;
 }
 
 export class PrerequisiteStack extends Stack {
@@ -25,7 +27,7 @@ export class PrerequisiteStack extends Stack {
   ) {
     super(scope, id, props);
 
-    const { project } = props;
+    const { project, branchFilter } = props;
 
     new CloudWatchLogsResourcePolicy(this, "logPolicy", { project });
 
@@ -44,6 +46,50 @@ export class PrerequisiteStack extends Stack {
 
     new apigateway.CfnAccount(this, "ApiGatewayRestApiAccount", {
       cloudWatchRoleArn: cloudWatchRole.roleArn,
+    });
+
+    const githubProvider = new iam.CfnOIDCProvider(
+      this,
+      "GitHubIdentityProvider",
+      {
+        url: "https://token.actions.githubusercontent.com",
+        thumbprintList: ["6938fd4d98bab03faadb97b34396831e3780aea1"], // pragma: allowlist secret
+        clientIdList: ["sts.amazonaws.com"],
+      }
+    );
+
+    new iam.CfnRole(this, "GitHubActionsServiceRole", {
+      description: "Service Role for use in GitHub Actions",
+      assumeRolePolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Sid: "RoleForGitHubActions",
+            Effect: "Allow",
+            Principal: {
+              Federated: githubProvider.attrArn,
+            },
+            Action: ["sts:AssumeRoleWithWebIdentity"],
+            Condition: {
+              StringEquals: {
+                "token.actions.githubusercontent.com:aud": [
+                  "sts.amazonaws.com",
+                ],
+              },
+              StringLike: {
+                "token.actions.githubusercontent.com:sub": [
+                  `repo:Enterprise-CMCS/macpro-mdct-carts:${branchFilter}`,
+                ],
+              },
+            },
+          },
+        ],
+      },
+      managedPolicyArns: [
+        `arn:aws:iam::${Aws.ACCOUNT_ID}:policy/ADO-Restriction-Policy`,
+        `arn:aws:iam::${Aws.ACCOUNT_ID}:policy/CMSApprovedAWSServices`,
+        "arn:aws:iam::aws:policy/AdministratorAccess",
+      ],
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@aws-sdk/client-lambda": "^3.823.0",
     "@aws-sdk/client-s3": "^3.824.0",
     "@aws-sdk/client-secrets-manager": "^3.823.0",
-    "aws-cdk-lib": "^2.200.1",
+    "aws-cdk-lib": "^2.214.0",
     "constructs": "^10.4.2",
     "jsdom": "^26.1.0",
     "source-map-support": "^0.5.21"
@@ -44,7 +44,7 @@
     "@typescript-eslint/eslint-plugin": "5.18.0",
     "@typescript-eslint/parser": "5.18.0",
     "@yarnpkg/lockfile": "^1.1.0",
-    "aws-cdk": "^2.1017.1",
+    "aws-cdk": "^2.1028.0",
     "aws-cdk-local": "^2.19.2",
     "dotenv": "^16.5.0",
     "eslint": "8.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,20 +13,20 @@
     "@csstools/css-tokenizer" "^3.0.3"
     lru-cache "^10.4.3"
 
-"@aws-cdk/asset-awscli-v1@2.2.237":
-  version "2.2.237"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.237.tgz#d3356aaf3f73e34982ae289b7e4441e20d58497a"
-  integrity sha512-OlXylbXI52lboFVJBFLae+WB99qWmI121x/wXQHEMj2RaVNVbWE+OAHcDk2Um1BitUQCaTf9ki57B0Fuqx0Rvw==
+"@aws-cdk/asset-awscli-v1@2.2.242":
+  version "2.2.242"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.242.tgz#235cb25b6d1ad26975b0095c0d6ee84309adae5c"
+  integrity sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==
 
 "@aws-cdk/asset-node-proxy-agent-v6@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz#6d3c7860354d4856a7e75375f2f0ecab313b4989"
   integrity sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==
 
-"@aws-cdk/cloud-assembly-schema@^44.1.0":
-  version "44.1.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-44.1.0.tgz#4100f98e3e28b57527bb3f5ec22685cf8bf7456a"
-  integrity sha512-WvesvSbBw5FrVbH8LZfjX5iDDRdixDkEnbsFGN8H2GNR9geBo4kIBI1nlOiqoGB6dwPwif8qDEM/4NOfuzIChQ==
+"@aws-cdk/cloud-assembly-schema@^48.6.0":
+  version "48.8.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-48.8.0.tgz#b28ac26b672649fcb492cb94fd6be9ecc9213f5e"
+  integrity sha512-PYA6oUpb/7IzCvhOQn3CBJoeDa7iZZkvrN+2hZEK5L1Wc40oInNIt4sz8LlYS/WvqdTDdZC5j53yfle6uutjEw==
   dependencies:
     jsonschema "~1.4.1"
     semver "^7.7.2"
@@ -1753,17 +1753,17 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-cdk-lib@^2.200.1:
-  version "2.200.1"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.200.1.tgz#32865efd815b009387175669b60b9f5a1bb6c2cb"
-  integrity sha512-kLeDtMJPYX3qSAGPONNa3XZk8Z/K3d0As8ui10/Hbv0ohsEsphxSy0xRoxdyj58/hGxOwj1TZsBezMp+TuPPrg==
+aws-cdk-lib@^2.214.0:
+  version "2.214.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.214.0.tgz#26bc0091585a195302775a2d446a1c46be180feb"
+  integrity sha512-Mj9GSJkkXj8wjiy2pKARquOsiiHsu7tK1WDfdA8Db39hIznWWP+/KscI2iqnntDMeEmcj1QX25PbYT+6rq8zkw==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "2.2.237"
+    "@aws-cdk/asset-awscli-v1" "2.2.242"
     "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.0"
-    "@aws-cdk/cloud-assembly-schema" "^44.1.0"
+    "@aws-cdk/cloud-assembly-schema" "^48.6.0"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
-    fs-extra "^11.3.0"
+    fs-extra "^11.3.1"
     ignore "^5.3.2"
     jsonschema "^1.5.0"
     mime-types "^2.1.35"
@@ -1780,10 +1780,10 @@ aws-cdk-local@^2.19.2:
   dependencies:
     diff "^5.0.0"
 
-aws-cdk@^2.1017.1:
-  version "2.1017.1"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.1017.1.tgz#3091e8f295c3fda397f3e691f5ffad8ad4be5d96"
-  integrity sha512-KtDdkMhfVjDeexjpMrVoSlz2mTYI5BE/KotvJ7iFbZy1G0nkpW1ImZ54TdBefeeFmZ+8DAjU3I6nUFtymyOI1A==
+aws-cdk@^2.1028.0:
+  version "2.1029.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.1029.0.tgz#8338bf992c2f7a819fe6e6b3421d3578ab074ec5"
+  integrity sha512-TYJGMs1QVYgOTqt0MnbykZvKXMThevjg/m16MuERlWK3fQErhKcUkMmJ8uUY0SBf70FvT7tQdBq9dnsa34TM2A==
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -2648,10 +2648,10 @@ form-data@^4.0.0:
     hasown "^2.0.2"
     mime-types "^2.1.12"
 
-fs-extra@^11.3.0:
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.0.tgz#0daced136bbaf65a555a326719af931adc7a314d"
-  integrity sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==
+fs-extra@^11.3.1:
+  version "11.3.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.1.tgz#ba7a1f97a85f94c6db2e52ff69570db3671d5a74"
+  integrity sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description
Moving github actions oidc role creation into our modern way of handling the need for assets that need to be in AWS account

### Related ticket(s)
CMDCT-5115

---

### How to test
NA - app still deploys is proof enough

### Notes
NA
---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->

_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
