### PR TITLE
only install chromium for playwright ci tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Run Playwright tests
         run: |
           yarn install
-          yarn playwright install
+          yarn playwright install --with-deps chromium
           yarn playwright test --grep-invert "@flaky" --reporter=github,html
         working-directory: tests/playwright
         env:


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
Only install chromium browser since that's all we test with

Doesn't save that much time but 🤷 

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Playwright tests pass
- Only chromium installs (check logs)
