### PR TITLE
CMDCT-5253: Replace all instances of BOOTSTRAP_BROKER_STRING_TLS with brokerString

### DIFF
--- a/deployment/stacks/bigmac-streams.ts
+++ b/deployment/stacks/bigmac-streams.ts
@@ -129,7 +129,7 @@ export function createBigmacStreamsComponents(
     vpcSubnets: { subnets: kafkaAuthorizedSubnets },
     securityGroups: [lambdaSG],
     environment: {
-      brokerString: brokerString,
+      brokerString,
       STAGE: stage,
     },
     ...commonProps,

--- a/deployment/stacks/bigmac-streams.ts
+++ b/deployment/stacks/bigmac-streams.ts
@@ -129,7 +129,7 @@ export function createBigmacStreamsComponents(
     vpcSubnets: { subnets: kafkaAuthorizedSubnets },
     securityGroups: [lambdaSG],
     environment: {
-      BOOTSTRAP_BROKER_STRING_TLS: brokerString,
+      brokerString: brokerString,
       STAGE: stage,
     },
     ...commonProps,

--- a/services/carts-bigmac-streams/libs/kafka-source-lib.js
+++ b/services/carts-bigmac-streams/libs/kafka-source-lib.js
@@ -4,7 +4,7 @@ import { Kafka } from "kafkajs";
 const STAGE = process.env.STAGE;
 const kafka = new Kafka({
   clientId: `carts-${STAGE}`,
-  brokers: process.env.BOOTSTRAP_BROKER_STRING_TLS.split(","),
+  brokers: process.env.brokerString.split(","),
   enforceRequestTimeout: false,
   retry: {
     initialRetryTime: 300,
@@ -105,7 +105,7 @@ export class KafkaSourceLib {
   }
 
   async handler(event) {
-    if (process.env.BOOTSTRAP_BROKER_STRING_TLS === "localstack") {
+    if (process.env.brokerString === "localstack") {
       return;
     }
 


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

CMDCT-5253: Replace all instances of BOOTSTRAP_BROKER_STRING_TLS with brokerString

### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-5253

---

### How to test

<!-- Step-by-step instructions on how to test, if necessary -->

### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->

_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
