### PR TITLE
Fix bouncing state header image in sidebar nav

### DIFF
--- a/services/ui-src/src/components/layout/TableOfContents.jsx
+++ b/services/ui-src/src/components/layout/TableOfContents.jsx
@@ -7,6 +7,15 @@ import StateHeader from "./StateHeader";
 //types
 import { AppRoles } from "../../types";
 
+const SkipAndState = () => (
+  <>
+    <div className="skip-content">
+      <a href="#main-content">Skip to main content</a>
+    </div>
+    <StateHeader />
+  </>
+);
+
 const TableOfContents = () => {
   const [userRole, formYear, formData] = useSelector(
     (state) => [
@@ -112,14 +121,7 @@ const TableOfContents = () => {
   // Add skip link and state header as the first item
   items.unshift({
     id: "skip-and-state",
-    component: () => (
-      <>
-        <div className="skip-content">
-          <a href="#main-content">Skip to main content</a>
-        </div>
-        <StateHeader />
-      </>
-    ),
+    component: SkipAndState,
   });
 
   const foundSelectedId = items.find((item) => item.selected)?.id;

--- a/services/ui-src/src/components/layout/TableOfContents.jsx
+++ b/services/ui-src/src/components/layout/TableOfContents.jsx
@@ -7,7 +7,7 @@ import StateHeader from "./StateHeader";
 //types
 import { AppRoles } from "../../types";
 
-const SkipAndState = () => (
+const SkipContentAndStateHeader = () => (
   <>
     <div className="skip-content">
       <a href="#main-content">Skip to main content</a>
@@ -121,7 +121,7 @@ const TableOfContents = () => {
   // Add skip link and state header as the first item
   items.unshift({
     id: "skip-and-state",
-    component: SkipAndState,
+    component: SkipContentAndStateHeader,
   });
 
   const foundSelectedId = items.find((item) => item.selected)?.id;


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
Quick and easy fix to a problem I saw while working on the dependency issues. The sidebars header image was constantly rerendering every time a user inputted text into a question or clicked a choice. Hoisting that header image and skip nav to a stable component and passing it into TableOfContents fixed this issue!

Before:

https://github.com/user-attachments/assets/f10a64f8-c88d-4100-a49a-721793cd7664

After:

https://github.com/user-attachments/assets/b9e5dc13-7514-4235-86fb-9f9f23d2340f


### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Load up a report
Type in any field of that report
Note that the stea header image doesn't move!


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary