### PR TITLE
CMDCT-5178 Remove synthesized table id

### DIFF
--- a/services/ui-src/src/components/fields/SynthesizedTable.jsx
+++ b/services/ui-src/src/components/fields/SynthesizedTable.jsx
@@ -76,7 +76,6 @@ const SynthesizedTable = ({ question, printView }) => {
     <div className="synthesized-table">
       <table
         className="ds-c-table"
-        id="synthesized-table-1"
         summary={question.label || "This is a table for the CARTS Application"}
       >
         <thead>


### PR DESCRIPTION
## Description

The `id` attribute on the synthesized table is hard coded and can create problems if there are more than one synthesized table on one page.

There are no references for the `id` anywhere in the app. I can't see any usefulness of this `id`, thus I'm deleting it.

## Related ticket(s)

CMDCT-5178

This work also closes: CMDCT-5229 and CMDCT-5264

---

## How to test

1. Start local app or navigate to the [deployed environment](https://d3p5vs9t6gehxt.cloudfront.net/)
2. Open a report
3. Navigate to section 2 of any year (`/sections/2025/02`)
4. Open the web inspector (`cmd + opt + i`)
5. Search for `<table>` (`//table`)
6. See that there is no `id` attribute
7. Thus there are now multiple `<table>`'s on the page without duplicate `id`s.
