### PR TITLE
CMDCT-5710 ox versioning paradigm shift + universal precommit config

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,9 +26,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - name: Configure pre-commit to skip irrelevant checks
-        run: echo "SKIP=typescript-check-cli,typescript-check-api,typescript-check-ui,typescript-check-cdk,no-commit-to-branch" >> $GITHUB_ENV
-      - uses: pre-commit/action@v3.0.1
       - name: run unit tests
         run: ./scripts/test-unit.ts
       - name: publish test coverage to qlty
@@ -38,6 +35,9 @@ jobs:
           files: |
             ${{github.workspace}}/services/app-api/coverage/lcov.info
             ${{github.workspace}}/services/ui-src/coverage/lcov.info
+      - name: Configure pre-commit to skip irrelevant checks
+        run: echo "SKIP=typescript-check-cli,typescript-check-api,typescript-check-ui,typescript-check-cdk,no-commit-to-branch" >> $GITHUB_ENV
+      - uses: pre-commit/action@v3.0.1
   assignAuthor:
     if: github.event.pull_request.user.type != 'Bot' && github.event.action == 'opened'
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,46 +1,68 @@
+# This file is managed by macpro-mdct-core so if you'd like to change it let's do it there
 exclude: "seed-section-base-*"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
+        exclude: '^services/ui-src/public/templates/.*template\.xlsx$'
+        stages: [pre-commit]
       - id: no-commit-to-branch
+        stages: [pre-commit]
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.1.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         args:
           - --exclude-files
-          - .*test\.json|^tests/seeds/fixtures/|^services/app-api/utils/constants/copyover.ts
+          - .*test\.json
           - --exclude-files
-          - services/uploads/src/test.json
+          - ^services/app-api/utils/constants/copyover.ts
           - --exclude-files
-          - tests/cypress/cypress.json
+          - ^services/app-api/forms/
+          - --exclude-files
+          - ^services/uploads/src/test.json
+          - --exclude-files
+          - ^services/ui-src/src/forms/
+          - --exclude-files
+          - ^services/ui-src/src/utils/forms
+          - --exclude-files
+          - ^tests/cypress/cypress.json
+          - --exclude-files
+          - ^tests/playwright/data/
+          - --exclude-files
+          - ^tests/seeds/fixtures/
+        stages: [pre-commit]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.272
     hooks:
       - id: ruff
+        stages: [pre-commit]
   - repo: https://github.com/zricethezav/gitleaks
     rev: v8.12.0
     hooks:
       - id: gitleaks
+        stages: [pre-commit]
   - repo: local
     hooks:
       - id: oxfmt
         name: oxfmt
-        entry: npx oxfmt
+        entry: yarn oxfmt
         language: system
         pass_filenames: false
+        stages: [pre-commit]
       - id: oxlint
         name: oxlint
-        entry: npx oxlint --deny-warnings
+        entry: yarn oxlint --deny-warnings
         language: system
         pass_filenames: false
+        stages: [pre-commit]
       - id: branch-name-validation
         name: branch-name-validation
         entry: .github/branchNameValidation.ts
         language: system
         pass_filenames: false
+        stages: [pre-commit]
       - id: validate-commit-msg
         name: validate-commit-msg
         entry: .github/validateCommitMessage.ts
@@ -51,18 +73,22 @@ repos:
         entry: bash -c "cd cli && yarn tsc --noEmit"
         language: system
         pass_filenames: false
+        stages: [pre-commit]
       - id: typescript-check-api
         name: typescript-check-api
         entry: bash -c "cd services/app-api && yarn tsc --noEmit"
         language: system
         pass_filenames: false
+        stages: [pre-commit]
       - id: typescript-check-ui
         name: typescript-check-ui
         entry: bash -c "cd services/ui-src && yarn tsc --noEmit"
         language: system
         pass_filenames: false
+        stages: [pre-commit]
       - id: typescript-check-cdk
         name: typescript-check-cdk
         entry: bash -c "cd deployment && yarn tsc --noEmit"
         language: system
         pass_filenames: false
+        stages: [pre-commit]


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
The oxlint and oxfmt versioning was set up such that locally and CI were running increasingly different versions over time. This cropped up in MCR and will if not fixed become an issue all over the place.

### Related ticket(s)
CMDCT-5710

---
### How to test
```
pre-commit run --all-files
```
or you can look at the prchecks since that will do roughly the same thing (excepting some typescript things)

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
