### PR TITLE
Upgrade react-router-dom v6 to react-router v7

### DIFF
--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -27,7 +27,7 @@
     "react-helmet": "^6.1.0",
     "react-multi-select-component": "4.3.4",
     "react-redux": "^8.1.3",
-    "react-router-dom": "^6.30.1",
+    "react-router": "^7.9.1",
     "redux": "4.2.1",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.4.2",

--- a/services/ui-src/src/App.jsx
+++ b/services/ui-src/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Routes, Route, useLocation } from "react-router-dom";
+import { Routes, Route, useLocation } from "react-router";
 import { useUser } from "./hooks/authHooks";
 import { PostLogoutRedirect } from "./components/layout/PostLogoutRedirect";
 import AppRoutes from "./AppRoutes";

--- a/services/ui-src/src/AppRoutes.jsx
+++ b/services/ui-src/src/AppRoutes.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Navigate, Routes, Route } from "react-router-dom";
+import { Navigate, Routes, Route } from "react-router";
 import { Print } from "./components/sections/Print";
 import Spinner from "./components/utils/Spinner";
 import UserProfile from "./components/sections/UserProfile";

--- a/services/ui-src/src/components/layout/CertifyAndSubmit.jsx
+++ b/services/ui-src/src/components/layout/CertifyAndSubmit.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { shallowEqual, useDispatch, useSelector } from "react-redux";
 import { Button, Dialog } from "@cmsgov/design-system";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 // components
 import PageInfo from "./PageInfo";
 import FormActions from "./FormActions";

--- a/services/ui-src/src/components/layout/CertifyAndSubmit.test.jsx
+++ b/services/ui-src/src/components/layout/CertifyAndSubmit.test.jsx
@@ -12,8 +12,8 @@ jest.mock("../../actions/initial", () => ({
 
 const mockedUsedNavigate = jest.fn();
 
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
   useNavigate: () => mockedUsedNavigate,
 }));
 

--- a/services/ui-src/src/components/layout/FormNavigation.jsx
+++ b/services/ui-src/src/components/layout/FormNavigation.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useSelector, shallowEqual } from "react-redux";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router";
 
 //components
 import { Button } from "@cmsgov/design-system";

--- a/services/ui-src/src/components/layout/FormNavigation.test.jsx
+++ b/services/ui-src/src/components/layout/FormNavigation.test.jsx
@@ -106,8 +106,8 @@ const adminNavComponent = (
   </Provider>
 );
 
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
   useNavigate: () => ({
     push: jest.fn(),
   }),

--- a/services/ui-src/src/components/layout/FormTemplates.jsx
+++ b/services/ui-src/src/components/layout/FormTemplates.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Button } from "@cmsgov/design-system";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { apiLib } from "../../util/apiLib";
 import { useFlags } from "launchdarkly-react-client-sdk";
 

--- a/services/ui-src/src/components/layout/FormTemplates.test.jsx
+++ b/services/ui-src/src/components/layout/FormTemplates.test.jsx
@@ -8,8 +8,8 @@ window.alert = jest.fn();
 
 const mockedUsedNavigate = jest.fn();
 
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
   useNavigate: () => mockedUsedNavigate,
 }));
 

--- a/services/ui-src/src/components/layout/Header.jsx
+++ b/services/ui-src/src/components/layout/Header.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 import { useSelector, shallowEqual } from "react-redux";
 // components
 import UsaBanner from "@cmsgov/design-system/dist/components/UsaBanner/UsaBanner";

--- a/services/ui-src/src/components/layout/HomeAdmin.jsx
+++ b/services/ui-src/src/components/layout/HomeAdmin.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 // components
 import { Main } from "./Main";
 import CMSHomepage from "../sections/homepage/CMSHomepage";

--- a/services/ui-src/src/components/layout/HomeCMS.jsx
+++ b/services/ui-src/src/components/layout/HomeCMS.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route } from "react-router";
 import CMSHomepage from "../sections/homepage/CMSHomepage";
 import InvokeSection from "../utils/InvokeSection";
 import SaveError from "./SaveError";

