### PR TITLE
[INC-1881392]: Logout alert showing in print docs

### DIFF
--- a/services/ui-src/src/components/layout/Timeout.jsx
+++ b/services/ui-src/src/components/layout/Timeout.jsx
@@ -87,6 +87,7 @@ const Timeout = () => {
       isOpen={showTimeout}
       onExit={refreshAuth}
       heading="You are about to be logged out."
+      className="no-print"
       actions={[
         <button
           className="ds-c-button ds-u-margin-right--1"

--- a/services/ui-src/src/styles/_skipNav.scss
+++ b/services/ui-src/src/styles/_skipNav.scss
@@ -15,6 +15,10 @@
   transition: all 0s !important;
   z-index: 2;
 
+  @media print {
+    display: none;
+  }
+
   &:focus-visible {
     top: variables.$padding;
     box-shadow:


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
It was reported today that print reports were showing the log out timeout notice at the top of the page. Thankfully, this is a nice and easy fix. All we have to do is make sure that dialog is marked as display:none in the print view. I've also gone ahead and made the skipnav button not viewable in the print view.

Before:
<img width="798" height="492" alt="Screenshot 2026-03-23 at 3 10 42 PM" src="https://github.com/user-attachments/assets/7dffaad9-80c0-4a2b-89a0-acdb035d3240" />

After:
<img width="826" height="329" alt="Screenshot 2026-03-23 at 3 11 27 PM" src="https://github.com/user-attachments/assets/b180523a-d244-4976-aa13-bca72bf8f119" />

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
INC-1881392

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Load up stateuser2
Click print on a report
Click print again in the report banner
On the generated report, see at the top of the first page theres no timeout alert message or skip nav link

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary