### PR TITLE
Add mockRouter with future prop

### DIFF
--- a/services/ui-src/src/AppRoutes.test.jsx
+++ b/services/ui-src/src/AppRoutes.test.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { screen, render } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "./util/testing/mockRouter";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
 import AppRoutes from "./AppRoutes";

--- a/services/ui-src/src/components/layout/Autosave.test.jsx
+++ b/services/ui-src/src/components/layout/Autosave.test.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "../../util/testing/mockRouter";
 import configureMockStore from "redux-mock-store";
 import Autosave from "./Autosave";
 

--- a/services/ui-src/src/components/layout/CertifyAndSubmit.test.jsx
+++ b/services/ui-src/src/components/layout/CertifyAndSubmit.test.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "../../util/testing/mockRouter";
 import configureMockStore from "redux-mock-store";
 import CertifyAndSubmit from "./CertifyAndSubmit";
 import { AppRoles } from "../../types";

--- a/services/ui-src/src/components/layout/FormActions.test.jsx
+++ b/services/ui-src/src/components/layout/FormActions.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter } from "../../util/testing/mockRouter";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";

--- a/services/ui-src/src/components/layout/FormNavigation.test.jsx
+++ b/services/ui-src/src/components/layout/FormNavigation.test.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { screen, render } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "../../util/testing/mockRouter";
 import configureMockStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import FormNavigation from "./FormNavigation";

--- a/services/ui-src/src/components/layout/Header.test.jsx
+++ b/services/ui-src/src/components/layout/Header.test.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { screen, render, fireEvent } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "../../util/testing/mockRouter";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
 import Header from "./Header";

--- a/services/ui-src/src/components/layout/Home.test.jsx
+++ b/services/ui-src/src/components/layout/Home.test.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "../../util/testing/mockRouter";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
 import Home from "./Home";

--- a/services/ui-src/src/components/layout/HomeAdmin.test.jsx
+++ b/services/ui-src/src/components/layout/HomeAdmin.test.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "../../util/testing/mockRouter";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
 import HomeAdmin from "./HomeAdmin";

--- a/services/ui-src/src/components/layout/HomeCMS.test.jsx
+++ b/services/ui-src/src/components/layout/HomeCMS.test.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "../../util/testing/mockRouter";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
 import CMSHome from "./HomeCMS";

--- a/services/ui-src/src/components/layout/HomeState.test.jsx
+++ b/services/ui-src/src/components/layout/HomeState.test.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "../../util/testing/mockRouter";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
 import StateHome from "./HomeState";

--- a/services/ui-src/src/components/layout/TableOfContents.test.jsx
+++ b/services/ui-src/src/components/layout/TableOfContents.test.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { screen, render, fireEvent } from "@testing-library/react";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "../../util/testing/mockRouter";
 import configureMockStore from "redux-mock-store";
 import TableOfContents from "./TableOfContents";
 import {

--- a/services/ui-src/src/components/layout/Timeout.test.jsx
+++ b/services/ui-src/src/components/layout/Timeout.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "../../util/testing/mockRouter";
 import { render, screen } from "@testing-library/react";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";

--- a/services/ui-src/src/components/sections/Print.test.jsx
+++ b/services/ui-src/src/components/sections/Print.test.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { screen, render } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "../../util/testing/mockRouter";
 import thunk from "redux-thunk";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";

--- a/services/ui-src/src/components/sections/homepage/CMSHomepage.test.jsx
+++ b/services/ui-src/src/components/sections/homepage/CMSHomepage.test.jsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import configureMockStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import thunk from "redux-thunk";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "../../../util/testing/mockRouter";
 // components
 import CMSHomepage from "./CMSHomepage";
 // mocks

--- a/services/ui-src/src/components/sections/homepage/ReportItem.test.jsx
+++ b/services/ui-src/src/components/sections/homepage/ReportItem.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "../../../util/testing/mockRouter";
 import { screen, render, fireEvent } from "@testing-library/react";
 import configureMockStore from "redux-mock-store";
 import ReportItem from "./ReportItem";

--- a/services/ui-src/src/util/testing/mockRouter.jsx
+++ b/services/ui-src/src/util/testing/mockRouter.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { MemoryRouter as MemoryRouterOriginal } from "react-router-dom";
+
+export const MemoryRouter = ({ children, ...props }) => (
+  <MemoryRouterOriginal
+    future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    {...props}
+  >
+    {children}
+  </MemoryRouterOriginal>
+);


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

The ``⚠️ React Router Future Flag Warning: React Router will begin wrapping state updates in `React.startTransition` in v7. You can use the `v7_startTransition` future flag to opt-in early. For more information, see https://reactrouter.com/v6/upgrading/future#v7_starttransition.`` warning causes a lot of noise when running unit tests. Adding the `future` prop to `MemoryRouter` will quiet them.

<!-- Detailed description of changes and related context -->

<!-- ### Related ticket(s) -->

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

<!-- CMDCT- -->

---

### How to test

<!-- Step-by-step instructions on how to test, if necessary -->
1. On `main`, in `ui-src` run `yarn test`
2. There should be about 30 instances of`⚠️ React Router Future Flag Warning`
3. On this branch,  in `ui-src` run `yarn test`
4. There should be no instances of`⚠️ React Router Future Flag Warning`

<!-- ### Notes -->

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->

<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->

<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->

<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
