### PR TITLE
convert assert to with

### DIFF
--- a/services/ui-auth/handlers/createUsers.js
+++ b/services/ui-auth/handlers/createUsers.js
@@ -3,7 +3,7 @@
 
 import * as cognitolib from "../libs/cognito-lib.js";
 const userPoolId = process.env.userPoolId;
-import users from "../libs/users.json" assert { type: "json" };
+import users from "../libs/users.json" with { type: "json" };
 
 // eslint-disable-next-line no-unused-vars
 export async function handler(_event, _context, _callback) {


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

<!-- Detailed description of changes and related context -->
```
 CDK deploy| Bundling asset mcr-main/bootstrapUsers/bootstrapUsers/Code/Stage...
 CDK deploy| 
 CDK deploy| ▲ [WARNING] The "assert" keyword is not supported in the configured target environment ("node22") [assert-to-with]
 CDK deploy| 
 CDK deploy|     services/ui-auth/handlers/createUsers.js:3:39:
 CDK deploy|       3 │ import users from "../libs/users.json" assert { type: "json" };
 CDK deploy|         │                                        ~~~~~~
 CDK deploy|         ╵                                        with
 CDK deploy| 
 CDK deploy|   Did you mean to use "with" instead of "assert"?
 CDK deploy| 
 CDK deploy| 
 CDK deploy| 1 warning
```

Saw this warning in our MCR deploy flow

[import attribute docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with#browser_compatibility)
