### PR TITLE
cmdct-5234 replace h3 with span

### DIFF
--- a/services/ui-src/src/components/layout/DateRange.jsx
+++ b/services/ui-src/src/components/layout/DateRange.jsx
@@ -233,9 +233,9 @@ const DateRange = ({
       </div>
 
       <div className="date-range-start">
-        <h3 className="question-inner-header">
+        <span className="question-inner-header span-pdf-no-bookmark">
           {question.answer.labels[1] ? question.answer.labels[1] : "End"}{" "}
-        </h3>
+        </span>
         <div className="ds-c-field__hint" aria-label="Date range hint">
           mm/yyyy
         </div>

--- a/services/ui-src/src/components/layout/DateRange.jsx
+++ b/services/ui-src/src/components/layout/DateRange.jsx
@@ -192,7 +192,7 @@ const DateRange = ({
   return (
     <div className="date-range" data-test="component-date-range">
       <div className="date-range-start">
-        <span className="question-inner-header span-pdf-no-bookmark">
+        <span className="question-inner-header span-inner-label">
           {question.answer.labels[0] ? question.answer.labels[0] : "Start"}
         </span>
         <div className="ds-c-field__hint" aria-label="Date range hint">
@@ -233,7 +233,7 @@ const DateRange = ({
       </div>
 
       <div className="date-range-start">
-        <span className="question-inner-header span-pdf-no-bookmark">
+        <span className="question-inner-header span-inner-label">
           {question.answer.labels[1] ? question.answer.labels[1] : "End"}{" "}
         </span>
         <div className="ds-c-field__hint" aria-label="Date range hint">

--- a/services/ui-src/src/styles/_fonts.scss
+++ b/services/ui-src/src/styles/_fonts.scss
@@ -70,3 +70,10 @@
   font-weight: bold;
   color: black;
 }
+
+.span-inner-label {
+  display: block;
+  font-size: 1em;
+  font-weight: bold;
+  color: black;
+}


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

Accessibility change: replace h3 with span. Also changed the font sizes of `End` and `Start` to 16px per guidance from Design that CMSDS size for label text is 16px.

### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-5234

---

### How to test

Goto the 4th section to see the `Start` and `End` text. `End` text should be wrapped in a `span` and both `Start` and `End` should be 16px.

### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
