### PR TITLE
CMDCT-4939 Add skip nav

### DIFF
--- a/services/ui-src/src/App.jsx
+++ b/services/ui-src/src/App.jsx
@@ -3,6 +3,7 @@ import { Routes, Route, useLocation } from "react-router";
 import { useUser } from "./hooks/authHooks";
 import { PostLogoutRedirect } from "./components/layout/PostLogoutRedirect";
 import AppRoutes from "./AppRoutes";
+import SkipNav from "./components/layout/SkipNav";
 import Header from "./components/layout/Header";
 import Timeout from "./components/layout/Timeout";
 import Footer from "./components/layout/Footer";
@@ -29,6 +30,11 @@ function App() {
           data-test="component-app"
         >
           <div className="app-content">
+            <SkipNav
+              id="skip-nav-main"
+              href="#main-content"
+              text="Skip to main content"
+            />
             <Timeout />
             <Header />
             <AppRoutes />

--- a/services/ui-src/src/components/layout/Main.jsx
+++ b/services/ui-src/src/components/layout/Main.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export const Main = ({ className, id, children }) => (
+export const Main = ({ className, id = "main-content", children }) => (
   <main tabIndex={"-1"} className={className} id={id}>
     {children}
   </main>

--- a/services/ui-src/src/components/layout/Section.jsx
+++ b/services/ui-src/src/components/layout/Section.jsx
@@ -9,7 +9,7 @@ import { Main } from "./Main";
 const Section = ({ subsectionId, printView }) => {
   return (
     <div className="section-basic-info ds-l-col--9 content">
-      <Main id="main-content" className="main">
+      <Main className="main">
         <PageInfo />
         <Subsection
           key={subsectionId}

--- a/services/ui-src/src/components/layout/SkipNav.jsx
+++ b/services/ui-src/src/components/layout/SkipNav.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+export const SkipNav = ({ id, href = "#main-content", text }) => {
+  return (
+    <a id={id} href={href} className="skip-nav">
+      {text}
+    </a>
+  );
+};
+
+SkipNav.propTypes = {
+  id: PropTypes.string.isRequired,
+  href: PropTypes.string,
+  text: PropTypes.string.isRequired,
+};
+
+export default SkipNav;

--- a/services/ui-src/src/components/layout/SkipNav.test.jsx
+++ b/services/ui-src/src/components/layout/SkipNav.test.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import SkipNav from "./SkipNav";
+
+const skipNav = (
+  <SkipNav
+    id="skip-nav-main"
+    href="#main-content"
+    text="Skip to main content"
+  />
+);
+
+describe("<SkipNav />", () => {
+  test("should have correct id attribute", () => {
+    render(skipNav);
+
+    expect(screen.getByRole("link")).toHaveAttribute("id", "skip-nav-main");
+  });
+
+  test("should have correct href attribute", () => {
+    render(skipNav);
+
+    expect(screen.getByRole("link")).toHaveAttribute("href", "#main-content");
+  });
+
+  test("should contain text", () => {
+    render(skipNav);
+
+    expect(screen.getByRole("link")).toHaveTextContent("Skip to main content");
+  });
+});

--- a/services/ui-src/src/styles/_skipNav.scss
+++ b/services/ui-src/src/styles/_skipNav.scss
@@ -1,0 +1,22 @@
+@use "variables";
+
+/**********************
+  SKIPNAV
+**********************/
+.skip-nav {
+  background: variables.$white;
+  left: 0;
+  min-width: 200px;
+  outline-offset: variables.$border-width;
+  outline: transparent solid 2px;
+  padding: variables.$padding (variables.$padding * 2);
+  position: absolute;
+  top: -96px;
+  transition: all 0s !important;
+  z-index: 2;
+
+  &:focus-visible {
+    top: variables.$padding;
+    box-shadow: 0 0 0 3px variables.$white,0 0 4px 6px variables.$color-focus !important;
+  }
+}

--- a/services/ui-src/src/styles/_variables.scss
+++ b/services/ui-src/src/styles/_variables.scss
@@ -37,6 +37,8 @@ $color-gray-lightest: #f1f1f1;
 
 $color-icon: #7b7b7b;
 
+$color-focus: #bd13b8;
+
 /* Padding/Margin */
 $padding: 8px;
 $margin: 8px;

--- a/services/ui-src/src/styles/app.scss
+++ b/services/ui-src/src/styles/app.scss
@@ -16,3 +16,4 @@
 @use "localLogin";
 @use "actionCard";
 @use "sortableTable";
+@use "skipNav";


### PR DESCRIPTION
### Description

Add skip nav link to the top of every page.

### Related ticket(s)
CMDCT-4939

---

### How to test

1. Run local or open [deployed env](https://d1ywwym0neyxig.cloudfront.net)
2. Once the home page is loaded, press the `Tab` key
3. Focus should move to the new skip nav link, which will appear on focus
4. Press `enter` to move focus to `<main>`
5. Press `tab` again to confirm that the next interactive element that gets focus is the next interactive element in the `<main>` section.

This can be repeated on any other page.

#### Video example on home page
https://github.com/user-attachments/assets/f535b10b-cac1-4f47-9402-938789856548





