### PR TITLE
Section-Base files now update on change

### DIFF
--- a/deployment/stacks/data.ts
+++ b/deployment/stacks/data.ts
@@ -2,7 +2,6 @@ import { Construct } from "constructs";
 import {
   aws_dynamodb as dynamodb,
   aws_iam as iam,
-  custom_resources as cr,
   CfnOutput,
   Duration,
   triggers,
@@ -14,11 +13,10 @@ interface CreateDataComponentsProps {
   scope: Construct;
   stage: string;
   isDev: boolean;
-  customResourceRole: iam.Role;
 }
 
 export function createDataComponents(props: CreateDataComponentsProps) {
-  const { scope, stage, isDev, customResourceRole } = props;
+  const { scope, stage, isDev } = props;
 
   const tables = [
     new DynamoDBTable(scope, "Acs", {
@@ -127,7 +125,6 @@ export function createDataComponents(props: CreateDataComponentsProps) {
     },
     isDev,
   }).lambda;
-
 
   new triggers.Trigger(scope, "InvokeSeedDataFunction", {
     handler: seedDataFunction,

--- a/deployment/stacks/data.ts
+++ b/deployment/stacks/data.ts
@@ -5,6 +5,7 @@ import {
   custom_resources as cr,
   CfnOutput,
   Duration,
+  triggers,
 } from "aws-cdk-lib";
 import { DynamoDBTable } from "../constructs/dynamodb-table";
 import { Lambda } from "../constructs/lambda";
@@ -127,47 +128,12 @@ export function createDataComponents(props: CreateDataComponentsProps) {
     isDev,
   }).lambda;
 
-  const seedDataInvoke = new cr.AwsCustomResource(
-    scope,
-    "InvokeSeedDataFunction",
-    {
-      onCreate: {
-        service: "Lambda",
-        action: "invoke",
-        parameters: {
-          FunctionName: seedDataFunction.functionName,
-          InvocationType: "Event",
-          Payload: JSON.stringify({}),
-        },
-        physicalResourceId: cr.PhysicalResourceId.of(
-          `InvokeSeedDataFunction-${stage}`
-        ),
-      },
-      onUpdate: {
-        service: "Lambda",
-        action: "invoke",
-        parameters: {
-          FunctionName: seedDataFunction.functionName,
-          InvocationType: "Event",
-          Payload: JSON.stringify({}),
-        },
-        physicalResourceId: cr.PhysicalResourceId.of(
-          `InvokeSeedDataFunction-${stage}`
-        ),
-      },
-      onDelete: undefined,
-      policy: cr.AwsCustomResourcePolicy.fromStatements([
-        new iam.PolicyStatement({
-          actions: ["lambda:InvokeFunction"],
-          resources: [seedDataFunction.functionArn],
-        }),
-      ]),
-      role: customResourceRole,
-      resourceType: "Custom::InvokeSeedDataFunction",
-    }
-  );
 
   seedDataInvoke.node.addDependency(seedDataFunction);
+  new triggers.Trigger(scope, "InvokeSeedDataFunction", {
+    handler: seedDataFunction,
+    invocationType: triggers.InvocationType.EVENT,
+  });
 
   new CfnOutput(scope, "SeedDataFunctionName", {
     value: seedDataFunction.functionName,

--- a/deployment/stacks/data.ts
+++ b/deployment/stacks/data.ts
@@ -129,7 +129,6 @@ export function createDataComponents(props: CreateDataComponentsProps) {
   }).lambda;
 
 
-  seedDataInvoke.node.addDependency(seedDataFunction);
   new triggers.Trigger(scope, "InvokeSeedDataFunction", {
     handler: seedDataFunction,
     invocationType: triggers.InvocationType.EVENT,

--- a/services/database/data/seed/seed-section-base-2025.json
+++ b/services/database/data/seed/seed-section-base-2025.json
@@ -8,7 +8,7 @@
         "type": "section",
         "year": 2025,
         "state": null,
-        "title": "Basic State Information2",
+        "title": "Basic State Information",
         "valid": null,
         "ordinal": 0,
         "subsections": [

--- a/services/database/data/seed/seed-section-base-2025.json
+++ b/services/database/data/seed/seed-section-base-2025.json
@@ -8,7 +8,7 @@
         "type": "section",
         "year": 2025,
         "state": null,
-        "title": "Basic State Information",
+        "title": "Basic Friends Information",
         "valid": null,
         "ordinal": 0,
         "subsections": [

--- a/services/database/data/seed/seed-section-base-2025.json
+++ b/services/database/data/seed/seed-section-base-2025.json
@@ -8,7 +8,7 @@
         "type": "section",
         "year": 2025,
         "state": null,
-        "title": "Basic State Information",
+        "title": "Basic State Information2",
         "valid": null,
         "ordinal": 0,
         "subsections": [

--- a/services/database/data/seed/seed-section-base-2025.json
+++ b/services/database/data/seed/seed-section-base-2025.json
@@ -8,7 +8,7 @@
         "type": "section",
         "year": 2025,
         "state": null,
-        "title": "Basic Friends Information",
+        "title": "Basic State Information",
         "valid": null,
         "ordinal": 0,
         "subsections": [


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

Noticed in our recent updates of the section-base files that they would update on create but never on change. This fixes it so that we can actually see our updates after the first deploy!

---

### How to test

Make a change in the seed-section-base-2025 file
Deploy the application
Open up `${youbranchnamehere}-section-base` in dynamo in mdct-carts-dev up in AWS
Find the form and section number you made the edit in (2025-0)
Edit, and open the json view and turn off the dynamo view
See the change you made is there
Make a change in the seed-section-base-2025 file
Deploy the application
See the change you made is now in that same file in dynamo!


### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---