### PR TITLE
Nit: Remove semicolon from jsx on local login

### DIFF
--- a/services/ui-src/src/App.jsx
+++ b/services/ui-src/src/App.jsx
@@ -44,7 +44,7 @@ function App() {
       )}
       {!user && showLocalLogins && (
         <Main>
-          <LocalLogins loginWithIDM={loginWithIDM} />;
+          <LocalLogins loginWithIDM={loginWithIDM} />
         </Main>
       )}
     </>


### PR DESCRIPTION
### Description

This was driving me crazy 🥴

There was a `;` in the `.jsx` in `App.jsx` that was loaded in the DOM on the local login page.

<img width="3704" height="2024" alt="CARTS Main has semicolon as child" src="https://github.com/user-attachments/assets/2d959042-3d4c-4129-a6be-af77ca503b02" />

### How to test

1. Start local dev or navigate to the deployed env !!!
2. Check that there is no visual `;` on the page

