### PR TITLE
[INC1791569] CMS Ticket: Print PDF Not Working

### DIFF
--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -16,7 +16,6 @@
     "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "4.7.0",
     "aws-amplify": "^6.15.6",
-    "buffer": "^6.0.3",
     "date-fns": "^4.1.0",
     "font-awesome": "^4.7.0",
     "jsonpath": "^1.1.1",

--- a/services/ui-src/src/components/sections/Print.jsx
+++ b/services/ui-src/src/components/sections/Print.jsx
@@ -12,11 +12,9 @@ import Section from "../layout/Section";
 import statesArray from "../utils/statesArray";
 import { loadEnrollmentCounts, loadSections } from "../../actions/initial";
 import { apiLib } from "../../util/apiLib";
-import { Buffer } from "buffer";
 
 const openPdf = (basePdf) => {
-  const byteCharacters = Buffer.from(basePdf, "base64").toString("utf8");
-  // const byteCharacters = atob(basePdf);
+  const byteCharacters = atob(basePdf);
   let byteNumbers = new Array(byteCharacters.length);
   for (let i = 0; i < byteCharacters.length; i++) {
     byteNumbers[i] = byteCharacters.charCodeAt(i);
@@ -57,7 +55,7 @@ export const getPdfFriendlyDocument = async () => {
     .replaceAll("\u2013", "-")
     .replaceAll("\u2014", "-");
 
-  const base64String = Buffer.from(htmlString, "base64").toString("utf8");
+  const base64String = btoa(unescape(encodeURIComponent(htmlString)));
   const opts = {
     body: {
       encodedHtml: base64String,

--- a/services/ui-src/src/components/sections/Print.test.jsx
+++ b/services/ui-src/src/components/sections/Print.test.jsx
@@ -23,7 +23,7 @@ jest.mock("../../actions/initial", () => ({
 // Mock apiLib.post for getPdfFriendlyDocument
 jest.mock("../../util/apiLib", () => ({
   apiLib: {
-    post: jest.fn(() => Promise.resolve({ data: "mockPdfBase64" })),
+    post: jest.fn(() => Promise.resolve({ data: "aGVsbG8gd29ybGQNCg==" })), // pragma: allowlist secret
   },
 }));
 


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

<!-- Detailed description of changes and related context -->

Print PDF was not working in higher envs. This reverts some of the changes to the the print function, specifically trying to remove the deprecated unescape and atob/btoa functions in favor of a supported Buffer. 


### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

INC1791569

---

### How to test

<!-- Step-by-step instructions on how to test, if necessary -->
Go to the dashboard and click print
Click print 1 more time and wait for the pdf to appear with any changes you might have made in the form

### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [x] Product: This work has been reviewed and approved by product owner, if necessary
