### PR TITLE
fix uncertify not working

### DIFF
--- a/services/ui-src/src/components/sections/homepage/ReportItemLinks.jsx
+++ b/services/ui-src/src/components/sections/homepage/ReportItemLinks.jsx
@@ -26,8 +26,8 @@ const ReportItemLinks = ({
   const dispatch = useDispatch();
   const { isShowing, toggleModal } = useModal();
 
-  const uncertify = () => {
-    dispatch(uncertifyReport(stateCode, Number(year)));
+  const uncertify = async () => {
+    await dispatch(uncertifyReport(stateCode, Number(year)));
     toggleModal();
     window.location.reload(false);
   };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Our admin uncertify function stopped working. After logging locally and checking AWS I noticed we were never hitting the api, and often not even getting into the uncertify action. I think since our dispatch was synchronous the modal was closing and aborting the thread before it could make the call.

Await the dispatch and uncertify works again

### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-5304

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[deployed env](https://d1bz3qz4w3yb0t.cloudfront.net/)
- Certify a report as a state user (maybe a few)
- Uncertify as an admin
- Verify it works consistently

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [x] Product: This work has been reviewed and approved by product owner, if necessary
