### PR TITLE
CMDCT-5116 Fix error message overflow

### DIFF
--- a/services/ui-src/src/styles/_form.scss
+++ b/services/ui-src/src/styles/_form.scss
@@ -33,6 +33,9 @@
 
 .ds-l-col fieldset .ds-c-label {
   white-space: nowrap;
+  .ds-c-field__error-message {
+    white-space: wrap;
+  }
 }
 
 .ds-l-col--2 {


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

<!-- Detailed description of changes and related context -->
Fix error message overflowing box

I think we can fully specify the display element if we wanted (CMSDS `errorMessage` [accepts ReactNode](https://github.com/CMSgov/design-system/blob/main/packages/design-system/src/components/InlineError/useInlineError.tsx#L26)) but for now this fixes the overflow issue. There is more CMSDS work to be done if we wish.


BEFORE
<img width="580" height="241" alt="Alert" src="https://github.com/user-attachments/assets/a5f417df-6f44-4ac8-a685-84fb42a5682e" />

AFTER
<img width="763" height="386" alt="Screenshot 2025-10-02 at 4 11 01 PM" src="https://github.com/user-attachments/assets/65eded08-f97b-434b-8325-abdd2e5d028e" />

### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-5116

---

### How to test

<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Navigate to any Integer field in a form
- Enter and delete a value
- Verify the error message does not overflow into anything else (in fact, it should wrap!)

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [x] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

---