### PR TITLE
Update sumAndPercentage to check for last years form data before doing calculation

### DIFF
--- a/services/ui-src/src/util/synthesize.js
+++ b/services/ui-src/src/util/synthesize.js
@@ -130,7 +130,11 @@ const sumAndPercentage = (
   let denominator, numerator;
 
   // If its an odd year, we can try and grab last years value for missing data
-  if (isOddYear && values.some((element) => element === null)) {
+  const valuesContainsNull = values.some((element) => element === null);
+  const additionalValuesContainsNull = additionalValues.some(
+    (element) => element === null
+  );
+  if (isOddYear && (valuesContainsNull || additionalValuesContainsNull)) {
     const foundValues = targets.map((target, index) => {
       if (values[index] !== null) {
         return values[index];

--- a/services/ui-src/src/util/synthesize.test.js
+++ b/services/ui-src/src/util/synthesize.test.js
@@ -730,6 +730,29 @@ describe("synthesize()", () => {
       // numerator = 1 + 6 (from lastYearFormData) = 7, denominator = 4, percent = 175%
       expect(out).toEqual({ contents: "7 (175%)" });
     });
+
+    test("sumAndPercentage uses lastYearFormData for odd year and missing denominator values", () => {
+      const out = synthesize(
+        {
+          targets: [
+            "$..*[?(@ && @.id==='2025-01-a-01-01-b')].answer.entry", // 1
+            "$..*[?(@ && @.id==='2025-01-a-01-01-d')].answer.entry", // 3
+          ],
+          additional_targets: [
+            "$..*[?(@ && @.id==='2025-01-a-01-01-g')].answer.entry", // null, should pull from lastYearFormData as 6
+          ],
+          actions: ["sumAndPercentage"],
+        },
+        state.allStatesData,
+        state.global.stateName,
+        state.stateUser.abbr,
+        state.enrollmentCounts.chipEnrollments,
+        state.formData,
+        state.lastYearFormData
+      );
+
+      expect(out).toEqual({ contents: "4 (66.67%)" });
+    });
   });
 
   describe("handles RPNs", () => {


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->

**Background**
CARTS Section 3c uses data from last years form and the current form to produce those tables. For example, last year the users inputted data for Section 5's questions 3-9. This years form users are inputting data for Sections 5's questions 10-20. The table isn’t generating a value for the column in the table because its looks for a 2025 answer in question 3-9, and not a 2024 answer. But Nick, theres a value carried over from 2024 in the 2025 report for the questions, you may ask. Cheekily, we do indeed try and help out in Section 5 by importing values from the prior year, but those values aren’t actually saved in the data. They are simply displayed.

**Fix**
Quite thankfully, past Nick accounted for this scenario! Unluckily, he missed 1 small check. A quick update to the synthesize function to check for null values for the denominator from the past year will have the table calculate using the current years. And away we go!

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

This will take a moment, and while it looks like a lot of steps this will be real quick I promise :).  

- To setup the scenario, you need to go to the seed-local file and open that up
- Optional step: Remove all years prior to 2024. You won't need them and making edits in such a big file can take a hot moment.
- Navigate to the 2025 Section 3c area (Doing a search for `2025-03-c-05-03-b` should get you there quickly.
- You are gonna update this field, with the id `2025-03-c-05-03-b`:
```
{
  "id": "2025-03-c-05-03-b",
  "label": "Ages 0-1",
  "type": "integer",
  "mask": "lessThanEleven"
},
```

- and give it the answer field of 
```
"answer": {
  "entry": null
},
```

- to look like
```
{
  "id": "2025-03-c-05-03-b",
  "label": "Ages 0-1",
  "type": "integer",
  "answer": {
    "entry": null
  },
  "mask": "lessThanEleven"
},
```

- And you'll do this exact same process for `2025-03-c-05-03-c`, `2025-03-c-05-03-d`, and `2025-03-c-05-03-e`.

- Now you're going to add some answer entries to another set of ID's, the `2025-03-c-05-10-b` through `2025-03-c-05-10-e` fields. It should look like this:
```
{
  "id": "2025-03-c-05-10-b",
  "label": "Ages 0-1",
  "type": "integer",
  "answer": {
    "entry": "342"
  },
  "mask": "lessThanEleven"
},
```
- And you'll do this exact same process for `2025-03-c-05-10-c`, `2025-03-c-05-03-d`, and `2025-03-c-05-03-e`.

- All good? Now to do it for 2024! But we're gonna change it up a little

- Navigate to the 2024 Section 3c area (Doing a search for `2024-03-c-05-03-b` should get you there quickly.
- You are gonna update this field, with the id `2024-03-c-05-03-b`:
```
{
  "id": "2024-03-c-05-03-b",
  "label": "Ages 0-1",
  "type": "integer",
  "mask": "lessThanEleven"
},
```

- and give it the answer field of 
```
"answer": {
  "entry": "619"
},
```

- to look like
```
{
  "id": "2024-03-c-05-03-b",
  "label": "Ages 0-1",
  "type": "integer",
  "answer": {
    "entry": "619"
  },
  "mask": "lessThanEleven"
},
```

- And you'll do this exact same process for `2024-03-c-05-03-c`, `2024-03-c-05-03-d`, and `2024-03-c-05-03-e`.

- Now you're going to add some answer entries to another set of ID's, the `2024-03-c-05-10-b` through `2024-03-c-05-10-e` fields. It should look like this:
```
{
  "id": "2024-03-c-05-10-b",
  "label": "Ages 0-1",
  "type": "integer",
  "answer": {
    "entry": null
  },
  "mask": "lessThanEleven"
},
```
- And you'll do this exact same process for `2024-03-c-05-10-c`, `2024-03-c-05-10-d`, and `2024-03-c-05-10-e`.
- Notice the difference here? The `2025-03-c-05-03-c` got an answer of null, but questions `2025-03-c-05-10-c` got an actual answer. We then reversed this for 2024's set. 

- If done correctly, you should end up with with the table `Table 3c. Duration Measure, CHIP, Enrollment 12 Months Later` as having an empty column where there should be a total.

- If you apply the fix in this PR, that column will now calculate correctly.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary
