### PR TITLE
CMDCT-5277 Reduce main elements on print all page

### DIFF
--- a/services/ui-src/src/components/layout/Section.jsx
+++ b/services/ui-src/src/components/layout/Section.jsx
@@ -6,17 +6,21 @@ import FormNavigation from "./FormNavigation";
 import FormActions from "./FormActions";
 import { Main } from "./Main";
 
-const Section = ({ subsectionId, printView }) => {
+const Section = ({ subsectionId, printView, useMain = true }) => {
+  const section = (
+    <>
+      <PageInfo />
+      <Subsection
+        key={subsectionId}
+        subsectionId={subsectionId}
+        printView={printView}
+      />
+    </>
+  );
+
   return (
     <div className="section-basic-info ds-l-col--9 content">
-      <Main className="main">
-        <PageInfo />
-        <Subsection
-          key={subsectionId}
-          subsectionId={subsectionId}
-          printView={printView}
-        />
-      </Main>
+      {useMain ? <Main className="main">{section}</Main> : section}
       <div className="form-footer">
         <FormNavigation />
         <FormActions />
@@ -28,6 +32,7 @@ Section.propTypes = {
   subsectionId: PropTypes.string.isRequired,
   sectionId: PropTypes.number.isRequired,
   printView: PropTypes.bool,
+  useMain: PropTypes.bool,
 };
 
 export default Section;

--- a/services/ui-src/src/components/layout/Section.test.jsx
+++ b/services/ui-src/src/components/layout/Section.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { screen, render } from "@testing-library/react";
 import configureMockStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import Section from "./Section";
@@ -39,10 +39,48 @@ const section = (
 describe("<Section />", () => {
   test("passes subsection info to the subsection component", () => {
     render(section);
+
     expect(mockChildComponent).toHaveBeenCalledWith(
       expect.objectContaining({
         subsectionId: testSubSectionId,
       })
     );
+  });
+
+  test("by default should render with a main element", () => {
+    render(section);
+    const main = screen.getByRole("main");
+    expect(main).toBeVisible();
+  });
+
+  test("renders with a <main> if useMain is true", () => {
+    const sectionWithUseMain = (
+      <Provider store={store}>
+        <Section
+          useMain={true}
+          sectionId={testSectionId}
+          subsectionId={testSubSectionId}
+        />
+      </Provider>
+    );
+    render(sectionWithUseMain);
+    const main = screen.getByRole("main");
+    expect(main).toBeVisible();
+  });
+
+  test("renders without a <main> if useMain is false", () => {
+    const sectionNoUseMain = (
+      <Provider store={store}>
+        <Section
+          useMain={false}
+          sectionId={testSectionId}
+          subsectionId={testSubSectionId}
+        />
+      </Provider>
+    );
+    render(sectionNoUseMain);
+    // Using `queryByRole` to allow null if not elements are found
+    const main = screen.queryByRole("main");
+    expect(main).toBeNull();
   });
 });

--- a/services/ui-src/src/components/sections/Print.jsx
+++ b/services/ui-src/src/components/sections/Print.jsx
@@ -8,6 +8,7 @@ import { Helmet } from "react-helmet";
 // components
 import Title from "../layout/Title";
 import Section from "../layout/Section";
+import { Main } from "../layout/Main";
 // utils
 import statesArray from "../utils/statesArray";
 import { loadEnrollmentCounts, loadSections } from "../../actions/initial";
@@ -141,7 +142,8 @@ export const Print = () => {
           sectionId={sectionId}
           subsectionId={subsectionId}
           readonly="false"
-          printView="true"
+          printView={true}
+          useMain={false}
         />
       );
     } else {
@@ -165,7 +167,8 @@ export const Print = () => {
               sectionId={sectionId}
               subsectionId={subsectionId}
               readonly="false"
-              printView="true"
+              printView={true}
+              useMain={false}
             />
           );
         }
@@ -193,7 +196,7 @@ export const Print = () => {
         <meta name="author" content="CMS" />
         <meta name="subject" content="Annual CARTS Report" />
       </Helmet>
-      {sections}
+      <Main className="main">{sections}</Main>
       <Button
         className="ds-c-button--solid ds-c-button--large print-all-btn"
         onClick={getPdfFriendlyDocument}

--- a/services/ui-src/src/components/sections/Print.test.jsx
+++ b/services/ui-src/src/components/sections/Print.test.jsx
@@ -97,7 +97,15 @@ describe("<Print />", () => {
     const path = "/print?year=2020&state=AL";
     render(setup(path));
     const sections = screen.getAllByTestId("print-section");
-    expect(sections.length).toBe(5);
+    expect(sections).toHaveLength(5);
+  });
+
+  test("should render full form with only one <main>", () => {
+    const path = "/print?year=2020&state=AL";
+    render(setup(path));
+
+    const mains = screen.getAllByRole("main");
+    expect(mains).toHaveLength(1);
   });
 
   test("should render for a subsection when provided the subsection query param", () => {
@@ -105,7 +113,16 @@ describe("<Print />", () => {
       "print?year=2020&state=AL&sectionId=2020-03&subsectionId=2020-03-b";
     render(setup(path));
     const sections = screen.getAllByTestId("print-section");
-    expect(sections.length).toBe(1);
+    expect(sections).toHaveLength(1);
+  });
+
+  test("should render subsection with only one <main>", () => {
+    const path =
+      "print?year=2020&state=AL&sectionId=2020-03&subsectionId=2020-03-b";
+    render(setup(path));
+
+    const mains = screen.getAllByRole("main");
+    expect(mains).toHaveLength(1);
   });
 
   test("does not render sections if formData is empty", () => {


### PR DESCRIPTION
## Description

On the print whole form page, there were as many `<main>` elements as there were sections. [Only one `<main>` is allowed on a page](https://dequeuniversity.com/rules/axe/4.6/landmark-one-main).

This was because the `Section` component is what adds the `<main>` to the page. I added a `prop` to stop the `Section` component from making a `<main>` so that I could control it for the print page.

## Related ticket(s)

CMDCT-5277

---

## How to test

1. Start local or [navigate to the deployed environment](https://d4wd5w4huykkd.cloudfront.net/)
2. Click "Edit" on an existing report
3. Scroll to the bottom of the page, click "Print" and then "Entire Form"
4. Check that there's only one `<main>`
    * Dev way:
        * Open inspector (`cmd + opt + i`)
        * Search HTML for any `<main>` element with `//main`
        * Confirm that there's only one
    * Assistive Tech (AT) way:
        * Turn on VoiceOver
        * Open rotor (`ctrl + opt + u`)
        * Navigate to Landmarks with arrows
        * Confirm that there is only one `main` listed

