### PR TITLE
Ensure answer is defined before clearing its entry

### DIFF
--- a/services/ui-src/src/actions/repeatables.js
+++ b/services/ui-src/src/actions/repeatables.js
@@ -39,7 +39,7 @@ const createNewRepeatableItem = (parentId, getState) => {
   // Set all the answers throughout the new item to null.
   jsonpath.apply(
     newItem,
-    "$..questions[?(@ && @.answer.entry)].answer.entry",
+    "$..questions[?(@ && @.ans && @.answer.entry)].answer.entry",
     () => null
   );
 


### PR DESCRIPTION
### Description
This PR avoids an edge case in the difference between `jsonpath` and `jsonpath-plus`. Given the filter `@ && @.answer.entry`, `jsonpath` would process just fine given an object with neither answer nor entry. But `jsonpath-plus` would attempt to access `element.answer.entry` even if `element.answer` were undefined.

This came about during our [April 2026 upgrade PR](https://github.com/Enterprise-CMCS/macpro-mdct-carts/pull/140343). You can find more details pertaining to this specific issue in this message here: https://github.com/Enterprise-CMCS/macpro-mdct-carts/pull/140343#issuecomment-4407936741

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Open up a carts report (Make sure you are on stateuser2 for easy testing)
- Navigate to Section 4
- Scroll down and click on "Add another goal"
- See a new goal is created!
- You can see this not work if you go to mdctcartsdev.cms.gov and do the same action.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

