### PR TITLE
[CMDCT-5268] Stop constantly calling AWS when clicking fields

### DIFF
--- a/services/ui-src/src/components/fields/Checkbox.jsx
+++ b/services/ui-src/src/components/fields/Checkbox.jsx
@@ -9,7 +9,7 @@ const Checkbox = ({ onChange, question, ...props }) => {
       ? selected.filter((v) => v !== value)
       : [...selected, value];
 
-    onChange({ target: { name, value: updated.length > 0 ? updated : null } });
+    onChange({ target: { name, value: updated.length > 0 ? updated : [] } });
   };
 
   const radioButttonList = question.answer.options.map(

--- a/services/ui-src/src/components/fields/Checkbox.jsx
+++ b/services/ui-src/src/components/fields/Checkbox.jsx
@@ -2,18 +2,14 @@ import React from "react";
 import PropTypes from "prop-types";
 
 const Checkbox = ({ onChange, question, ...props }) => {
-  const value = Array.isArray(question.answer.entry)
-    ? question.answer.entry
-    : [question.answer.entry];
+  const selected = [question.answer.entry].flat().filter((v) => v != null);
 
-  const change = ({ target: { name, value: newValue } }) => {
-    const index = value.indexOf(newValue);
-    if (index !== -1) {
-      value.splice(index, 1);
-      onChange({ target: { name, value } });
-    } else {
-      onChange({ target: { name, value: [...value, newValue] } });
-    }
+  const change = ({ target: { name, value } }) => {
+    const updated = selected.includes(value)
+      ? selected.filter((v) => v !== value)
+      : [...selected, value];
+
+    onChange({ target: { name, value: updated.length > 0 ? updated : null } });
   };
 
   const radioButttonList = question.answer.options.map(
@@ -31,7 +27,7 @@ const Checkbox = ({ onChange, question, ...props }) => {
             type="checkbox"
             value={checkBoxValue}
             onChange={change}
-            checked={value.includes(checkBoxValue)}
+            checked={selected.includes(checkBoxValue)}
             name={props.name}
           />
           <label

--- a/services/ui-src/src/components/fields/Checkbox.test.jsx
+++ b/services/ui-src/src/components/fields/Checkbox.test.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, fireEvent } from "@testing-library/react";
 import Checkbox from "./Checkbox";
+import userEvent from "@testing-library/user-event";
 
 describe("Checkbox component", () => {
   const baseProps = {
@@ -76,6 +77,82 @@ describe("Checkbox component", () => {
     const { getByLabelText } = render(<Checkbox {...props} />);
     const bananaCheckbox = getByLabelText(/Banana/);
     fireEvent.click(bananaCheckbox);
+    expect(props.onChange).toHaveBeenCalledWith({
+      target: { name: "fruits", value: ["apple"] },
+    });
+  });
+
+  it("returns null when unchecking the last checked item", async () => {
+    const props = {
+      ...baseProps,
+      question: {
+        ...baseProps.question,
+        answer: {
+          ...baseProps.question.answer,
+          entry: ["apple"],
+        },
+      },
+    };
+    const { getByLabelText } = render(<Checkbox {...props} />);
+    const appleCheckbox = getByLabelText(/Apple/);
+    await userEvent.click(appleCheckbox);
+    expect(props.onChange).toHaveBeenCalledWith({
+      target: { name: "fruits", value: null },
+    });
+  });
+
+  it("handles null entry by creating a clean array on check", async () => {
+    const props = {
+      ...baseProps,
+      question: {
+        ...baseProps.question,
+        answer: {
+          ...baseProps.question.answer,
+          entry: null,
+        },
+      },
+    };
+    const { getByLabelText } = render(<Checkbox {...props} />);
+    const appleCheckbox = getByLabelText(/Apple/);
+    await userEvent.click(appleCheckbox);
+    expect(props.onChange).toHaveBeenCalledWith({
+      target: { name: "fruits", value: ["apple"] },
+    });
+  });
+
+  it("handles undefined entry by creating a clean array on check", async () => {
+    const props = {
+      ...baseProps,
+      question: {
+        ...baseProps.question,
+        answer: {
+          ...baseProps.question.answer,
+          entry: undefined,
+        },
+      },
+    };
+    const { getByLabelText } = render(<Checkbox {...props} />);
+    const bananaCheckbox = getByLabelText(/Banana/);
+    await userEvent.click(bananaCheckbox);
+    expect(props.onChange).toHaveBeenCalledWith({
+      target: { name: "fruits", value: ["banana"] },
+    });
+  });
+
+  it("filters out null values from an existing array entry", async () => {
+    const props = {
+      ...baseProps,
+      question: {
+        ...baseProps.question,
+        answer: {
+          ...baseProps.question.answer,
+          entry: [null],
+        },
+      },
+    };
+    const { getByLabelText } = render(<Checkbox {...props} />);
+    const appleCheckbox = getByLabelText(/Apple/);
+    await userEvent.click(appleCheckbox);
     expect(props.onChange).toHaveBeenCalledWith({
       target: { name: "fruits", value: ["apple"] },
     });

--- a/services/ui-src/src/components/fields/Checkbox.test.jsx
+++ b/services/ui-src/src/components/fields/Checkbox.test.jsx
@@ -97,7 +97,7 @@ describe("Checkbox component", () => {
     const appleCheckbox = getByLabelText(/Apple/);
     await userEvent.click(appleCheckbox);
     expect(props.onChange).toHaveBeenCalledWith({
-      target: { name: "fruits", value: null },
+      target: { name: "fruits", value: [] },
     });
   });
 

--- a/services/ui-src/src/components/fields/Checkbox.test.jsx
+++ b/services/ui-src/src/components/fields/Checkbox.test.jsx
@@ -82,7 +82,7 @@ describe("Checkbox component", () => {
     });
   });
 
-  it("returns null when unchecking the last checked item", async () => {
+  it("returns empty array when unchecking the last checked item", async () => {
     const props = {
       ...baseProps,
       question: {

--- a/services/ui-src/src/components/fields/Question.jsx
+++ b/services/ui-src/src/components/fields/Question.jsx
@@ -103,9 +103,10 @@ const Question = ({
   };
 
   const handleOnClick = (e) => {
+    if (e.target.type !== "checkbox" && e.target.type !== "radio") return;
     if (e.target.checked) {
       dispatch(setAnswerEntry(e.target.name, ""));
-    } else if (e.target.checked !== undefined) {
+    } else {
       dispatch(setAnswerEntry(e.target.name, e.target.value));
     }
   };

--- a/services/ui-src/src/components/fields/Question.jsx
+++ b/services/ui-src/src/components/fields/Question.jsx
@@ -68,7 +68,6 @@ const Question = ({
   label,
   name,
   onChange,
-  onClick,
   setAnswer,
   // eslint-enable no-unused-vars
   ...props
@@ -100,15 +99,6 @@ const Question = ({
 
   const handleOnChange = ({ target: { name: id, value } }) => {
     dispatch(setAnswerEntry(id, value));
-  };
-
-  const handleOnClick = (e) => {
-    if (e.target.type !== "checkbox" && e.target.type !== "radio") return;
-    if (e.target.checked) {
-      dispatch(setAnswerEntry(e.target.name, ""));
-    } else {
-      dispatch(setAnswerEntry(e.target.name, e.target.value));
-    }
   };
 
   const shouldRenderChildren =
@@ -161,7 +151,6 @@ const Question = ({
           question={question}
           name={question.id}
           onChange={handleOnChange}
-          onClick={handleOnClick}
           disabled={
             prevYearDisabled ||
             pageDisable ||
@@ -203,7 +192,6 @@ Question.propTypes = {
   label: PropTypes.string,
   name: PropTypes.string,
   onChange: PropTypes.func,
-  onClick: PropTypes.func,
   question: PropTypes.object.isRequired,
   prevYear: PropTypes.object,
   printView: PropTypes.bool,

--- a/services/ui-src/src/components/fields/Question.test.jsx
+++ b/services/ui-src/src/components/fields/Question.test.jsx
@@ -343,7 +343,7 @@ describe("<Question />", () => {
     });
   });
 
-  describe("handleOnClick only dispatches for checkbox and radio", () => {
+  describe("clicking fields only dispatches when appropriate", () => {
     beforeEach(() => {
       mockDispatch.mockClear();
       useDispatch.mockReturnValue(mockDispatch);
@@ -376,7 +376,7 @@ describe("<Question />", () => {
       expect(mockDispatch).not.toHaveBeenCalled();
     });
 
-    test("clicking a checkbox dispatches", async () => {
+    test("clicking a checkbox dispatches via onChange only", async () => {
       const props = {
         ...baseProps,
         question: {
@@ -393,7 +393,7 @@ describe("<Question />", () => {
       expect(mockDispatch).toHaveBeenCalledWith({
         type: "QUESTION ANSWERED",
         fragmentId: mockQuestions["checkbox"].id,
-        data: "",
+        data: ["mock-checkbox-answer"],
       });
     });
 
@@ -411,7 +411,7 @@ describe("<Question />", () => {
       expect(mockDispatch).toHaveBeenCalledWith({
         type: "QUESTION ANSWERED",
         fragmentId: mockQuestions["radio"].id,
-        data: "",
+        data: "mock-radio-answer",
       });
     });
   });

--- a/services/ui-src/src/components/fields/Question.test.jsx
+++ b/services/ui-src/src/components/fields/Question.test.jsx
@@ -342,4 +342,77 @@ describe("<Question />", () => {
       expect(numberInput).toHaveValue("5555555555");
     });
   });
+
+  describe("handleOnClick only dispatches for checkbox and radio", () => {
+    beforeEach(() => {
+      mockDispatch.mockClear();
+      useDispatch.mockReturnValue(mockDispatch);
+    });
+
+    test("clicking a text input does not dispatch", async () => {
+      const props = {
+        ...baseProps,
+        question: mockQuestions["text"],
+      };
+      renderQuestion(props);
+
+      const input = screen.getByRole("textbox", { name: "Mock text question" });
+      await userEvent.click(input);
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    test("clicking an integer input does not dispatch", async () => {
+      const props = {
+        ...baseProps,
+        question: mockQuestions["integer"],
+      };
+      renderQuestion(props);
+
+      const group = screen.getByRole("group", {
+        name: /Mock integer question/,
+      });
+      const input = within(group).getByRole("textbox");
+      await userEvent.click(input);
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    test("clicking a checkbox dispatches", async () => {
+      const props = {
+        ...baseProps,
+        question: {
+          ...mockQuestions["checkbox"],
+          questions: [],
+        },
+      };
+      renderQuestion(props);
+
+      const checkbox = screen.getByRole("checkbox", {
+        name: "Question: Mock checkbox question, Answer: Mock checkbox answer",
+      });
+      await userEvent.click(checkbox);
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: "QUESTION ANSWERED",
+        fragmentId: mockQuestions["checkbox"].id,
+        data: "",
+      });
+    });
+
+    test("clicking a radio button dispatches", async () => {
+      const props = {
+        ...baseProps,
+        question: mockQuestions["radio"],
+      };
+      renderQuestion(props);
+
+      const radio = screen.getByRole("radio", {
+        name: "Mock radio answer",
+      });
+      await userEvent.click(radio);
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: "QUESTION ANSWERED",
+        fragmentId: mockQuestions["radio"].id,
+        data: "",
+      });
+    });
+  });
 });

--- a/services/ui-src/src/components/fields/Radio.jsx
+++ b/services/ui-src/src/components/fields/Radio.jsx
@@ -8,12 +8,10 @@ const Radio = ({ question, ...props }) => {
   const [selected, setSelected] = useState(question.answer.entry);
   const dispatch = useDispatch();
 
-  const handleClick = (e) => {
+  const handleChange = (e) => {
     const { name, value } = e.target;
-    const isDeselecting = selected === value;
-
-    setSelected(isDeselecting ? "" : value);
-    dispatch(setAnswerEntry(name, isDeselecting ? "" : value));
+    setSelected(value);
+    dispatch(setAnswerEntry(name, value));
   };
 
   const children =
@@ -39,7 +37,7 @@ const Radio = ({ question, ...props }) => {
               value={value}
               name={props.name}
               disabled={props.disabled}
-              onChange={handleClick}
+              onChange={handleChange}
               id={props.name + "-" + value}
             />
             <label className="label-radio" htmlFor={props.name + "-" + value}>

--- a/services/ui-src/src/components/fields/Radio.jsx
+++ b/services/ui-src/src/components/fields/Radio.jsx
@@ -1,62 +1,60 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
+import { useDispatch } from "react-redux";
 import Question from "./Question";
+import { setAnswerEntry } from "../../actions/initial";
 
-const Radio = ({ onChange, onClick, question, ...props }) => {
-  const [checked, setChecked] = useState(question.answer.entry);
-  const onCheck = (e) => {
-    setChecked(e.target.value);
-    onChange(e);
+const Radio = ({ question, ...props }) => {
+  const [selected, setSelected] = useState(question.answer.entry);
+  const dispatch = useDispatch();
+
+  const handleClick = (e) => {
+    const { name, value } = e.target;
+    const isDeselecting = selected === value;
+
+    setSelected(isDeselecting ? "" : value);
+    dispatch(setAnswerEntry(name, isDeselecting ? "" : value));
   };
 
-  const unCheck = (e) => {
-    setChecked("");
-    onClick(e);
-  };
-
-  let children = <></>;
-
-  if (question.questions && question.questions.length > 0) {
-    children = (
+  const children =
+    question.questions?.length > 0 ? (
       <div className="radio-children">
         {question.questions.map((q, i) => (
           <Question key={q.id || i} question={q} />
         ))}
       </div>
-    );
-  }
+    ) : null;
 
-  const radioButttonList = question.answer.options.map(({ label, value }) => {
-    const isChecked = checked === value;
+  return (
+    <div className="ds-c-fieldset">
+      {question.answer.options.map(({ label, value }) => {
+        const isChecked = selected === value;
 
-    return (
-      <div className="radio-container" key={props.name + "-" + value}>
-        <input
-          key={value}
-          checked={isChecked}
-          type="radio"
-          value={value}
-          name={props.name}
-          disabled={props.disabled}
-          onChange={onCheck}
-          onClick={unCheck}
-          id={props.name + "-" + value}
-        />
-        <label className="label-radio" htmlFor={props.name + "-" + value}>
-          {label}
-        </label>
-        {isChecked && children}
-      </div>
-    );
-  });
-
-  return <div className="ds-c-fieldset">{radioButttonList}</div>;
+        return (
+          <div className="radio-container" key={props.name + "-" + value}>
+            <input
+              key={value}
+              checked={isChecked}
+              type="radio"
+              value={value}
+              name={props.name}
+              disabled={props.disabled}
+              onChange={handleClick}
+              id={props.name + "-" + value}
+            />
+            <label className="label-radio" htmlFor={props.name + "-" + value}>
+              {label}
+            </label>
+            {isChecked && children}
+          </div>
+        );
+      })}
+    </div>
+  );
 };
 Radio.propTypes = {
-  onChange: PropTypes.func.isRequired,
   question: PropTypes.object.isRequired,
   name: PropTypes.string,
-  onClick: PropTypes.func,
 };
 
 export { Radio };

--- a/services/ui-src/src/components/fields/Radio.test.jsx
+++ b/services/ui-src/src/components/fields/Radio.test.jsx
@@ -104,18 +104,6 @@ describe("Radio Component", () => {
     });
   });
 
-  it("dispatches empty string when deselecting the current option", async () => {
-    render(basicRadioProvider);
-    const option1 = screen.getByLabelText("Option 1");
-    await userEventLib.click(option1);
-    expect(option1).not.toBeChecked();
-    expect(store.getActions()).toContainEqual({
-      type: "QUESTION ANSWERED",
-      fragmentId: "test-radio",
-      data: "",
-    });
-  });
-
   it("renders children questions when an option is selected", async () => {
     render(basicRadioProvider);
     const option2 = screen.getByLabelText("Option 2");

--- a/services/ui-src/src/components/fields/Radio.test.jsx
+++ b/services/ui-src/src/components/fields/Radio.test.jsx
@@ -70,18 +70,14 @@ const radioProvider = (props) => {
   );
 };
 
-const onChange = jest.fn();
-const onClick = jest.fn();
-
 const basicRadioProvider = radioProvider({
   question: mockQuestion,
-  onChange,
-  onClick,
 });
 
 describe("Radio Component", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    store.clearActions();
   });
 
   it("renders radio options", () => {
@@ -96,21 +92,35 @@ describe("Radio Component", () => {
     expect(screen.getByLabelText("Option 2")).not.toBeChecked();
   });
 
-  it("calls onChange and updates checked value when a radio is selected", async () => {
+  it("dispatches and updates checked value when a radio is selected", async () => {
     render(basicRadioProvider);
     const option2 = screen.getByLabelText("Option 2");
     await userEventLib.click(option2);
-    expect(onChange).toHaveBeenCalled();
     expect(option2).toBeChecked();
+    expect(store.getActions()).toContainEqual({
+      type: "QUESTION ANSWERED",
+      fragmentId: "test-radio",
+      data: "option2",
+    });
+  });
+
+  it("dispatches empty string when deselecting the current option", async () => {
+    render(basicRadioProvider);
+    const option1 = screen.getByLabelText("Option 1");
+    await userEventLib.click(option1);
+    expect(option1).not.toBeChecked();
+    expect(store.getActions()).toContainEqual({
+      type: "QUESTION ANSWERED",
+      fragmentId: "test-radio",
+      data: "",
+    });
   });
 
   it("renders children questions when an option is selected", async () => {
     render(basicRadioProvider);
     const option2 = screen.getByLabelText("Option 2");
     await userEventLib.click(option2);
-    expect(onChange).toHaveBeenCalled();
     expect(option2).toBeChecked();
-    // Children should be rendered for the checked option
     expect(screen.getByText("childTextQuestion")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->

In the past we've been having intermittent tier 3 alarms over the consumed write capacity units for DynamoDB. Based on our discussions, one of the ways to help reduce the frequency of this alarm is to reduce the amount of writes all fields are doing. On focus, entering data, and leaving focus triggers a 1.2 mb write of the whole report. This happens regardless of any actual data input. These changes can get queued in a debounce function, but that function has a timer of 300ms, hence the consistent 300ms write requests we’re seeing that keep getting fired as a user clicks/tabs through the page. 

This PR fixes that insane amount of writes! It turns out we had an overzealous onHandleClick function that would run any time a user clicked in, changed a value, or lost focus. This was meant for checkboxes and radio fields to help capture their checked and unchecked states but bled over into every other field. Thus, now checkboxes and radio fields correctly capture their onHandleClick, while other fields no longer submit endless streams of AWS writes while perusing the report! This should also save some money with AWS :) 

I've also cleaned up a few other things:
- Fixed double-dispatch on checkbox clicks. Previously, clicking a checkbox triggered 2 calls with the first being an empty string. This was causing two Redux dispatches per click and the second call was masking the first. Now only onChange fires once with the actual value of the checkbox.
- Radio and Checkbox now own their onChange/dispatch logic.
- I also fixed checkbox's null handling. If you checked a checkbox you'd end up with the array `[null, 'checkedvalue']`. Null should never be in that array in the first place. Null is there only if a user has every checkbox unchecked. Now checkboxes will have a clean standard output of `null` (If never selected anything), `['checkedvalue1']` (If you've selected a value), or `[]` (If you previously selected an option, but unchecked everything after). We support null here for legacy data purposes.
- Radio buttons now handle like radio buttons. If you select a radio option, that group will now properly require one option to be selected at all times.

Demo of this working in action:

https://github.com/user-attachments/assets/7751d8fc-501e-415d-9eca-800ab3a2373a



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5268

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Load up any report in the deployed instance
- Play around with all the different fields. The change here related to the Question field which is used by just about ever form field rendered on the page. Users should be able to enter and save data, click in and out of fields without triggering a write, and things like fileUpload should still work
- One thing to note is the data being sent. If you checkout the report payload, you'll no longer see `[null, 'combo']` as a potential value. You'll only see `['combo']` like it should have been in the first place :). 
- Now see how it used to be!
- Run main locally
- Click in and out of a field and watch the calls fly
- Play with the checkboxes and see the above data issue in full view

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
