### PR TITLE
CMDCT-5194 Add state user report playwright test

### DIFF
--- a/tests/playwright/tests/home.spec.ts
+++ b/tests/playwright/tests/home.spec.ts
@@ -1,18 +1,8 @@
-import { test, expect } from "@playwright/test";
-import { e2eA11y } from "../utils/a11y";
+import { test } from "@playwright/test";
+import { e2eA11y } from "../utils";
 
 test.describe("State user home page", () => {
   test.use({ storageState: ".auth/user.json" });
-  test("displays", async ({ page }) => {
-    await page.goto("/");
-    await expect(
-      page.getByRole("heading", { name: "CARTS Developer Login" })
-    ).not.toBeVisible();
-    await expect(
-      page.getByRole("heading", { name: "All Reports" })
-    ).toBeVisible();
-  });
-
   test("is accessible", async ({ page }) => {
     await e2eA11y(page, "/");
   });

--- a/tests/playwright/tests/report.spec.ts
+++ b/tests/playwright/tests/report.spec.ts
@@ -1,0 +1,13 @@
+import test, { expect } from "@playwright/test";
+import { enterFirstReport, stateUserHomePageLoad } from "../utils";
+
+test.describe("State user report tests", () => {
+  test.use({ storageState: ".auth/user.json" });
+  test("can open a report", async ({ page }) => {
+    await stateUserHomePageLoad(page);
+    await enterFirstReport(page);
+    expect(
+      page.getByRole("heading", { name: /CARTS FY\d{4} Report/ })
+    ).toBeVisible();
+  });
+});

--- a/tests/playwright/tests/report.spec.ts
+++ b/tests/playwright/tests/report.spec.ts
@@ -6,8 +6,8 @@ test.describe("State user report tests", () => {
   test("can open a report", async ({ page }) => {
     await stateUserHomePageLoad(page);
     await enterFirstReport(page);
-    expect(
-      page.getByRole("heading", { name: /CARTS FY\d{4} Report/ })
-    ).toBeVisible();
+    const reportTitle = page.locator('[data-testid="report-title"] h1');
+    await expect(reportTitle).toBeVisible();
+    await expect(reportTitle).toHaveText(/CARTS FY\d{4} Report/);
   });
 });

--- a/tests/playwright/tests/setup/auth.setup.ts
+++ b/tests/playwright/tests/setup/auth.setup.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import { expect, Page, test as setup } from "@playwright/test";
+import { STATE_USER_HOME_HEADING } from "../../utils";
 
 const stateUserAuthPath: string = ".auth/user.json";
 const stateUser = process.env.CYPRESS_STATE_USER_EMAIL!;
@@ -44,7 +45,7 @@ setup("authenticate as user", async ({ page }) => {
     page,
     stateUser,
     statePassword,
-    "CHIP Annual Reporting Template System (CARTS)",
+    STATE_USER_HOME_HEADING,
     "state user"
   );
   await page.context().storageState({ path: stateUserAuthPath });

--- a/tests/playwright/utils/constants.ts
+++ b/tests/playwright/utils/constants.ts
@@ -1,0 +1,3 @@
+export const STATE_USER_HOME_HEADING =
+  "CHIP Annual Reporting Template System (CARTS)";
+export const LOADING_IMG_ALT_TEXT = "Loading. Please wait.";

--- a/tests/playwright/utils/home.ts
+++ b/tests/playwright/utils/home.ts
@@ -1,6 +1,12 @@
 import { Page } from "@playwright/test";
+import { STATE_USER_HOME_HEADING } from "./constants";
 
 export async function stateUserHomePageLoad(page: Page) {
   await page.goto("/");
-  await page.getByRole("table").waitFor();
+  await page
+    .getByRole("heading", { name: STATE_USER_HOME_HEADING })
+    .waitFor({ state: "visible" });
+  await page
+    .getByRole("table", { name: "All Reports" })
+    .waitFor({ state: "visible" });
 }

--- a/tests/playwright/utils/home.ts
+++ b/tests/playwright/utils/home.ts
@@ -1,10 +1,6 @@
-import { expect, Page } from "@playwright/test";
+import { Page } from "@playwright/test";
 
 export async function stateUserHomePageLoad(page: Page) {
   await page.goto("/");
-  await page.waitForResponse(
-    (response) =>
-      response.url().includes("state_status") && response.status() === 200
-  );
-  expect(page.getByRole("table")).toBeVisible();
+  await page.getByRole("table").waitFor();
 }

--- a/tests/playwright/utils/home.ts
+++ b/tests/playwright/utils/home.ts
@@ -1,0 +1,10 @@
+import { expect, Page } from "@playwright/test";
+
+export async function stateUserHomePageLoad(page: Page) {
+  await page.goto("/");
+  await page.waitForResponse(
+    (response) =>
+      response.url().includes("state_status") && response.status() === 200
+  );
+  expect(page.getByRole("table")).toBeVisible();
+}

--- a/tests/playwright/utils/index.ts
+++ b/tests/playwright/utils/index.ts
@@ -1,0 +1,4 @@
+export * from "./a11y";
+export * from "./constants";
+export * from "./home";
+export * from "./reports";

--- a/tests/playwright/utils/reports.ts
+++ b/tests/playwright/utils/reports.ts
@@ -2,14 +2,12 @@ import { Page } from "@playwright/test";
 import { LOADING_IMG_ALT_TEXT } from "./constants";
 
 export async function enterFirstReport(page: Page) {
-  // Any concerns this data-testid could be modified or removed?
   const firstEditLink = page
     .locator('[data-testid="report-action-button"]')
     .first();
   await firstEditLink.waitFor({ state: "visible" });
   await firstEditLink.click();
 
-  // I need to run it locally, but pretty sure this would be more stable when waiting for the loader
   const loader = page.getByRole("img", { name: LOADING_IMG_ALT_TEXT });
   if (await loader.isVisible().catch(() => false)) {
     await loader.waitFor({ state: "detached" });

--- a/tests/playwright/utils/reports.ts
+++ b/tests/playwright/utils/reports.ts
@@ -2,9 +2,16 @@ import { Page } from "@playwright/test";
 import { LOADING_IMG_ALT_TEXT } from "./constants";
 
 export async function enterFirstReport(page: Page) {
-  const reportEditLinks = await page.getByRole("link", { name: /Edit/ }).all();
-  await reportEditLinks[0].click();
-  await page
-    .getByRole("img", { name: LOADING_IMG_ALT_TEXT })
-    .waitFor({ state: "detached" }); // "detached" checks it's not in the DOM
+  // Any concerns this data-testid could be modified or removed?
+  const firstEditLink = page
+    .locator('[data-testid="report-action-button"]')
+    .first();
+  await firstEditLink.waitFor({ state: "visible" });
+  await firstEditLink.click();
+
+  // I need to run it locally, but pretty sure this would be more stable when waiting for the loader
+  const loader = page.getByRole("img", { name: LOADING_IMG_ALT_TEXT });
+  if (await loader.isVisible().catch(() => false)) {
+    await loader.waitFor({ state: "detached" });
+  }
 }

--- a/tests/playwright/utils/reports.ts
+++ b/tests/playwright/utils/reports.ts
@@ -1,0 +1,10 @@
+import { Page } from "@playwright/test";
+import { LOADING_IMG_ALT_TEXT } from "./constants";
+
+export async function enterFirstReport(page: Page) {
+  const reportEditLinks = await page.getByRole("link", { name: /Edit/ }).all();
+  await reportEditLinks[0].click();
+  await page
+    .getByRole("img", { name: LOADING_IMG_ALT_TEXT })
+    .waitFor({ state: "detached" }); // "detached" checks it's not in the DOM
+}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Add state user playwright test that enters a report
- Refactor playwright tests to set up reusable functions and constants
  - This doesn't have to be the final state of how we organize things, and we can always easily compile these into PageObjects, but I wanted to keep things clean at the start
- Remove redundant home page test
  - It was doing the same thing as the auth setup, so now we just run a11y on homepage
  - Prefer to keep tests minimal and useful as we are building them out


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5194

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Checkout this branch
- `yarn test:e2e-ui` (runs app and opens playwright ui)
  - If you haven't used playwright in CARTS yet, first: `cd tests/playwright && yarn playwright install`
- Run all tests

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---