--- a/services/ui-src/src/components/layout/TableOfContents.jsx
+++ b/services/ui-src/src/components/layout/TableOfContents.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 import { useSelector, shallowEqual } from "react-redux";
 //components
 import { VerticalNav } from "@cmsgov/design-system";

--- a/services/ui-src/src/components/layout/TableOfContents.test.jsx
+++ b/services/ui-src/src/components/layout/TableOfContents.test.jsx
@@ -125,8 +125,8 @@ const noFormsToC = (
 
 const mockedUsedNavigate = jest.fn();
 
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
   useNavigate: () => mockedUsedNavigate,
 }));
 

--- a/services/ui-src/src/components/layout/Timeout.jsx
+++ b/services/ui-src/src/components/layout/Timeout.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 //components
 import { Dialog } from "@cmsgov/design-system";
 //auth

--- a/services/ui-src/src/components/sections/Print.jsx
+++ b/services/ui-src/src/components/sections/Print.jsx
@@ -3,7 +3,7 @@ import { shallowEqual, useDispatch, useSelector } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPrint } from "@fortawesome/free-solid-svg-icons";
 import { Button } from "@cmsgov/design-system";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 import { Helmet } from "react-helmet";
 // components
 import Title from "../layout/Title";

--- a/services/ui-src/src/components/sections/homepage/ReportItem.jsx
+++ b/services/ui-src/src/components/sections/homepage/ReportItem.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { useDispatch } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { Dialog } from "@cmsgov/design-system";
 // utils
 import { uncertifyReport } from "../../../actions/uncertify";

--- a/services/ui-src/src/components/sections/login/LocalLogins.jsx
+++ b/services/ui-src/src/components/sections/login/LocalLogins.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 //components
 import { AlertNotification } from "../../alerts/AlertNotification";
 //utils

--- a/services/ui-src/src/components/sections/login/LocalLogins.test.jsx
+++ b/services/ui-src/src/components/sections/login/LocalLogins.test.jsx
@@ -10,8 +10,8 @@ jest.mock("../../../util/apiLib", () => ({
 
 const mockedUsedNavigate = jest.fn();
 
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
   useNavigate: () => mockedUsedNavigate,
 }));
 

--- a/services/ui-src/src/components/utils/InvokeSection.jsx
+++ b/services/ui-src/src/components/utils/InvokeSection.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 // components
 import Section from "../layout/Section";
 // utils

--- a/services/ui-src/src/components/utils/ScrollToTop.js
+++ b/services/ui-src/src/components/utils/ScrollToTop.js
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 function ScrollToTop() {
   const location = useLocation();

--- a/services/ui-src/src/hooks/authHooks/userProvider.jsx
+++ b/services/ui-src/src/hooks/authHooks/userProvider.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 import { UserContext } from "./userContext";
 import { AppRoles, IdmRoles } from "../../types";
 import { loadUser } from "../../actions/initial";

--- a/services/ui-src/src/index.jsx
+++ b/services/ui-src/src/index.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter as Router } from "react-router-dom";
+import { BrowserRouter as Router } from "react-router";
 import * as serviceWorker from "./serviceWorker";
 import { Provider } from "react-redux";
 import { UserProvider } from "./hooks/authHooks";

--- a/services/ui-src/src/setupTests.js
+++ b/services/ui-src/src/setupTests.js
@@ -6,6 +6,9 @@
  */
 import "@testing-library/jest-dom";
 import "jest-axe/extend-expect";
