### PR TITLE
CMDCT-5522 adds vscode settings for repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea/
-.vscode/
 .infra
 .dynamodb
 .yarn_install

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "oxc.path.oxfmt": "node_modules/oxfmt/bin/oxfmt"
+}


### PR DESCRIPTION
### Description
We'll now start using vscode's workspace files to add settings that will help vscode users of the repo.


### Related ticket(s)
CMDCT-5522

---
### How to test
You could install a npm global version of oxfmt that doesn't match the repo version. Then add config to your general vs code user settings to provides the path to the global version. When you run oxc in vscode, as long as you're at the root of this repo it should be using the version as specified in this repo's package.json (not the global one).

### Notes
NA

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---
