### PR TITLE
Fix duplicate data-grid questions on initial render

### DIFF
--- a/services/ui-src/src/components/fields/DataGrid.jsx
+++ b/services/ui-src/src/components/fields/DataGrid.jsx
@@ -21,6 +21,13 @@ const DataGrid = ({ question, printView }) => {
       return;
     }
 
+    const questionIsAlreadySet = questionsToSet.some(
+      (obj) => obj.question.id === item.id
+    );
+    if (questionIsAlreadySet) {
+      return;
+    }
+
     // Split and create array from id
     const splitID = item.id.split("-");
 


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

React 18 upgrade is pretty slick! One thing I caught this morning after wanting to check production though is that the data-grid has a new tendency of duplicating all of the questions it renders. Not so great! The original function called was assuming that useState was constantly being reset as it was prior to React 18. So anytime a new render triggered an empty list would be born. Well.. In React 18 it looks like they've done a slight tuning and the useState is no longer rending quite as often. Kinda cool! But we've been relying on this old way to clean our questionstoSet array for us. Not so great. 

So what have I done? I've added a quick check to make sure that any questions that get added to our state array don't get added twice. I want to call out this is a working temp solution - Based on my speed testing I've found that synthesized values are causing significant slow down, particularly tables. I'm working on a render re-write that'll speed this up, and part of that is moving this section 3c edge cases out of functions like this which are late in the render cycle (At least, thats the goal 😅, still a WIP). Once that's in, we shouldn't ever have this problem in the first place and we can separate out edge case concerns from our low-level components.

Before:
<img width="740" height="509" alt="Screenshot 2025-09-29 at 2 39 25 PM" src="https://github.com/user-attachments/assets/ab9518d6-c2f9-4bf7-951e-a5712a836e92" />

After:
<img width="760" height="587" alt="Screenshot 2025-09-29 at 2 35 16 PM" src="https://github.com/user-attachments/assets/7d59fc4d-c706-4ad0-a00a-5ba268a6cea0" />

### How to test

- Open up the 2024 report
- Answer Question 2 Program type with "Both Medicaid expansion CHIP and separate CHIP" or "Separate CHIP only"
- Navigate to Section 5
- See theres no duplicated questions in those data grids. 

Extra Credit:
- Open up the DataGrid file, and comment out the added lines and see the original bug I was talking about :). Uncomment it and you'll see its fixed again!

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

#### Review
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

---