+import { TextEncoder } from "util";
+
+global.TextEncoder = TextEncoder;
 
 global.window.env = {
   API_POSTGRES_URL: "fakeurl",

--- a/services/ui-src/src/util/testing/mockRouter.jsx
+++ b/services/ui-src/src/util/testing/mockRouter.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MemoryRouter as MemoryRouterOriginal } from "react-router-dom";
+import { MemoryRouter as MemoryRouterOriginal } from "react-router";
 
 export const MemoryRouter = ({ children, ...props }) => (
   <MemoryRouterOriginal

--- a/services/ui-src/src/util/testing/mockRouter.jsx
+++ b/services/ui-src/src/util/testing/mockRouter.jsx
@@ -2,10 +2,5 @@ import React from "react";
 import { MemoryRouter as MemoryRouterOriginal } from "react-router";
 
 export const MemoryRouter = ({ children, ...props }) => (
-  <MemoryRouterOriginal
-    future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-    {...props}
-  >
-    {children}
-  </MemoryRouterOriginal>
+  <MemoryRouterOriginal {...props}>{children}</MemoryRouterOriginal>
 );

--- a/services/ui-src/src/util/testing/testUtils.js
+++ b/services/ui-src/src/util/testing/testUtils.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router } from "react-router-dom";
+import { BrowserRouter as Router } from "react-router";
 import { createStore, applyMiddleware } from "redux";
 import thunk from "redux-thunk";
 import { render } from "@testing-library/react";
@@ -16,9 +16,7 @@ export const storeFactory = (initialState) => {
 };
 
 export const RouterWrappedComponent = ({ children }) => (
-  <Router future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-    {children}
-  </Router>
+  <Router>{children}</Router>
 );
 
 /*

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -2329,11 +2329,6 @@
     "@babel/runtime" "^7.23.2"
     immutable "^4.3.4"
 
-"@remix-run/router@1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.0.tgz#35390d0e7779626c026b11376da6789eb8389242"
-  integrity sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==
-
 "@rolldown/pluginutils@1.0.0-beta.27":
   version "1.0.0-beta.27"
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz#47d2bf4cef6d470b22f5831b420f8964e0bf755f"
@@ -3808,6 +3803,11 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cookie@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
+  integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
 
 core-js-compat@^3.43.0:
   version "3.45.1"
@@ -6141,20 +6141,13 @@ react-refresh@^0.17.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.17.0.tgz#b7e579c3657f23d04eccbe4ad2e58a8ed51e7e53"
   integrity sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==
 
-react-router-dom@^6.30.1:
-  version "6.30.1"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.1.tgz#da2580c272ddb61325e435478566be9563a4a237"
-  integrity sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==
+react-router@^7.9.1:
+  version "7.9.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.9.1.tgz#b227410c31f24dd416c939ca5d0f8d5c8a1404d4"
+  integrity sha512-pfAByjcTpX55mqSDGwGnY9vDCpxqBLASg0BMNAuMmpSGESo/TaOUG6BllhAtAkCGx8Rnohik/XtaqiYUJtgW2g==
   dependencies:
-    "@remix-run/router" "1.23.0"
-    react-router "6.30.1"
-
-react-router@6.30.1:
-  version "6.30.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.1.tgz#ecb3b883c9ba6dbf5d319ddbc996747f4ab9f4c3"
-  integrity sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==
-  dependencies:
-    "@remix-run/router" "1.23.0"
+    cookie "^1.0.1"
+    set-cookie-parser "^2.6.0"
 
 react-side-effect@^2.1.0:
   version "2.1.2"
@@ -6422,6 +6415,11 @@ semver@^7.5.3, semver@^7.5.4, semver@^7.7.2, semver@~7.7.1:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+
+set-cookie-parser@^2.6.0:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz#3016f150072202dfbe90fadee053573cc89d2943"
+  integrity sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==
 
 shebang-command@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Followed [upgrade guide](https://reactrouter.com/upgrading/v6#v7_starttransition) but then ultimately deviated...

The only flags we needed were `v7_relativeSplatPath` and `v7_startTransition`. Only the former required code changes (and after testing with and without those changes I found no difference). We weren't using anything that was deprecated. Thus the changes come out as such:

- Install react-router@7
- Remove react-router-dom
- Change all instances of `react-router-dom` for `react-router`
- Remove v7 opt-in flags
- Polyfill `TextEncoder` to fix failing tests

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5188

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- All tests pass
- Click around [deployed app](https://d1dn47he0m3evh.cloudfront.net/) and verify all links work as expected. No errors. Some links to test:
  - FAQ link
  - Generate templates link (admin)
  - View/Edit and Print report links (in home table view)

Print view for 2023 and earlier doesn't work. This is known. Will be addressed separately. 

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
Run `yarn` in services/ui-src locally


---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
