### PR TITLE
CMDCT-5088 Move all sidebar content into nav

### DIFF
--- a/services/ui-src/src/components/layout/Sidebar.jsx
+++ b/services/ui-src/src/components/layout/Sidebar.jsx
@@ -1,13 +1,8 @@
 import React from "react";
-import StateHeader from "./StateHeader";
 import TableOfContents from "./TableOfContents";
 
 const Sidebar = () => (
   <div className="sidebar ds-l-col--3">
-    <div className="skip-content">
-      <a href="#main-content">Skip to main content</a>
-    </div>
-    <StateHeader />
     <TableOfContents />
   </div>
 );

--- a/services/ui-src/src/components/layout/Sidebar.test.jsx
+++ b/services/ui-src/src/components/layout/Sidebar.test.jsx
@@ -2,9 +2,6 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import Sidebar from "./Sidebar";
 
-jest.mock("./StateHeader", () => () => {
-  return <p>state-header</p>;
-});
 jest.mock("./TableOfContents", () => () => {
   return <p>table-of-contents</p>;
 });
@@ -13,7 +10,6 @@ const sidebar = <Sidebar />;
 describe("<Sidebar />", () => {
   test("should contain a header and table of contents", () => {
     render(sidebar);
-    expect(screen.getByText("state-header")).toBeVisible();
     expect(screen.getByText("table-of-contents")).toBeVisible();
   });
 });

--- a/services/ui-src/src/components/layout/TableOfContents.jsx
+++ b/services/ui-src/src/components/layout/TableOfContents.jsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from "react-router";
 import { useSelector, shallowEqual } from "react-redux";
 //components
 import { VerticalNav } from "@cmsgov/design-system";
+import StateHeader from "./StateHeader";
 //types
 import { AppRoles } from "../../types";
 
@@ -106,6 +107,19 @@ const TableOfContents = () => {
       url: `/sections/${formYear}/certify-and-submit`,
     });
   }
+
+  // Add skip link and state header as the first item
+  items.unshift({
+    id: "skip-and-state",
+    component: () => (
+      <>
+        <div className="skip-content">
+          <a href="#main-content">Skip to main content</a>
+        </div>
+        <StateHeader />
+      </>
+    ),
+  });
 
   const foundSelectedId = items.find((item) => item.selected)?.id;
   return <VerticalNav selectedId={foundSelectedId} items={items} />;

--- a/services/ui-src/src/components/layout/TableOfContents.test.jsx
+++ b/services/ui-src/src/components/layout/TableOfContents.test.jsx
@@ -139,6 +139,14 @@ describe("<TableOfContents />", () => {
   beforeEach(() => {
     setLocation();
   });
+  test("should render skip link", async () => {
+    render(tableOfContents);
+    expect(screen.getByText("Skip to main content")).toBeVisible();
+  });
+  test("should render state image", async () => {
+    render(tableOfContents);
+    expect(screen.getByAltText("Alabama")).toBeVisible();
+  });
   test("should render cmsgov vertical nav and pass sections and certify and submit", async () => {
     render(tableOfContents);
     expect(screen.getByText("Section 1: my section")).toBeVisible();


### PR DESCRIPTION
## Description

This ticket was set to be a spike, but in investigating, I was able to solve the issue.

By passing a custom component as one of the vertical nav items, I'm able to get the skip link and state image HTML into the `<nav>` element.

### Related ticket(s)

CMDCT-5088

## How to test

* Run local dev with `./run local` or navigate to [PR deployed environment](https://d2cu9aezkfkq23.cloudfront.net/)
* Navigate to a form, (a page with sidebar navigation)
* Check in the web inspector that every element in the sidebar is nested within the `<nav>` element

### Check with VoiceOver
* Run local dev with `./run local` or navigate to [PR deployed environment](https://d2cu9aezkfkq23.cloudfront.net/)
* Navigate to a form, (a page with sidebar navigation)
* Turn on [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts)
* Activate the rotor (`VO + u`), scroll with left/right arrows to `Landmarks`
* Activate the `navigation` landmark
* Use VoiceOver shortcut to navigate to the next element (`VO + right arrow`), the skip link in the sidebar should be the next element that is focused (indicating that the element is within the `<nav>`)
