### PR TITLE
[CMDCT-5255]: Make the sortable table mobile friendly

### DIFF
--- a/services/ui-src/src/components/sections/homepage/CMSHomepage.jsx
+++ b/services/ui-src/src/components/sections/homepage/CMSHomepage.jsx
@@ -285,7 +285,7 @@ const CMSHomepage = () => {
             <div className="ds-l-row">
               <div className="reports">
                 <SortableTable
-                  aria-labelledBy={"reports-heading"}
+                  ariaLabelledBy={"reports-heading"}
                   columns={columns}
                   data={data}
                 />

--- a/services/ui-src/src/components/sections/homepage/CMSHomepage.jsx
+++ b/services/ui-src/src/components/sections/homepage/CMSHomepage.jsx
@@ -142,9 +142,37 @@ const CMSHomepage = () => {
     const actionLinkURL = `/views/sections/${stateCode}/${year}/00/a`;
 
     switch (headKey) {
-      case "stateName":
+      case "stateName": {
+        return (
+          <span className="cell-bolded">
+            <span className="cell-header">State: </span>
+            {value}
+          </span>
+        );
+      }
       case "year": {
-        return <span className="name">{value}</span>;
+        return (
+          <span className="cell-bolded">
+            <span className="cell-header">Year: </span>
+            {value}
+          </span>
+        );
+      }
+      case "statusText": {
+        return (
+          <span>
+            <span className="cell-header">Status: </span>
+            {value}
+          </span>
+        );
+      }
+      case "lastEdited": {
+        return (
+          <span>
+            <span className="cell-header">Last Edited: </span>
+            {value}
+          </span>
+        );
       }
       case "actions": {
         return (

--- a/services/ui-src/src/components/sections/homepage/CMSHomepage.jsx
+++ b/services/ui-src/src/components/sections/homepage/CMSHomepage.jsx
@@ -160,18 +160,18 @@ const CMSHomepage = () => {
       }
       case "statusText": {
         return (
-          <span>
+          <>
             <span className="cell-header">Status: </span>
             {value}
-          </span>
+          </>
         );
       }
       case "lastEdited": {
         return (
-          <span>
+          <>
             <span className="cell-header">Last Edited: </span>
             {value}
-          </span>
+          </>
         );
       }
       case "actions": {

--- a/services/ui-src/src/components/sections/homepage/CMSHomepage.test.jsx
+++ b/services/ui-src/src/components/sections/homepage/CMSHomepage.test.jsx
@@ -28,10 +28,15 @@ const CmsHomepageComponent = (
 describe("<CMSHomepage />", () => {
   test("renders all rows", () => {
     render(CmsHomepageComponent);
-    expect(screen.getAllByRole("cell", { name: "Alabama" }).length).toBe(2);
-    expect(screen.getAllByRole("cell", { name: "Alaska" }).length).toBe(1);
+    expect(screen.getAllByRole("cell", { name: "State: Alabama" }).length).toBe(
+      2
+    );
+    expect(screen.getAllByRole("cell", { name: "State: Alaska" }).length).toBe(
+      1
+    );
     expect(
-      screen.getAllByRole("cell", { name: "Certified and Submitted" }).length
+      screen.getAllByRole("cell", { name: "Status: Certified and Submitted" })
+        .length
     ).toBe(1);
   });
 
@@ -39,8 +44,12 @@ describe("<CMSHomepage />", () => {
     const user = userEvent.setup();
     render(CmsHomepageComponent);
     expect(screen.getAllByRole("row").length).toBe(4);
-    expect(screen.getAllByRole("cell", { name: "Alabama" }).length).toBe(2);
-    expect(screen.getAllByRole("cell", { name: "Alaska" }).length).toBe(1);
+    expect(screen.getAllByRole("cell", { name: "State: Alabama" }).length).toBe(
+      2
+    );
+    expect(screen.getAllByRole("cell", { name: "State: Alaska" }).length).toBe(
+      1
+    );
     expect(
       screen.queryByRole("cell", { name: "California" })
     ).not.toBeInTheDocument();
@@ -61,9 +70,11 @@ describe("<CMSHomepage />", () => {
     await user.click(screen.getByText("Filter", { selector: "button" }));
 
     expect(screen.getAllByRole("row").length).toBe(3);
-    expect(screen.getAllByRole("cell", { name: "Alabama" }).length).toBe(2);
+    expect(screen.getAllByRole("cell", { name: "State: Alabama" }).length).toBe(
+      2
+    );
     expect(
-      screen.queryByRole("cell", { name: "Alaska" })
+      screen.queryByRole("cell", { name: "State: Alaska" })
     ).not.toBeInTheDocument();
   });
 
@@ -71,8 +82,8 @@ describe("<CMSHomepage />", () => {
     const user = userEvent.setup();
     render(CmsHomepageComponent);
     expect(screen.getAllByRole("row").length).toBe(4);
-    expect(screen.getAllByRole("cell", { name: "2021" }).length).toBe(2);
-    expect(screen.getAllByRole("cell", { name: "2020" }).length).toBe(1);
+    expect(screen.getAllByRole("cell", { name: "Year: 2021" }).length).toBe(2);
+    expect(screen.getAllByRole("cell", { name: "Year: 2020" }).length).toBe(1);
 
     let filterContainer = document.querySelector("div.filter-container");
     const yearFilterDropdown = within(filterContainer).getByText("Year", {
@@ -88,9 +99,9 @@ describe("<CMSHomepage />", () => {
     await user.click(screen.getByText("Filter", { selector: "button" }));
 
     expect(screen.getAllByRole("row").length).toBe(3);
-    expect(screen.getAllByRole("cell", { name: "2021" }).length).toBe(2);
+    expect(screen.getAllByRole("cell", { name: "Year: 2021" }).length).toBe(2);
     expect(
-      screen.queryByRole("cell", { name: "2020" })
+      screen.queryByRole("cell", { name: "Year: 2020" })
     ).not.toBeInTheDocument();
   });
 
@@ -99,7 +110,9 @@ describe("<CMSHomepage />", () => {
     render(CmsHomepageComponent);
     expect(screen.getAllByRole("row").length).toBe(4);
     expect(screen.queryByText("Not Started")).not.toBeInTheDocument();
-    expect(screen.getAllByRole("cell", { name: "In Progress" }).length).toBe(2);
+    expect(
+      screen.getAllByRole("cell", { name: "Status: In Progress" }).length
+    ).toBe(2);
 
     const filterContainer = document.querySelector("div.filter-container");
     const yearFilterDropdown = within(filterContainer).getByText("Status", {
@@ -111,7 +124,7 @@ describe("<CMSHomepage />", () => {
 
     expect(screen.getAllByRole("row").length).toBe(1);
     expect(
-      screen.queryByRole("cell", { name: "In Progress" })
+      screen.queryByRole("cell", { name: "Status: In Progress" })
     ).not.toBeInTheDocument();
   });
 
@@ -119,7 +132,9 @@ describe("<CMSHomepage />", () => {
     const user = userEvent.setup();
     render(CmsHomepageComponent);
     expect(screen.getAllByRole("row").length).toBe(4);
-    expect(screen.getAllByRole("cell", { name: "In Progress" }).length).toBe(2);
+    expect(
+      screen.getAllByRole("cell", { name: "Status: In Progress" }).length
+    ).toBe(2);
     expect(
       screen.queryByRole("cell", { name: "Not Started" })
     ).not.toBeInTheDocument();
@@ -134,15 +149,17 @@ describe("<CMSHomepage />", () => {
 
     expect(screen.getAllByRole("row").length).toBe(1);
     expect(
-      screen.queryByRole("cell", { name: "In Progress" })
+      screen.queryByRole("cell", { name: "Status: In Progress" })
     ).not.toBeInTheDocument();
 
     await user.click(screen.getByText("Clear", { selector: "button" }));
 
     expect(screen.getAllByRole("row").length).toBe(4);
-    expect(screen.getAllByRole("cell", { name: "In Progress" }).length).toBe(2);
     expect(
-      screen.queryByRole("cell", { name: "Not Started" })
+      screen.getAllByRole("cell", { name: "Status: In Progress" }).length
+    ).toBe(2);
+    expect(
+      screen.queryByRole("cell", { name: "Status: Not Started" })
     ).not.toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/components/sections/homepage/Homepage.jsx
+++ b/services/ui-src/src/components/sections/homepage/Homepage.jsx
@@ -48,18 +48,18 @@ const Homepage = ({ reportStatus }) => {
       }
       case "statusText": {
         return (
-          <span>
+          <>
             <span className="cell-header">Status: </span>
             {value}
-          </span>
+          </>
         );
       }
       case "lastEdited": {
         return (
-          <span>
+          <>
             <span className="cell-header">Last Edited: </span>
             {value}
-          </span>
+          </>
         );
       }
       case "actions": {

--- a/services/ui-src/src/components/sections/homepage/Homepage.jsx
+++ b/services/ui-src/src/components/sections/homepage/Homepage.jsx
@@ -106,7 +106,7 @@ const Homepage = ({ reportStatus }) => {
         <div className="ds-l-row">
           <div className="reports">
             <SortableTable
-              aria-labelledBy={"reports-heading"}
+              ariaLabelledBy={"reports-heading"}
               columns={columns}
               data={data}
             />

--- a/services/ui-src/src/components/sections/homepage/Homepage.jsx
+++ b/services/ui-src/src/components/sections/homepage/Homepage.jsx
@@ -39,7 +39,28 @@ const Homepage = ({ reportStatus }) => {
 
     switch (headKey) {
       case "year": {
-        return <span className="name">{value}</span>;
+        return (
+          <span className="cell-bolded">
+            <span className="cell-header">Year: </span>
+            {value}
+          </span>
+        );
+      }
+      case "statusText": {
+        return (
+          <span>
+            <span className="cell-header">Status: </span>
+            {value}
+          </span>
+        );
+      }
+      case "lastEdited": {
+        return (
+          <span>
+            <span className="cell-header">Last Edited: </span>
+            {value}
+          </span>
+        );
       }
       case "actions": {
         return (

--- a/services/ui-src/src/components/sections/homepage/Homepage.test.jsx
+++ b/services/ui-src/src/components/sections/homepage/Homepage.test.jsx
@@ -34,9 +34,11 @@ describe("<Homepage />", () => {
       screen.getByRole("button", { name: "Download template" })
     );
     expect(screen.getAllByRole("row").length).toBe(3);
-    expect(screen.getByRole("cell", { name: "In Progress" })).toBeVisible();
     expect(
-      screen.getByRole("cell", { name: "Certified and Submitted" })
+      screen.getByRole("cell", { name: "Status: In Progress" })
+    ).toBeVisible();
+    expect(
+      screen.getByRole("cell", { name: "Status: Certified and Submitted" })
     ).toBeVisible(1);
   });
 });

--- a/services/ui-src/src/components/sections/homepage/SortableTable.jsx
+++ b/services/ui-src/src/components/sections/homepage/SortableTable.jsx
@@ -59,68 +59,64 @@ const SortableTable = ({
 
   return (
     <TableRoot className="sortable-table" aria-labelledby={ariaLabelledBy}>
-      {
-        <Thead>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <Tr className="report-header" key={headerGroup.id}>
-              {headerGroup.headers.map((header) => {
-                const ariaSort = header.column.getIsSorted()
-                  ? {
-                      "aria-sort":
-                        header.column.getIsSorted() === "asc"
-                          ? "ascending"
-                          : "descending",
-                    }
-                  : {};
+      <Thead>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <Tr className="report-header" key={headerGroup.id}>
+            {headerGroup.headers.map((header) => {
+              const ariaSort = header.column.getIsSorted()
+                ? {
+                    "aria-sort":
+                      header.column.getIsSorted() === "asc"
+                        ? "ascending"
+                        : "descending",
+                  }
+                : {};
 
-                return (
-                  <Th key={header.id} scope="col" {...ariaSort}>
-                    {header.column.getCanSort() && (
-                      <button
-                        className="sortable-table-button sortable-table-header"
-                        onClick={header.column.getToggleSortingHandler()}
-                        aria-label={headerLabels[header.id]}
-                        type="button"
-                      >
-                        <span
-                          ref={(el) => (headerRefs.current[header.id] = el)}
-                        >
-                          {flexRender(
-                            header.column.columnDef.header,
-                            header.getContext()
-                          )}
-                        </span>
-                        <span
-                          className="sortable-table-arrows"
-                          aria-hidden="true"
-                        >
-                          {!header.column.getIsSorted() && (
-                            <FontAwesomeIcon icon={faArrowsUpDown} />
-                          )}
-                          {header.column.getIsSorted() === "asc" && (
-                            <FontAwesomeIcon icon={faArrowUpLong} />
-                          )}
-                          {header.column.getIsSorted() === "desc" && (
-                            <FontAwesomeIcon icon={faArrowDownLong} />
-                          )}
-                        </span>
-                      </button>
-                    )}
-                    {!header.column.getCanSort() && (
-                      <span className="sortable-table-header">
+              return (
+                <Th key={header.id} scope="col" {...ariaSort}>
+                  {header.column.getCanSort() && (
+                    <button
+                      className="sortable-table-button sortable-table-header"
+                      onClick={header.column.getToggleSortingHandler()}
+                      aria-label={headerLabels[header.id]}
+                      type="button"
+                    >
+                      <span ref={(el) => (headerRefs.current[header.id] = el)}>
                         {flexRender(
                           header.column.columnDef.header,
                           header.getContext()
                         )}
                       </span>
-                    )}
-                  </Th>
-                );
-              })}
-            </Tr>
-          ))}
-        </Thead>
-      }
+                      <span
+                        className="sortable-table-arrows"
+                        aria-hidden="true"
+                      >
+                        {!header.column.getIsSorted() && (
+                          <FontAwesomeIcon icon={faArrowsUpDown} />
+                        )}
+                        {header.column.getIsSorted() === "asc" && (
+                          <FontAwesomeIcon icon={faArrowUpLong} />
+                        )}
+                        {header.column.getIsSorted() === "desc" && (
+                          <FontAwesomeIcon icon={faArrowDownLong} />
+                        )}
+                      </span>
+                    </button>
+                  )}
+                  {!header.column.getCanSort() && (
+                    <span className="sortable-table-header">
+                      {flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                    </span>
+                  )}
+                </Th>
+              );
+            })}
+          </Tr>
+        ))}
+      </Thead>
       <Tbody>
         {table.getRowModel().rows.map((row, idx) => (
           <Tr

--- a/services/ui-src/src/components/sections/homepage/SortableTable.jsx
+++ b/services/ui-src/src/components/sections/homepage/SortableTable.jsx
@@ -25,7 +25,7 @@ import {
 } from "@tanstack/react-table";
 
 const SortableTable = ({
-  "aria-labelledby": ariaLabelledBy,
+  ariaLabelledBy,
   columns,
   data,
   initialSorting = [],

--- a/services/ui-src/src/components/sections/homepage/SortableTable.jsx
+++ b/services/ui-src/src/components/sections/homepage/SortableTable.jsx
@@ -59,64 +59,68 @@ const SortableTable = ({
 
   return (
     <TableRoot className="sortable-table" aria-labelledby={ariaLabelledBy}>
-      <Thead>
-        {table.getHeaderGroups().map((headerGroup) => (
-          <Tr className="report-header" key={headerGroup.id}>
-            {headerGroup.headers.map((header) => {
-              const ariaSort = header.column.getIsSorted()
-                ? {
-                    "aria-sort":
-                      header.column.getIsSorted() === "asc"
-                        ? "ascending"
-                        : "descending",
-                  }
-                : {};
+      {
+        <Thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <Tr className="report-header" key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                const ariaSort = header.column.getIsSorted()
+                  ? {
+                      "aria-sort":
+                        header.column.getIsSorted() === "asc"
+                          ? "ascending"
+                          : "descending",
+                    }
+                  : {};
 
-              return (
-                <Th key={header.id} scope="col" {...ariaSort}>
-                  {header.column.getCanSort() && (
-                    <button
-                      className="sortable-table-button sortable-table-header"
-                      onClick={header.column.getToggleSortingHandler()}
-                      aria-label={headerLabels[header.id]}
-                      type="button"
-                    >
-                      <span ref={(el) => (headerRefs.current[header.id] = el)}>
+                return (
+                  <Th key={header.id} scope="col" {...ariaSort}>
+                    {header.column.getCanSort() && (
+                      <button
+                        className="sortable-table-button sortable-table-header"
+                        onClick={header.column.getToggleSortingHandler()}
+                        aria-label={headerLabels[header.id]}
+                        type="button"
+                      >
+                        <span
+                          ref={(el) => (headerRefs.current[header.id] = el)}
+                        >
+                          {flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                        </span>
+                        <span
+                          className="sortable-table-arrows"
+                          aria-hidden="true"
+                        >
+                          {!header.column.getIsSorted() && (
+                            <FontAwesomeIcon icon={faArrowsUpDown} />
+                          )}
+                          {header.column.getIsSorted() === "asc" && (
+                            <FontAwesomeIcon icon={faArrowUpLong} />
+                          )}
+                          {header.column.getIsSorted() === "desc" && (
+                            <FontAwesomeIcon icon={faArrowDownLong} />
+                          )}
+                        </span>
+                      </button>
+                    )}
+                    {!header.column.getCanSort() && (
+                      <span className="sortable-table-header">
                         {flexRender(
                           header.column.columnDef.header,
                           header.getContext()
                         )}
                       </span>
-                      <span
-                        className="sortable-table-arrows"
-                        aria-hidden="true"
-                      >
-                        {!header.column.getIsSorted() && (
-                          <FontAwesomeIcon icon={faArrowsUpDown} />
-                        )}
-                        {header.column.getIsSorted() === "asc" && (
-                          <FontAwesomeIcon icon={faArrowUpLong} />
-                        )}
-                        {header.column.getIsSorted() === "desc" && (
-                          <FontAwesomeIcon icon={faArrowDownLong} />
-                        )}
-                      </span>
-                    </button>
-                  )}
-                  {!header.column.getCanSort() && (
-                    <span className="sortable-table-header">
-                      {flexRender(
-                        header.column.columnDef.header,
-                        header.getContext()
-                      )}
-                    </span>
-                  )}
-                </Th>
-              );
-            })}
-          </Tr>
-        ))}
-      </Thead>
+                    )}
+                  </Th>
+                );
+              })}
+            </Tr>
+          ))}
+        </Thead>
+      }
       <Tbody>
         {table.getRowModel().rows.map((row, idx) => (
           <Tr

--- a/services/ui-src/src/styles/_form.scss
+++ b/services/ui-src/src/styles/_form.scss
@@ -425,8 +425,6 @@
 }
 
 .dropdown-container {
-  max-width: 320px;
-
   .dropdown-heading-value {
     color: #262626;
   }

--- a/services/ui-src/src/styles/_main.scss
+++ b/services/ui-src/src/styles/_main.scss
@@ -185,52 +185,6 @@ img {
     }
   }
 
-  .sortable-table {
-
-    .cell-bolded {
-      color: #333;
-      font-weight: 700;
-    }
-
-    .cell-header {
-      font-weight: 700;
-    }
-
-    thead {
-      display: none;
-    }
-
-    tr {
-      display: grid;
-      padding: 12px 0;
-    }
-
-    td {
-      width: 100%;
-      padding: 4px 16px;
-    }
-
-    @media only screen and (min-width: 768px) {
-      .cell-header {
-        display: none;
-      }
-
-      thead {
-        display: table-header-group;
-      }
-
-      tr {
-        display: table-row;
-        padding: 0;
-      }
-
-      td {
-        width: initial;
-        padding: 16px;
-      }
-    }
-  }
-
   .ds-c-table th {
     background: none;
     color: #333;

--- a/services/ui-src/src/styles/_main.scss
+++ b/services/ui-src/src/styles/_main.scss
@@ -185,6 +185,44 @@ img {
     }
   }
 
+  .sortable-table {
+
+    .cell-bolded {
+      color: #333;
+      font-weight: 700;
+    }
+
+    thead {
+      display: none;
+    }
+
+    .cell-header {
+      font-weight: 700;
+    }
+
+    @media only screen and (min-width: 768px) {
+      thead {
+        display: table-header-group;
+      }
+
+      .cell-header {
+        display: none;
+      }
+    }
+
+    @media only screen and (max-width: 767px) {
+      tr {
+        display: grid;
+        padding: 12px 0;
+      }
+
+      td {
+        width: 100%;
+        padding: 4px 16px;
+      }
+    }
+  }
+
   .ds-c-table th {
     background: none;
     color: #333;

--- a/services/ui-src/src/styles/_main.scss
+++ b/services/ui-src/src/styles/_main.scss
@@ -192,33 +192,41 @@ img {
       font-weight: 700;
     }
 
-    thead {
-      display: none;
-    }
-
     .cell-header {
       font-weight: 700;
     }
 
+    thead {
+      display: none;
+    }
+
+    tr {
+      display: grid;
+      padding: 12px 0;
+    }
+
+    td {
+      width: 100%;
+      padding: 4px 16px;
+    }
+
     @media only screen and (min-width: 768px) {
+      .cell-header {
+        display: none;
+      }
+
       thead {
         display: table-header-group;
       }
 
-      .cell-header {
-        display: none;
-      }
-    }
-
-    @media only screen and (max-width: 767px) {
       tr {
-        display: grid;
-        padding: 12px 0;
+        display: table-row;
+        padding: 0;
       }
 
       td {
-        width: 100%;
-        padding: 4px 16px;
+        width: initial;
+        padding: 16px;
       }
     }
   }

--- a/services/ui-src/src/styles/_sortableTable.scss
+++ b/services/ui-src/src/styles/_sortableTable.scss
@@ -9,6 +9,49 @@
   font-family: "Open Sans", sans-serif;
   margin-top: 0;
 
+  .cell-bolded {
+    color: #333;
+    font-weight: 700;
+  }
+
+  .cell-header {
+    font-weight: 700;
+  }
+
+  thead {
+    display: none;
+  }
+
+  tr {
+    display: grid;
+    padding: 12px 0;
+  }
+
+  td {
+    width: 100%;
+    padding: 4px 16px;
+  }
+
+  @media only screen and (min-width: 768px) {
+    .cell-header {
+      display: none;
+    }
+
+    thead {
+      display: table-header-group;
+    }
+
+    tr {
+      display: table-row;
+      padding: 0;
+    }
+
+    td {
+      width: initial;
+      padding: 16px;
+    }
+  }
+
   &-button {
     background-color: transparent;
     border: 0;


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

The new sortable table didn't really shrink down when it got to smaller viewports. This was especially noticeable when viewing the admin table with its additional column. As such, this PR aims to fix our mobile problems! Working with Cypress, we've aimed to remove the headers while placing them directly in the cell, and going for a more vertical format. While this does remove the sorting feature for mobile users, it keeps it accessibility friendly.

Orignal Mobile View:
<img width="621" height="902" alt="Screenshot 2025-10-02 at 2 38 15 PM" src="https://github.com/user-attachments/assets/3cf9c390-a859-47f8-bd11-32616ee183be" />


New Mobile View:

<img width="472" height="846" alt="Screenshot 2025-10-02 at 4 20 59 PM" src="https://github.com/user-attachments/assets/e6c624dd-a53a-444b-a06e-8e5bfc99f60c" />


### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-5255

---

### How to test

<!-- Step-by-step instructions on how to test, if necessary -->
Load up the report dashboard as any of the following cms.admin/cms.user/stateuser2
See the new dashboard :D. Feel free to grab the edge of the browser and play with it!

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary
