### PR TITLE
[CMDCT-4851] Add unique page titles across the application

### DIFF
--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -27,7 +27,6 @@
     "prop-types": "^15.8.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "react-helmet": "^6.1.0",
     "react-multi-select-component": "4.3.4",
     "react-redux": "^9.2.0",
     "react-router": "^7.15.1",

--- a/services/ui-src/src/App.jsx
+++ b/services/ui-src/src/App.jsx
@@ -12,6 +12,7 @@ import { fireTealiumPageView } from "./util/tealium";
 import "font-awesome/css/font-awesome.min.css";
 import "./styles/app.scss";
 import { LocalLogins } from "./components/sections/login/LocalLogins";
+import { PageTitle } from "./components/utils/PageTitle";
 
 function App() {
   const { pathname, key } = useLocation();
@@ -52,6 +53,7 @@ function App() {
 
   return (
     <div id="app-wrapper">
+      <PageTitle />
       <Routes>
         <Route path="*" element={authenticatedRoutes} />
         <Route path="/postLogout" element={<PostLogoutRedirect />} />

--- a/services/ui-src/src/AppRoutes.jsx
+++ b/services/ui-src/src/AppRoutes.jsx
@@ -17,6 +17,7 @@ import SaveError from "./components/layout/SaveError";
 import ScrollToTop from "./components/utils/ScrollToTop";
 import { NotFoundPage } from "./components/layout/NotFoundPage";
 import { AppRoles } from "./types.js";
+import { ROUTE_PATHS } from "./util/routePaths";
 
 const CertifyPage = () => (
   <>
@@ -65,7 +66,7 @@ const AppRoutes = () => {
       <Routes>
         {/* General Routes */}
         <Route
-          path="/"
+          path={ROUTE_PATHS.home}
           element={
             isStateUser ? (
               <StateHome />
@@ -73,36 +74,27 @@ const AppRoutes = () => {
             isCMSUser | isAdminUser ? (
               <CMSHomepage />
             ) : (
-              <Navigate to="/user/profile" />
+              <Navigate to={ROUTE_PATHS.userProfile} />
             )
           }
         />
-        <Route path="/user/profile" element={<UserProfile />} />
-        <Route path="/print" element={<Print />} />
-        <Route path="/get-help" element={<GetHelp />} />
-        // State User Form URLS
+        <Route path={ROUTE_PATHS.userProfile} element={<UserProfile />} />
+        <Route path={ROUTE_PATHS.print} element={<Print />} />
+        <Route path={ROUTE_PATHS.getHelp} element={<GetHelp />} />
+        {/* State user form URLs */}
+        <Route path={ROUTE_PATHS.sectionSubsection} element={<Section />} />
+        <Route path={ROUTE_PATHS.section} element={<Section />} />
+        <Route path={ROUTE_PATHS.certifyAndSubmit} element={<CertifyPage />} />
+        {/* Admin & CMS user form URLs */}
         <Route
-          path="/sections/:year/:sectionOrdinal/:subsectionMarker"
+          path={ROUTE_PATHS.viewsSectionSubsection}
           element={<Section />}
         />
-        <Route path="sections/:year/:sectionOrdinal" element={<Section />} />
-        <Route
-          path="/sections/:year/certify-and-submit"
-          element={<CertifyPage />}
-        />
-        //Admin & CMS User Form URLS
-        <Route
-          path="/views/sections/:state/:year/:sectionOrdinal/:subsectionMarker"
-          element={<Section />}
-        />
-        <Route
-          path="/views/sections/:state/:year/:sectionOrdinal"
-          element={<Section />}
-        />
-        <Route path="/state-reports" element={<CMSHomepage />} />
-        <Route path="/templates" element={<FormTemplates />} />
-        //If path not found
-        <Route path="*" element={<NotFoundPage />} />
+        <Route path={ROUTE_PATHS.viewsSection} element={<Section />} />
+        <Route path={ROUTE_PATHS.stateReports} element={<CMSHomepage />} />
+        <Route path={ROUTE_PATHS.templates} element={<FormTemplates />} />
+        {/* If path not found */}
+        <Route path={ROUTE_PATHS.notFound} element={<NotFoundPage />} />
       </Routes>
     </>
   );

--- a/services/ui-src/src/components/sections/Print.jsx
+++ b/services/ui-src/src/components/sections/Print.jsx
@@ -89,7 +89,6 @@ export const Print = () => {
   const stateInitials = searchParams.get("state");
   const stateName =
     name || statesArray.find(({ value }) => value === stateInitials)?.label;
-  const formYear = searchParams.get("year");
   const sectionId = searchParams.get("sectionId");
   const subsectionId = searchParams.get("subsectionId");
 
@@ -190,10 +189,8 @@ export const Print = () => {
           <FontAwesomeIcon icon={faPrint} /> Print
         </Button>
       </div>
+      {/* The document <title> is set centrally in PageTitle.jsx (WCAG 2.4.2). */}
       <Helmet>
-        <title>
-          {stateName} CARTS FY{formYear} Report
-        </title>
         <meta name="author" content="CMS" />
         <meta name="subject" content="Annual CARTS Report" />
       </Helmet>

--- a/services/ui-src/src/components/sections/Print.jsx
+++ b/services/ui-src/src/components/sections/Print.jsx
@@ -13,10 +13,8 @@ import statesArray from "../utils/statesArray";
 import { loadEnrollmentCounts, loadSections } from "../../actions/initial";
 import { apiLib } from "../../util/apiLib";
 
-// Document <meta> tags carried into the generated PDF. These were previously
-// rendered via react-helmet, whose side-effect mechanism does not apply under
-// React 19 (the tags never reached the DOM), so the values were silently lost.
-// We set them directly on mount and remove them on unmount.
+// <meta> tags carried into the generated PDF. Set directly on mount and removed
+// on unmount because react-helmet's side effects don't apply under React 19.
 const PRINT_META = [
   { name: "author", content: "CMS" },
   { name: "subject", content: "Annual CARTS Report" },
@@ -158,8 +156,6 @@ export const Print = () => {
     }
   }, [currentUser]);
 
-  // Author/subject metadata for the printed report. Set directly on the DOM
-  // because react-helmet is a no-op under React 19 (see PRINT_META above).
   useEffect(() => {
     const entries = setPrintMeta();
     return () => cleanupPrintMeta(entries);
@@ -227,11 +223,6 @@ export const Print = () => {
           <FontAwesomeIcon icon={faPrint} /> Print
         </Button>
       </div>
-      {/*
-        The document <title> is set centrally in PageTitle.jsx and the
-        author/subject <meta> tags are set via effect above (WCAG 2.4.2;
-        react-helmet does not apply either under React 19).
-      */}
       <Main className="main">{sections}</Main>
       <Button
         className="ds-c-button--solid ds-c-button--large print-all-btn"

--- a/services/ui-src/src/components/sections/Print.jsx
+++ b/services/ui-src/src/components/sections/Print.jsx
@@ -4,7 +4,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPrint } from "@fortawesome/free-solid-svg-icons";
 import { Button } from "@cmsgov/design-system";
 import { useLocation } from "react-router";
-import { Helmet } from "react-helmet";
 // components
 import Title from "../layout/Title";
 import Section from "../layout/Section";
@@ -13,6 +12,38 @@ import { Main } from "../layout/Main";
 import statesArray from "../utils/statesArray";
 import { loadEnrollmentCounts, loadSections } from "../../actions/initial";
 import { apiLib } from "../../util/apiLib";
+
+// Document <meta> tags carried into the generated PDF. These were previously
+// rendered via react-helmet, whose side-effect mechanism does not apply under
+// React 19 (the tags never reached the DOM), so the values were silently lost.
+// We set them directly on mount and remove them on unmount.
+const PRINT_META = [
+  { name: "author", content: "CMS" },
+  { name: "subject", content: "Annual CARTS Report" },
+];
+
+const setPrintMeta = () =>
+  PRINT_META.map(({ name, content }) => {
+    let el = document.head.querySelector(`meta[name="${name}"]`);
+    const created = !el;
+    if (!el) {
+      el = document.createElement("meta");
+      el.setAttribute("name", name);
+      document.head.append(el);
+    }
+    const prevContent = el.getAttribute("content");
+    el.setAttribute("content", content);
+    return { el, created, prevContent };
+  });
+
+const cleanupPrintMeta = (entries) =>
+  entries.forEach(({ el, created, prevContent }) => {
+    if (created) {
+      el.remove();
+    } else if (prevContent !== null) {
+      el.setAttribute("content", prevContent);
+    }
+  });
 
 const openPdf = (basePdf) => {
   const byteCharacters = atob(basePdf);
@@ -127,6 +158,13 @@ export const Print = () => {
     }
   }, [currentUser]);
 
+  // Author/subject metadata for the printed report. Set directly on the DOM
+  // because react-helmet is a no-op under React 19 (see PRINT_META above).
+  useEffect(() => {
+    const entries = setPrintMeta();
+    return () => cleanupPrintMeta(entries);
+  }, []);
+
   const sections = [];
 
   // Check if formData has values
@@ -189,11 +227,11 @@ export const Print = () => {
           <FontAwesomeIcon icon={faPrint} /> Print
         </Button>
       </div>
-      {/* The document <title> is set centrally in PageTitle.jsx (WCAG 2.4.2). */}
-      <Helmet>
-        <meta name="author" content="CMS" />
-        <meta name="subject" content="Annual CARTS Report" />
-      </Helmet>
+      {/*
+        The document <title> is set centrally in PageTitle.jsx and the
+        author/subject <meta> tags are set via effect above (WCAG 2.4.2;
+        react-helmet does not apply either under React 19).
+      */}
       <Main className="main">{sections}</Main>
       <Button
         className="ds-c-button--solid ds-c-button--large print-all-btn"

--- a/services/ui-src/src/components/sections/Print.jsx
+++ b/services/ui-src/src/components/sections/Print.jsx
@@ -13,36 +13,6 @@ import statesArray from "../utils/statesArray";
 import { loadEnrollmentCounts, loadSections } from "../../actions/initial";
 import { apiLib } from "../../util/apiLib";
 
-// <meta> tags carried into the generated PDF. Set directly on mount and removed
-// on unmount because react-helmet's side effects don't apply under React 19.
-const PRINT_META = [
-  { name: "author", content: "CMS" },
-  { name: "subject", content: "Annual CARTS Report" },
-];
-
-const setPrintMeta = () =>
-  PRINT_META.map(({ name, content }) => {
-    let el = document.head.querySelector(`meta[name="${name}"]`);
-    const created = !el;
-    if (!el) {
-      el = document.createElement("meta");
-      el.setAttribute("name", name);
-      document.head.append(el);
-    }
-    const prevContent = el.getAttribute("content");
-    el.setAttribute("content", content);
-    return { el, created, prevContent };
-  });
-
-const cleanupPrintMeta = (entries) =>
-  entries.forEach(({ el, created, prevContent }) => {
-    if (created) {
-      el.remove();
-    } else if (prevContent !== null) {
-      el.setAttribute("content", prevContent);
-    }
-  });
-
 const openPdf = (basePdf) => {
   const byteCharacters = atob(basePdf);
   let byteNumbers = Array.from({ length: byteCharacters.length });
@@ -156,11 +126,6 @@ export const Print = () => {
     }
   }, [currentUser]);
 
-  useEffect(() => {
-    const entries = setPrintMeta();
-    return () => cleanupPrintMeta(entries);
-  }, []);
-
   const sections = [];
 
   // Check if formData has values
@@ -213,6 +178,9 @@ export const Print = () => {
   // Return sections with wrapper div and print dialogue box
   return (
     <div className="print-all">
+      {/* React 19 hoists these into <head>; carried into the generated PDF. */}
+      <meta name="author" content="CMS" />
+      <meta name="subject" content="Annual CARTS Report" />
       <div className="print-directions">
         <p>Click below to print full CARTS report shown here</p>
         <Button

--- a/services/ui-src/src/components/utils/PageTitle.jsx
+++ b/services/ui-src/src/components/utils/PageTitle.jsx
@@ -4,8 +4,7 @@ import { shallowEqual, useSelector } from "react-redux";
 import { useUser } from "../../hooks/authHooks";
 import { getPageTitle } from "../../util/pageTitles";
 
-// Sets document.title for every route (WCAG 2.4.2). Mounted once near the app
-// root; forwards raw location/user/Redux values to the resolver in pageTitles.js.
+// Sets document.title for every route. Mounted once near the app root
 export const PageTitle = () => {
   const { pathname, search } = useLocation();
   const { user } = useUser();
@@ -29,7 +28,7 @@ export const PageTitle = () => {
     globalStateName,
     formYear,
   });
-  
+
   useEffect(() => {
     document.title = title;
   }, [title]);

--- a/services/ui-src/src/components/utils/PageTitle.jsx
+++ b/services/ui-src/src/components/utils/PageTitle.jsx
@@ -29,8 +29,7 @@ export const PageTitle = () => {
     globalStateName,
     formYear,
   });
-
-  // Set directly: react-helmet's side effects don't apply titles under React 19.
+  
   useEffect(() => {
     document.title = title;
   }, [title]);

--- a/services/ui-src/src/components/utils/PageTitle.jsx
+++ b/services/ui-src/src/components/utils/PageTitle.jsx
@@ -2,16 +2,16 @@ import { useEffect } from "react";
 import { useLocation } from "react-router";
 import { shallowEqual, useSelector } from "react-redux";
 import { useUser } from "../../hooks/authHooks";
-import statesArray from "./statesArray";
 import { getPageTitle } from "../../util/pageTitles";
-
-const stateNameFromAbbr = (abbr) =>
-  statesArray.find(({ value }) => value === abbr)?.label;
 
 /**
  * Sets a unique, descriptive document.title for every route (WCAG 2.4.2).
  * Rendered once near the app root; reads the current location and Redux
  * form data so section titles stay in sync with the underlying JSON.
+ *
+ * This component only forwards raw location/user/Redux values — all routing
+ * and title logic (including which state name to show) lives in the pure
+ * resolver in util/pageTitles.js.
  *
  * Note: we set document.title directly in an effect rather than via
  * react-helmet, whose side-effect mechanism does not apply titles under
@@ -31,23 +31,13 @@ export const PageTitle = () => {
     shallowEqual
   );
 
-  // Resolve the full state name used in form/print titles. State users get
-  // their own state; admins viewing another state get it from the URL.
-  let stateName = stateUserName;
-  if (pathname.startsWith("/views/sections/")) {
-    const abbr = pathname.split("/")[3];
-    stateName = globalStateName || stateNameFromAbbr(abbr) || stateUserName;
-  } else if (pathname === "/print") {
-    const stateParam = new URLSearchParams(search).get("state");
-    stateName = stateUserName || stateNameFromAbbr(stateParam) || "";
-  }
-
   const title = getPageTitle({
     pathname,
     search,
     hasUser: Boolean(user),
     formData,
-    stateName,
+    stateUserName,
+    globalStateName,
     formYear,
   });
 

--- a/services/ui-src/src/components/utils/PageTitle.jsx
+++ b/services/ui-src/src/components/utils/PageTitle.jsx
@@ -1,0 +1,61 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router";
+import { shallowEqual, useSelector } from "react-redux";
+import { useUser } from "../../hooks/authHooks";
+import statesArray from "./statesArray";
+import { getPageTitle } from "../../util/pageTitles";
+
+const stateNameFromAbbr = (abbr) =>
+  statesArray.find(({ value }) => value === abbr)?.label;
+
+/**
+ * Sets a unique, descriptive document.title for every route (WCAG 2.4.2).
+ * Rendered once near the app root; reads the current location and Redux
+ * form data so section titles stay in sync with the underlying JSON.
+ *
+ * Note: we set document.title directly in an effect rather than via
+ * react-helmet, whose side-effect mechanism does not apply titles under
+ * React 19.
+ */
+export const PageTitle = () => {
+  const { pathname, search } = useLocation();
+  const { user } = useUser();
+
+  const { formData, stateUserName, globalStateName, formYear } = useSelector(
+    (state) => ({
+      formData: state.formData,
+      stateUserName: state.stateUser.name,
+      globalStateName: state.global.stateName,
+      formYear: state.global.formYear,
+    }),
+    shallowEqual
+  );
+
+  // Resolve the full state name used in form/print titles. State users get
+  // their own state; admins viewing another state get it from the URL.
+  let stateName = stateUserName;
+  if (pathname.startsWith("/views/sections/")) {
+    const abbr = pathname.split("/")[3];
+    stateName = globalStateName || stateNameFromAbbr(abbr) || stateUserName;
+  } else if (pathname === "/print") {
+    const stateParam = new URLSearchParams(search).get("state");
+    stateName = stateUserName || stateNameFromAbbr(stateParam) || "";
+  }
+
+  const title = getPageTitle({
+    pathname,
+    search,
+    hasUser: Boolean(user),
+    formData,
+    stateName,
+    formYear,
+  });
+
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
+
+  return null;
+};
+
+export default PageTitle;

--- a/services/ui-src/src/components/utils/PageTitle.jsx
+++ b/services/ui-src/src/components/utils/PageTitle.jsx
@@ -4,19 +4,8 @@ import { shallowEqual, useSelector } from "react-redux";
 import { useUser } from "../../hooks/authHooks";
 import { getPageTitle } from "../../util/pageTitles";
 
-/**
- * Sets a unique, descriptive document.title for every route (WCAG 2.4.2).
- * Rendered once near the app root; reads the current location and Redux
- * form data so section titles stay in sync with the underlying JSON.
- *
- * This component only forwards raw location/user/Redux values — all routing
- * and title logic (including which state name to show) lives in the pure
- * resolver in util/pageTitles.js.
- *
- * Note: we set document.title directly in an effect rather than via
- * react-helmet, whose side-effect mechanism does not apply titles under
- * React 19.
- */
+// Sets document.title for every route (WCAG 2.4.2). Mounted once near the app
+// root; forwards raw location/user/Redux values to the resolver in pageTitles.js.
 export const PageTitle = () => {
   const { pathname, search } = useLocation();
   const { user } = useUser();
@@ -41,6 +30,7 @@ export const PageTitle = () => {
     formYear,
   });
 
+  // Set directly: react-helmet's side effects don't apply titles under React 19.
   useEffect(() => {
     document.title = title;
   }, [title]);

--- a/services/ui-src/src/util/pageTitles.js
+++ b/services/ui-src/src/util/pageTitles.js
@@ -1,4 +1,3 @@
-// Resolves a unique, descriptive document title for every route (WCAG 2.4.2).
 import { matchRoutes } from "react-router";
 import { ROUTE_PATHS } from "./routePaths";
 import statesArray from "../components/utils/statesArray";
@@ -49,8 +48,7 @@ export const selectFormRouteTitle = (formData, ordinal, subsectionMarker) => {
   return section.title || null;
 };
 
-// "[lead –] [State] [Year] – CARTS". A null/empty lead (e.g. formData still
-// loading) drops out, leaving "[State] [Year] – CARTS".
+// "[lead –] [State] [Year] – CARTS".
 const stateYearTitle = (lead, params, context) =>
   appTitle(
     [lead, `${routeStateName(params, context)} ${params.year}`.trim()]
@@ -121,7 +119,7 @@ export const titleRoutes = [
   },
 ];
 
-// Resolve the document title for the current route from a context object
+// Resolve the document title for the current route
 export const getPageTitle = (context = {}) => {
   const { pathname = "/" } = context;
   const matches = matchRoutes(titleRoutes, { pathname }) || [];

--- a/services/ui-src/src/util/pageTitles.js
+++ b/services/ui-src/src/util/pageTitles.js
@@ -1,48 +1,28 @@
-/**
- * Centralized page-title resolution for WCAG 2.4.2 (Page Titled).
- *
- * Every route in the app resolves to a unique, descriptive document title.
- * Routes are matched with React Router's own `matchRoutes` against the shared
- * `ROUTE_PATHS` registry — the same path patterns the router uses — so titles
- * stay aligned with routing instead of re-parsing the pathname by hand.
- *
- * Section/subsection titles are driven from the form JSON (Redux `formData`)
- * so that title text stays in sync with the content that defines each section.
- */
+// Resolves a unique, descriptive document title for every route (WCAG 2.4.2).
+// Routes are matched with React Router's matchRoutes against the shared
+// ROUTE_PATHS registry; section titles come from the form JSON (Redux formData).
 import { matchRoutes } from "react-router";
 import { ROUTE_PATHS } from "./routePaths";
 import statesArray from "../components/utils/statesArray";
 
-const BASE = "CARTS";
+const APP_SUFFIX = "CARTS";
 // en dash with surrounding spaces, e.g. "User profile – CARTS"
-const SEP = " – ";
+const TITLE_SEPARATOR = " – ";
 
 const stateNameFromAbbr = (abbr) =>
   statesArray.find(({ value }) => value === abbr)?.label || "";
 
-/**
- * Resolve the full state name for form/print titles. State users get their own
- * state from Redux; admins viewing another state get it from the matched
- * `:state` route param (CARTS stores it as a two-letter abbr in the URL). This
- * reads matched route params rather than re-parsing the pathname, so it stays
- * aligned with the router.
- */
-const routeStateName = (params, ctx) =>
+// State name for form/print titles: admins viewing another state get it from the
+// matched :state param (a two-letter abbr); state users get their own from Redux.
+const routeStateName = (params, context) =>
   params.state
-    ? ctx.globalStateName ||
+    ? context.globalStateName ||
       stateNameFromAbbr(params.state) ||
-      ctx.stateUserName
-    : ctx.stateUserName || "";
+      context.stateUserName
+    : context.stateUserName || "";
 
-/**
- * Find the section/subsection title for a form route from the loaded formData.
- *
- * @param {Array} formData - Redux formData array (each entry has contents.section)
- * @param {number} ordinal - section ordinal parsed from the URL (e.g. 0, 1, 3)
- * @param {string} [subMarker] - subsection marker from the URL (e.g. "a")
- * @returns {string|null} the most specific title available, or null while loading
- */
-export const selectFormRouteTitle = (formData, ordinal, subMarker) => {
+// Most specific section/subsection title from formData, or null while loading.
+export const selectFormRouteTitle = (formData, ordinal, subsectionMarker) => {
   if (!Array.isArray(formData) || formData.length === 0) {
     return null;
   }
@@ -55,11 +35,10 @@ export const selectFormRouteTitle = (formData, ordinal, subMarker) => {
     return null;
   }
 
-  // Prefer the subsection title when the URL targets a specific subsection
-  // and that subsection actually has a title (sections 00-02, 04-06 have a
-  // single untitled subsection, so we fall back to the section title there).
-  if (subMarker) {
-    const marker = subMarker.toLowerCase();
+  // Untitled subsections (sections 00-02, 04-06 each have one) fall back to the
+  // section title.
+  if (subsectionMarker) {
+    const marker = subsectionMarker.toLowerCase();
     const subsection = (section.subsections || []).find(
       (sub) => typeof sub?.id === "string" && sub.id.split("-").pop() === marker
     );
@@ -72,59 +51,54 @@ export const selectFormRouteTitle = (formData, ordinal, subMarker) => {
 };
 
 // Title builder shared by every form/section route (state + admin views).
-// `params` come straight from React Router (year, sectionOrdinal, etc.).
-const formSectionTitle = (params, ctx) => {
-  const stateYear = `${routeStateName(params, ctx)} ${params.year}`.trim();
+const buildSectionTitle = (params, context) => {
+  const stateYear = `${routeStateName(params, context)} ${params.year}`.trim();
   const sectionTitle = selectFormRouteTitle(
-    ctx.formData,
+    context.formData,
     Number(params.sectionOrdinal),
     params.subsectionMarker
   );
 
-  // While formData is still loading we omit the (empty) section title rather
-  // than render a misleading one; the title updates once data arrives.
+  // Omit the section title while formData loads rather than render an empty one.
   return sectionTitle
-    ? `${sectionTitle}${SEP}${stateYear}${SEP}${BASE}`
-    : `${stateYear}${SEP}${BASE}`;
+    ? `${sectionTitle}${TITLE_SEPARATOR}${stateYear}${TITLE_SEPARATOR}${APP_SUFFIX}`
+    : `${stateYear}${TITLE_SEPARATOR}${APP_SUFFIX}`;
 };
 
-/**
- * Declarative route -> title table. Each `path` is a shared `ROUTE_PATHS`
- * pattern; each `title(params, ctx)` returns the document title for a match.
- * Exported so the drift-guard test can assert it covers every ROUTE_PATHS entry.
- */
+// Route -> title table. Each path is a ROUTE_PATHS pattern; each title(params,
+// context) returns the document title. The drift-guard test asserts this covers
+// every ROUTE_PATHS entry.
 export const titleRoutes = [
   {
     path: ROUTE_PATHS.home,
-    title: (_params, ctx) =>
-      ctx.hasUser
+    title: (_params, context) =>
+      context.hasUser
         ? "CHIP Annual Reporting Template System (CARTS)"
-        : `Login${SEP}${BASE}`,
+        : `Login${TITLE_SEPARATOR}${APP_SUFFIX}`,
   },
   {
     path: ROUTE_PATHS.userProfile,
-    title: () => `User profile${SEP}${BASE}`,
+    title: () => `User profile${TITLE_SEPARATOR}${APP_SUFFIX}`,
   },
   {
     path: ROUTE_PATHS.getHelp,
-    title: () => `How can we help you?${SEP}${BASE}`,
+    title: () => `How can we help you?${TITLE_SEPARATOR}${APP_SUFFIX}`,
   },
   {
     path: ROUTE_PATHS.templates,
-    title: () => `Generate form base templates${SEP}${BASE}`,
+    title: () => `Generate form base templates${TITLE_SEPARATOR}${APP_SUFFIX}`,
   },
   {
     path: ROUTE_PATHS.stateReports,
-    title: () => `State reports${SEP}${BASE}`,
+    title: () => `State reports${TITLE_SEPARATOR}${APP_SUFFIX}`,
   },
   {
-    // Print view: "[State] CARTS [Year] Report"
     path: ROUTE_PATHS.print,
-    title: (_params, ctx) => {
-      const query = new URLSearchParams(ctx.search);
+    title: (_params, context) => {
+      const query = new URLSearchParams(context.search);
       const stateName =
-        ctx.stateUserName || stateNameFromAbbr(query.get("state")) || "";
-      const year = query.get("year") || ctx.formYear;
+        context.stateUserName || stateNameFromAbbr(query.get("state")) || "";
+      const year = query.get("year") || context.formYear;
       return `${stateName} CARTS ${year || ""} Report`
         .replace(/\s+/g, " ")
         .trim();
@@ -132,55 +106,30 @@ export const titleRoutes = [
   },
   {
     path: ROUTE_PATHS.certifyAndSubmit,
-    title: (params, ctx) =>
-      `Certify and Submit${SEP}${`${routeStateName(params, ctx)} ${params.year}`.trim()}${SEP}${BASE}`,
+    title: (params, context) =>
+      `Certify and Submit${TITLE_SEPARATOR}${`${routeStateName(params, context)} ${params.year}`.trim()}${TITLE_SEPARATOR}${APP_SUFFIX}`,
   },
-  { path: ROUTE_PATHS.sectionSubsection, title: formSectionTitle },
-  { path: ROUTE_PATHS.section, title: formSectionTitle },
-  { path: ROUTE_PATHS.viewsSectionSubsection, title: formSectionTitle },
-  { path: ROUTE_PATHS.viewsSection, title: formSectionTitle },
+  { path: ROUTE_PATHS.sectionSubsection, title: buildSectionTitle },
+  { path: ROUTE_PATHS.section, title: buildSectionTitle },
+  { path: ROUTE_PATHS.viewsSectionSubsection, title: buildSectionTitle },
+  { path: ROUTE_PATHS.viewsSection, title: buildSectionTitle },
   {
     path: ROUTE_PATHS.notFound,
-    title: () => `Page not found${SEP}${BASE}`,
+    title: () => `Page not found${TITLE_SEPARATOR}${APP_SUFFIX}`,
   },
 ];
 
-/**
- * Resolve the document title for the current route.
- *
- * @param {object} ctx
- * @param {string} ctx.pathname - location.pathname
- * @param {string} [ctx.search] - location.search (for /print)
- * @param {boolean} ctx.hasUser - whether a user is authenticated
- * @param {Array} [ctx.formData] - Redux formData (drives section titles)
- * @param {string} [ctx.stateUserName] - the signed-in state user's state name
- * @param {string} [ctx.globalStateName] - state name for admin `/views/...` routes
- * @param {(string|number)} [ctx.formYear] - report year for form/print titles
- * @returns {string} the document title
- */
-export const getPageTitle = ({
-  pathname = "/",
-  search = "",
-  hasUser = false,
-  formData = [],
-  stateUserName = "",
-  globalStateName = "",
-  formYear = "",
-} = {}) => {
+// Resolve the document title for the current route from a context object
+// (pathname, search, hasUser, formData, stateUserName, globalStateName, formYear).
+export const getPageTitle = (context = {}) => {
+  const { pathname = "/" } = context;
   const matches = matchRoutes(titleRoutes, { pathname }) || [];
   const match = matches[matches.length - 1];
 
   // The catch-all "*" route guarantees a match, but stay defensive.
   if (!match) {
-    return `Page not found${SEP}${BASE}`;
+    return `Page not found${TITLE_SEPARATOR}${APP_SUFFIX}`;
   }
 
-  return match.route.title(match.params, {
-    search,
-    hasUser,
-    formData,
-    stateUserName,
-    globalStateName,
-    formYear,
-  });
+  return match.route.title(match.params, context);
 };

--- a/services/ui-src/src/util/pageTitles.js
+++ b/services/ui-src/src/util/pageTitles.js
@@ -2,9 +2,15 @@
  * Centralized page-title resolution for WCAG 2.4.2 (Page Titled).
  *
  * Every route in the app resolves to a unique, descriptive document title.
+ * Routes are matched with React Router's own `matchRoutes` against the shared
+ * `ROUTE_PATHS` registry — the same path patterns the router uses — so titles
+ * stay aligned with routing instead of re-parsing the pathname by hand.
+ *
  * Section/subsection titles are driven from the form JSON (Redux `formData`)
  * so that title text stays in sync with the content that defines each section.
  */
+import { matchRoutes } from "react-router";
+import { ROUTE_PATHS } from "./routePaths";
 
 const BASE = "CARTS";
 // en dash with surrounding spaces, e.g. "User profile – CARTS"
@@ -47,6 +53,77 @@ export const selectFormRouteTitle = (formData, ordinal, subMarker) => {
   return section.title || null;
 };
 
+// Title builder shared by every form/section route (state + admin views).
+// `params` come straight from React Router (year, sectionOrdinal, etc.).
+const formSectionTitle = (params, ctx) => {
+  const stateYear = `${ctx.stateName} ${params.year}`.trim();
+  const sectionTitle = selectFormRouteTitle(
+    ctx.formData,
+    Number(params.sectionOrdinal),
+    params.subsectionMarker
+  );
+
+  // While formData is still loading we omit the (empty) section title rather
+  // than render a misleading one; the title updates once data arrives.
+  return sectionTitle
+    ? `${sectionTitle}${SEP}${stateYear}${SEP}${BASE}`
+    : `${stateYear}${SEP}${BASE}`;
+};
+
+/**
+ * Declarative route -> title table. Each `path` is a shared `ROUTE_PATHS`
+ * pattern; each `title(params, ctx)` returns the document title for a match.
+ * Exported so the drift-guard test can assert it covers every ROUTE_PATHS entry.
+ */
+export const titleRoutes = [
+  {
+    path: ROUTE_PATHS.home,
+    title: (_params, ctx) =>
+      ctx.hasUser
+        ? "CHIP Annual Reporting Template System (CARTS)"
+        : `Login${SEP}${BASE}`,
+  },
+  {
+    path: ROUTE_PATHS.userProfile,
+    title: () => `User profile${SEP}${BASE}`,
+  },
+  {
+    path: ROUTE_PATHS.getHelp,
+    title: () => `How can we help you?${SEP}${BASE}`,
+  },
+  {
+    path: ROUTE_PATHS.templates,
+    title: () => `Generate form base templates${SEP}${BASE}`,
+  },
+  {
+    path: ROUTE_PATHS.stateReports,
+    title: () => `State reports${SEP}${BASE}`,
+  },
+  {
+    // Print view: "[State] CARTS [Year] Report"
+    path: ROUTE_PATHS.print,
+    title: (_params, ctx) => {
+      const year = new URLSearchParams(ctx.search).get("year") || ctx.formYear;
+      return `${ctx.stateName} CARTS ${year || ""} Report`
+        .replace(/\s+/g, " ")
+        .trim();
+    },
+  },
+  {
+    path: ROUTE_PATHS.certifyAndSubmit,
+    title: (params, ctx) =>
+      `Certify and Submit${SEP}${`${ctx.stateName} ${params.year}`.trim()}${SEP}${BASE}`,
+  },
+  { path: ROUTE_PATHS.sectionSubsection, title: formSectionTitle },
+  { path: ROUTE_PATHS.section, title: formSectionTitle },
+  { path: ROUTE_PATHS.viewsSectionSubsection, title: formSectionTitle },
+  { path: ROUTE_PATHS.viewsSection, title: formSectionTitle },
+  {
+    path: ROUTE_PATHS.notFound,
+    title: () => `Page not found${SEP}${BASE}`,
+  },
+];
+
 /**
  * Resolve the document title for the current route.
  *
@@ -67,67 +144,19 @@ export const getPageTitle = ({
   stateName = "",
   formYear = "",
 } = {}) => {
-  const segments = pathname.split("/").filter(Boolean);
+  const matches = matchRoutes(titleRoutes, { pathname }) || [];
+  const match = matches[matches.length - 1];
 
-  // Home / login
-  if (pathname === "/") {
-    return hasUser
-      ? "CHIP Annual Reporting Template System (CARTS)"
-      : `Login${SEP}${BASE}`;
+  // The catch-all "*" route guarantees a match, but stay defensive.
+  if (!match) {
+    return `Page not found${SEP}${BASE}`;
   }
 
-  // Static authenticated pages
-  if (pathname === "/user/profile") {
-    return `User profile${SEP}${BASE}`;
-  }
-  if (pathname === "/get-help") {
-    return `How can we help you?${SEP}${BASE}`;
-  }
-  if (pathname === "/templates") {
-    return `Generate form base templates${SEP}${BASE}`;
-  }
-  if (pathname === "/state-reports") {
-    return `State reports${SEP}${BASE}`;
-  }
-
-  // Print view: "[State] CARTS [Year] Report"
-  if (pathname === "/print") {
-    const year = new URLSearchParams(search).get("year") || formYear || "";
-    return `${stateName} CARTS ${year} Report`.replace(/\s+/g, " ").trim();
-  }
-
-  // Form section routes (state users) and admin "views" routes
-  let formTokens = null;
-  if (segments[0] === "sections") {
-    // /sections/:year/:sectionOrdinal(/:subsectionMarker)
-    formTokens = segments.slice(1);
-  } else if (segments[0] === "views" && segments[1] === "sections") {
-    // /views/sections/:state/:year/:sectionOrdinal(/:subsectionMarker)
-    formTokens = segments.slice(3);
-  }
-
-  if (formTokens) {
-    const [year, sectionToken, subMarker] = formTokens;
-    const stateYear = `${stateName} ${year}`.trim();
-
-    if (sectionToken === "certify-and-submit") {
-      return `Certify and Submit${SEP}${stateYear}${SEP}${BASE}`;
-    }
-
-    const sectionTitle = selectFormRouteTitle(
-      formData,
-      Number(sectionToken),
-      subMarker
-    );
-
-    // While formData is still loading we omit the (empty) section title rather
-    // than render a misleading one; the title updates once data arrives.
-    if (sectionTitle) {
-      return `${sectionTitle}${SEP}${stateYear}${SEP}${BASE}`;
-    }
-    return `${stateYear}${SEP}${BASE}`;
-  }
-
-  // Catch-all 404
-  return `Page not found${SEP}${BASE}`;
+  return match.route.title(match.params, {
+    search,
+    hasUser,
+    formData,
+    stateName,
+    formYear,
+  });
 };

--- a/services/ui-src/src/util/pageTitles.js
+++ b/services/ui-src/src/util/pageTitles.js
@@ -102,7 +102,7 @@ export const titleRoutes = [
         context.stateUserName || stateNameFromAbbr(query.get("state")) || "";
       const year = query.get("year") || context.formYear;
       return `${stateName} CARTS ${year || ""} Report`
-        .replace(/\s+/g, " ")
+        .replace(/\s+/, " ")
         .trim();
     },
   },
@@ -125,7 +125,7 @@ export const titleRoutes = [
 export const getPageTitle = (context = {}) => {
   const { pathname = "/" } = context;
   const matches = matchRoutes(titleRoutes, { pathname }) || [];
-  const match = matches[matches.length - 1];
+  const match = matches.at(-1);
 
   if (!match) {
     return appTitle("Page not found");

--- a/services/ui-src/src/util/pageTitles.js
+++ b/services/ui-src/src/util/pageTitles.js
@@ -1,0 +1,133 @@
+/**
+ * Centralized page-title resolution for WCAG 2.4.2 (Page Titled).
+ *
+ * Every route in the app resolves to a unique, descriptive document title.
+ * Section/subsection titles are driven from the form JSON (Redux `formData`)
+ * so that title text stays in sync with the content that defines each section.
+ */
+
+const BASE = "CARTS";
+// en dash with surrounding spaces, e.g. "User profile – CARTS"
+const SEP = " – ";
+
+/**
+ * Find the section/subsection title for a form route from the loaded formData.
+ *
+ * @param {Array} formData - Redux formData array (each entry has contents.section)
+ * @param {number} ordinal - section ordinal parsed from the URL (e.g. 0, 1, 3)
+ * @param {string} [subMarker] - subsection marker from the URL (e.g. "a")
+ * @returns {string|null} the most specific title available, or null while loading
+ */
+export const selectFormRouteTitle = (formData, ordinal, subMarker) => {
+  if (!Array.isArray(formData) || formData.length === 0) {
+    return null;
+  }
+
+  const entry = formData.find(
+    (item) => item?.contents?.section?.ordinal === ordinal
+  );
+  const section = entry?.contents?.section;
+  if (!section) {
+    return null;
+  }
+
+  // Prefer the subsection title when the URL targets a specific subsection
+  // and that subsection actually has a title (sections 00-02, 04-06 have a
+  // single untitled subsection, so we fall back to the section title there).
+  if (subMarker) {
+    const marker = subMarker.toLowerCase();
+    const subsection = (section.subsections || []).find(
+      (sub) => typeof sub?.id === "string" && sub.id.split("-").pop() === marker
+    );
+    if (subsection?.title) {
+      return subsection.title;
+    }
+  }
+
+  return section.title || null;
+};
+
+/**
+ * Resolve the document title for the current route.
+ *
+ * @param {object} ctx
+ * @param {string} ctx.pathname - location.pathname
+ * @param {string} [ctx.search] - location.search (for /print)
+ * @param {boolean} ctx.hasUser - whether a user is authenticated
+ * @param {Array} [ctx.formData] - Redux formData (drives section titles)
+ * @param {string} [ctx.stateName] - resolved full state name (e.g. "New York")
+ * @param {(string|number)} [ctx.formYear] - report year for form/print titles
+ * @returns {string} the document title
+ */
+export const getPageTitle = ({
+  pathname = "/",
+  search = "",
+  hasUser = false,
+  formData = [],
+  stateName = "",
+  formYear = "",
+} = {}) => {
+  const segments = pathname.split("/").filter(Boolean);
+
+  // Home / login
+  if (pathname === "/") {
+    return hasUser
+      ? "CHIP Annual Reporting Template System (CARTS)"
+      : `Login${SEP}${BASE}`;
+  }
+
+  // Static authenticated pages
+  if (pathname === "/user/profile") {
+    return `User profile${SEP}${BASE}`;
+  }
+  if (pathname === "/get-help") {
+    return `How can we help you?${SEP}${BASE}`;
+  }
+  if (pathname === "/templates") {
+    return `Generate form base templates${SEP}${BASE}`;
+  }
+  if (pathname === "/state-reports") {
+    return `State reports${SEP}${BASE}`;
+  }
+
+  // Print view: "[State] CARTS [Year] Report"
+  if (pathname === "/print") {
+    const year = new URLSearchParams(search).get("year") || formYear || "";
+    return `${stateName} CARTS ${year} Report`.replace(/\s+/g, " ").trim();
+  }
+
+  // Form section routes (state users) and admin "views" routes
+  let formTokens = null;
+  if (segments[0] === "sections") {
+    // /sections/:year/:sectionOrdinal(/:subsectionMarker)
+    formTokens = segments.slice(1);
+  } else if (segments[0] === "views" && segments[1] === "sections") {
+    // /views/sections/:state/:year/:sectionOrdinal(/:subsectionMarker)
+    formTokens = segments.slice(3);
+  }
+
+  if (formTokens) {
+    const [year, sectionToken, subMarker] = formTokens;
+    const stateYear = `${stateName} ${year}`.trim();
+
+    if (sectionToken === "certify-and-submit") {
+      return `Certify and Submit${SEP}${stateYear}${SEP}${BASE}`;
+    }
+
+    const sectionTitle = selectFormRouteTitle(
+      formData,
+      Number(sectionToken),
+      subMarker
+    );
+
+    // While formData is still loading we omit the (empty) section title rather
+    // than render a misleading one; the title updates once data arrives.
+    if (sectionTitle) {
+      return `${sectionTitle}${SEP}${stateYear}${SEP}${BASE}`;
+    }
+    return `${stateYear}${SEP}${BASE}`;
+  }
+
+  // Catch-all 404
+  return `Page not found${SEP}${BASE}`;
+};

--- a/services/ui-src/src/util/pageTitles.js
+++ b/services/ui-src/src/util/pageTitles.js
@@ -6,11 +6,13 @@ import statesArray from "../components/utils/statesArray";
 const APP_SUFFIX = "CARTS";
 const TITLE_SEPARATOR = " – ";
 
+const appTitle = (text) => `${text}${TITLE_SEPARATOR}${APP_SUFFIX}`;
+
 const stateNameFromAbbr = (abbr) =>
   statesArray.find(({ value }) => value === abbr)?.label || "";
 
 // State name for form/print titles: admins viewing another state get it from the
-// matched :state param. State users get their own from Redux.
+// matched :state param. State users get their own from the store.
 const routeStateName = (params, context) =>
   params.state
     ? context.globalStateName ||
@@ -47,19 +49,26 @@ export const selectFormRouteTitle = (formData, ordinal, subsectionMarker) => {
   return section.title || null;
 };
 
-// Title builder shared by every form/section route (state + admin views).
-const buildSectionTitle = (params, context) => {
-  const stateYear = `${routeStateName(params, context)} ${params.year}`.trim();
-  const sectionTitle = selectFormRouteTitle(
-    context.formData,
-    Number(params.sectionOrdinal),
-    params.subsectionMarker
+// "[lead –] [State] [Year] – CARTS". A null/empty lead (e.g. formData still
+// loading) drops out, leaving "[State] [Year] – CARTS".
+const stateYearTitle = (lead, params, context) =>
+  appTitle(
+    [lead, `${routeStateName(params, context)} ${params.year}`.trim()]
+      .filter(Boolean)
+      .join(TITLE_SEPARATOR)
   );
 
-  return sectionTitle
-    ? `${sectionTitle}${TITLE_SEPARATOR}${stateYear}${TITLE_SEPARATOR}${APP_SUFFIX}`
-    : `${stateYear}${TITLE_SEPARATOR}${APP_SUFFIX}`;
-};
+// Title builder shared by every form/section route (state + admin views).
+const buildSectionTitle = (params, context) =>
+  stateYearTitle(
+    selectFormRouteTitle(
+      context.formData,
+      Number(params.sectionOrdinal),
+      params.subsectionMarker
+    ),
+    params,
+    context
+  );
 
 export const titleRoutes = [
   {
@@ -67,23 +76,23 @@ export const titleRoutes = [
     title: (_params, context) =>
       context.hasUser
         ? "CHIP Annual Reporting Template System (CARTS)"
-        : `Login${TITLE_SEPARATOR}${APP_SUFFIX}`,
+        : appTitle("Login"),
   },
   {
     path: ROUTE_PATHS.userProfile,
-    title: () => `User profile${TITLE_SEPARATOR}${APP_SUFFIX}`,
+    title: () => appTitle("User profile"),
   },
   {
     path: ROUTE_PATHS.getHelp,
-    title: () => `How can we help you?${TITLE_SEPARATOR}${APP_SUFFIX}`,
+    title: () => appTitle("How can we help you?"),
   },
   {
     path: ROUTE_PATHS.templates,
-    title: () => `Generate form base templates${TITLE_SEPARATOR}${APP_SUFFIX}`,
+    title: () => appTitle("Generate form base templates"),
   },
   {
     path: ROUTE_PATHS.stateReports,
-    title: () => `State reports${TITLE_SEPARATOR}${APP_SUFFIX}`,
+    title: () => appTitle("State reports"),
   },
   {
     path: ROUTE_PATHS.print,
@@ -100,7 +109,7 @@ export const titleRoutes = [
   {
     path: ROUTE_PATHS.certifyAndSubmit,
     title: (params, context) =>
-      `Certify and Submit${TITLE_SEPARATOR}${`${routeStateName(params, context)} ${params.year}`.trim()}${TITLE_SEPARATOR}${APP_SUFFIX}`,
+      stateYearTitle("Certify and Submit", params, context),
   },
   { path: ROUTE_PATHS.sectionSubsection, title: buildSectionTitle },
   { path: ROUTE_PATHS.section, title: buildSectionTitle },
@@ -108,7 +117,7 @@ export const titleRoutes = [
   { path: ROUTE_PATHS.viewsSection, title: buildSectionTitle },
   {
     path: ROUTE_PATHS.notFound,
-    title: () => `Page not found${TITLE_SEPARATOR}${APP_SUFFIX}`,
+    title: () => appTitle("Page not found"),
   },
 ];
 
@@ -119,7 +128,7 @@ export const getPageTitle = (context = {}) => {
   const match = matches[matches.length - 1];
 
   if (!match) {
-    return `Page not found${TITLE_SEPARATOR}${APP_SUFFIX}`;
+    return appTitle("Page not found");
   }
 
   return match.route.title(match.params, context);

--- a/services/ui-src/src/util/pageTitles.js
+++ b/services/ui-src/src/util/pageTitles.js
@@ -11,10 +11,28 @@
  */
 import { matchRoutes } from "react-router";
 import { ROUTE_PATHS } from "./routePaths";
+import statesArray from "../components/utils/statesArray";
 
 const BASE = "CARTS";
 // en dash with surrounding spaces, e.g. "User profile – CARTS"
 const SEP = " – ";
+
+const stateNameFromAbbr = (abbr) =>
+  statesArray.find(({ value }) => value === abbr)?.label || "";
+
+/**
+ * Resolve the full state name for form/print titles. State users get their own
+ * state from Redux; admins viewing another state get it from the matched
+ * `:state` route param (CARTS stores it as a two-letter abbr in the URL). This
+ * reads matched route params rather than re-parsing the pathname, so it stays
+ * aligned with the router.
+ */
+const routeStateName = (params, ctx) =>
+  params.state
+    ? ctx.globalStateName ||
+      stateNameFromAbbr(params.state) ||
+      ctx.stateUserName
+    : ctx.stateUserName || "";
 
 /**
  * Find the section/subsection title for a form route from the loaded formData.
@@ -56,7 +74,7 @@ export const selectFormRouteTitle = (formData, ordinal, subMarker) => {
 // Title builder shared by every form/section route (state + admin views).
 // `params` come straight from React Router (year, sectionOrdinal, etc.).
 const formSectionTitle = (params, ctx) => {
-  const stateYear = `${ctx.stateName} ${params.year}`.trim();
+  const stateYear = `${routeStateName(params, ctx)} ${params.year}`.trim();
   const sectionTitle = selectFormRouteTitle(
     ctx.formData,
     Number(params.sectionOrdinal),
@@ -103,8 +121,11 @@ export const titleRoutes = [
     // Print view: "[State] CARTS [Year] Report"
     path: ROUTE_PATHS.print,
     title: (_params, ctx) => {
-      const year = new URLSearchParams(ctx.search).get("year") || ctx.formYear;
-      return `${ctx.stateName} CARTS ${year || ""} Report`
+      const query = new URLSearchParams(ctx.search);
+      const stateName =
+        ctx.stateUserName || stateNameFromAbbr(query.get("state")) || "";
+      const year = query.get("year") || ctx.formYear;
+      return `${stateName} CARTS ${year || ""} Report`
         .replace(/\s+/g, " ")
         .trim();
     },
@@ -112,7 +133,7 @@ export const titleRoutes = [
   {
     path: ROUTE_PATHS.certifyAndSubmit,
     title: (params, ctx) =>
-      `Certify and Submit${SEP}${`${ctx.stateName} ${params.year}`.trim()}${SEP}${BASE}`,
+      `Certify and Submit${SEP}${`${routeStateName(params, ctx)} ${params.year}`.trim()}${SEP}${BASE}`,
   },
   { path: ROUTE_PATHS.sectionSubsection, title: formSectionTitle },
   { path: ROUTE_PATHS.section, title: formSectionTitle },
@@ -132,7 +153,8 @@ export const titleRoutes = [
  * @param {string} [ctx.search] - location.search (for /print)
  * @param {boolean} ctx.hasUser - whether a user is authenticated
  * @param {Array} [ctx.formData] - Redux formData (drives section titles)
- * @param {string} [ctx.stateName] - resolved full state name (e.g. "New York")
+ * @param {string} [ctx.stateUserName] - the signed-in state user's state name
+ * @param {string} [ctx.globalStateName] - state name for admin `/views/...` routes
  * @param {(string|number)} [ctx.formYear] - report year for form/print titles
  * @returns {string} the document title
  */
@@ -141,7 +163,8 @@ export const getPageTitle = ({
   search = "",
   hasUser = false,
   formData = [],
-  stateName = "",
+  stateUserName = "",
+  globalStateName = "",
   formYear = "",
 } = {}) => {
   const matches = matchRoutes(titleRoutes, { pathname }) || [];
@@ -156,7 +179,8 @@ export const getPageTitle = ({
     search,
     hasUser,
     formData,
-    stateName,
+    stateUserName,
+    globalStateName,
     formYear,
   });
 };

--- a/services/ui-src/src/util/pageTitles.js
+++ b/services/ui-src/src/util/pageTitles.js
@@ -1,19 +1,16 @@
 // Resolves a unique, descriptive document title for every route (WCAG 2.4.2).
-// Routes are matched with React Router's matchRoutes against the shared
-// ROUTE_PATHS registry; section titles come from the form JSON (Redux formData).
 import { matchRoutes } from "react-router";
 import { ROUTE_PATHS } from "./routePaths";
 import statesArray from "../components/utils/statesArray";
 
 const APP_SUFFIX = "CARTS";
-// en dash with surrounding spaces, e.g. "User profile – CARTS"
 const TITLE_SEPARATOR = " – ";
 
 const stateNameFromAbbr = (abbr) =>
   statesArray.find(({ value }) => value === abbr)?.label || "";
 
 // State name for form/print titles: admins viewing another state get it from the
-// matched :state param (a two-letter abbr); state users get their own from Redux.
+// matched :state param. State users get their own from Redux.
 const routeStateName = (params, context) =>
   params.state
     ? context.globalStateName ||
@@ -59,15 +56,11 @@ const buildSectionTitle = (params, context) => {
     params.subsectionMarker
   );
 
-  // Omit the section title while formData loads rather than render an empty one.
   return sectionTitle
     ? `${sectionTitle}${TITLE_SEPARATOR}${stateYear}${TITLE_SEPARATOR}${APP_SUFFIX}`
     : `${stateYear}${TITLE_SEPARATOR}${APP_SUFFIX}`;
 };
 
-// Route -> title table. Each path is a ROUTE_PATHS pattern; each title(params,
-// context) returns the document title. The drift-guard test asserts this covers
-// every ROUTE_PATHS entry.
 export const titleRoutes = [
   {
     path: ROUTE_PATHS.home,
@@ -120,13 +113,11 @@ export const titleRoutes = [
 ];
 
 // Resolve the document title for the current route from a context object
-// (pathname, search, hasUser, formData, stateUserName, globalStateName, formYear).
 export const getPageTitle = (context = {}) => {
   const { pathname = "/" } = context;
   const matches = matchRoutes(titleRoutes, { pathname }) || [];
   const match = matches[matches.length - 1];
 
-  // The catch-all "*" route guarantees a match, but stay defensive.
   if (!match) {
     return `Page not found${TITLE_SEPARATOR}${APP_SUFFIX}`;
   }

--- a/services/ui-src/src/util/pageTitles.test.js
+++ b/services/ui-src/src/util/pageTitles.test.js
@@ -43,7 +43,7 @@ const titleFor = (pathname, overrides = {}) =>
     pathname,
     hasUser: true,
     formData,
-    stateName: "New York",
+    stateUserName: "New York",
     formYear: 2024,
     ...overrides,
   });
@@ -81,15 +81,25 @@ describe("getPageTitle() - static routes", () => {
     expect(titleFor("/state-reports")).toBe("State reports – CARTS");
   });
 
-  test("print view", () => {
+  test("print view (state user)", () => {
     expect(
       getPageTitle({
         pathname: "/print",
         search: "?year=2024&state=NY",
         hasUser: true,
-        stateName: "New York",
+        stateUserName: "New York",
       })
     ).toBe("New York CARTS 2024 Report");
+  });
+
+  test("print view derives state from the ?state= abbr when no state user", () => {
+    expect(
+      getPageTitle({
+        pathname: "/print",
+        search: "?year=2024&state=CA",
+        hasUser: true,
+      })
+    ).toBe("California CARTS 2024 Report");
   });
 });
 
@@ -134,13 +144,38 @@ describe("getPageTitle() - form section routes (driven by JSON)", () => {
     );
   });
 
+  test("admin /views route derives the state name from the URL abbr", () => {
+    // No state user; the admin is viewing California's report. The state name
+    // must come from the :state route param, not from stateUserName.
+    expect(
+      getPageTitle({
+        pathname: "/views/sections/CA/2024/03/a",
+        hasUser: true,
+        formData,
+        formYear: 2024,
+      })
+    ).toBe("Program Outreach – California 2024 – CARTS");
+  });
+
+  test("admin /views route prefers globalStateName when set", () => {
+    expect(
+      getPageTitle({
+        pathname: "/views/sections/CA/2024/03/a",
+        hasUser: true,
+        formData,
+        globalStateName: "California",
+        formYear: 2024,
+      })
+    ).toBe("Program Outreach – California 2024 – CARTS");
+  });
+
   test("falls back to state + year while formData is still loading", () => {
     expect(
       getPageTitle({
         pathname: "/sections/2024/01",
         hasUser: true,
         formData: [],
-        stateName: "New York",
+        stateUserName: "New York",
       })
     ).toBe("New York 2024 – CARTS");
   });

--- a/services/ui-src/src/util/pageTitles.test.js
+++ b/services/ui-src/src/util/pageTitles.test.js
@@ -1,8 +1,6 @@
 import { getPageTitle, selectFormRouteTitle, titleRoutes } from "./pageTitles";
 import { ROUTE_PATHS } from "./routePaths";
 
-// Minimal formData mirroring the 2024 section JSON (only fields the
-// resolver reads: section ordinal/title and subsection id/title).
 const section = (ordinal, title, subsections = []) => ({
   contents: { section: { ordinal, title, subsections } },
 });
@@ -145,8 +143,6 @@ describe("getPageTitle() - form section routes (driven by JSON)", () => {
   });
 
   test("admin /views route derives the state name from the URL abbr", () => {
-    // No state user; the admin is viewing California's report. The state name
-    // must come from the :state route param, not from stateUserName.
     expect(
       getPageTitle({
         pathname: "/views/sections/CA/2024/03/a",
@@ -200,9 +196,9 @@ describe("selectFormRouteTitle()", () => {
 });
 
 describe("title/route registry stays in sync", () => {
-  // Guards against drift: if a route is added to ROUTE_PATHS (and therefore the
-  // router) without a matching title entry — or vice versa — this fails, so a
-  // new route can't silently fall through to "Page not found".
+  // This test helps guard against drift: if a route is added to ROUTE_PATHS 
+  // (and therefore the router) without a matching title entry this fails, 
+  // so a new route can't silently fall through to "Page not found".
   test("every ROUTE_PATHS pattern has exactly one title entry and vice versa", () => {
     const declared = Object.values(ROUTE_PATHS).sort();
     const titled = titleRoutes.map((route) => route.path).sort();

--- a/services/ui-src/src/util/pageTitles.test.js
+++ b/services/ui-src/src/util/pageTitles.test.js
@@ -178,8 +178,8 @@ describe("title/route registry stays in sync", () => {
   // (and therefore the router) without a matching title entry this fails,
   // so a new route can't silently fall through to "Page not found".
   test("every ROUTE_PATHS pattern has exactly one title entry and vice versa", () => {
-    const declared = Object.values(ROUTE_PATHS).sort();
-    const titled = titleRoutes.map((route) => route.path).sort();
+    const declared = Object.values(ROUTE_PATHS).toSorted();
+    const titled = titleRoutes.map((route) => route.path).toSorted();
     expect(titled).toEqual(declared);
   });
 });

--- a/services/ui-src/src/util/pageTitles.test.js
+++ b/services/ui-src/src/util/pageTitles.test.js
@@ -1,0 +1,164 @@
+import { getPageTitle, selectFormRouteTitle } from "./pageTitles";
+
+// Minimal formData mirroring the 2024 section JSON (only fields the
+// resolver reads: section ordinal/title and subsection id/title).
+const section = (ordinal, title, subsections = []) => ({
+  contents: { section: { ordinal, title, subsections } },
+});
+
+const formData = [
+  section(0, "Basic State Information", [{ id: "2024-00-a", title: null }]),
+  section(1, "Program Fees and Policy Changes", [
+    { id: "2024-01-a", title: null },
+  ]),
+  section(2, "Enrollment and Uninsured Data", [
+    { id: "2024-02-a", title: null },
+  ]),
+  section(3, "Eligibility, Enrollment, and Operations", [
+    { id: "2024-03-a", title: "Program Outreach" },
+    { id: "2024-03-b", title: "Substitution of Coverage" },
+    { id: "2024-03-c", title: "Renewal, Denials, and Retention" },
+    { id: "2024-03-d", title: "Cost Sharing (Out-of-Pocket Costs)" },
+    {
+      id: "2024-03-e",
+      title: "Employer Sponsored Insurance and Premium Assistance",
+    },
+    { id: "2024-03-f", title: "Program Integrity" },
+    { id: "2024-03-g", title: "Dental Benefits" },
+    { id: "2024-03-h", title: "CAHPS Survey Results" },
+    { id: "2024-03-i", title: "Health Services Initiatives (HSI) Programs" },
+  ]),
+  section(4, "State Plan Strategic Objectives and Performance Goals", [
+    { id: "2024-04-a", title: null },
+  ]),
+  section(5, "Program Financing", [{ id: "2024-05-a", title: null }]),
+  section(6, "Challenges and Accomplishments", [
+    { id: "2024-06-a", title: null },
+  ]),
+];
+
+const titleFor = (pathname, overrides = {}) =>
+  getPageTitle({
+    pathname,
+    hasUser: true,
+    formData,
+    stateName: "New York",
+    formYear: 2024,
+    ...overrides,
+  });
+
+describe("getPageTitle() - static routes", () => {
+  test("logged-out home is the login title", () => {
+    expect(getPageTitle({ pathname: "/", hasUser: false })).toBe(
+      "Login – CARTS"
+    );
+  });
+
+  test("logged-in home", () => {
+    expect(titleFor("/")).toBe("CHIP Annual Reporting Template System (CARTS)");
+  });
+
+  test("user profile", () => {
+    expect(titleFor("/user/profile")).toBe("User profile – CARTS");
+  });
+
+  test("get help", () => {
+    expect(titleFor("/get-help")).toBe("How can we help you? – CARTS");
+  });
+
+  test("unknown route -> page not found", () => {
+    expect(titleFor("/path-that-does-not-exist")).toBe(
+      "Page not found – CARTS"
+    );
+  });
+
+  test("templates", () => {
+    expect(titleFor("/templates")).toBe("Generate form base templates – CARTS");
+  });
+
+  test("state reports", () => {
+    expect(titleFor("/state-reports")).toBe("State reports – CARTS");
+  });
+
+  test("print view", () => {
+    expect(
+      getPageTitle({
+        pathname: "/print",
+        search: "?year=2024&state=NY",
+        hasUser: true,
+        stateName: "New York",
+      })
+    ).toBe("New York CARTS 2024 Report");
+  });
+});
+
+describe("getPageTitle() - form section routes (driven by JSON)", () => {
+  const expected = {
+    "/sections/2024/00": "Basic State Information – New York 2024 – CARTS",
+    "/sections/2024/01":
+      "Program Fees and Policy Changes – New York 2024 – CARTS",
+    "/sections/2024/02":
+      "Enrollment and Uninsured Data – New York 2024 – CARTS",
+    "/sections/2024/03/a": "Program Outreach – New York 2024 – CARTS",
+    "/sections/2024/03/b": "Substitution of Coverage – New York 2024 – CARTS",
+    "/sections/2024/03/c":
+      "Renewal, Denials, and Retention – New York 2024 – CARTS",
+    "/sections/2024/03/d":
+      "Cost Sharing (Out-of-Pocket Costs) – New York 2024 – CARTS",
+    "/sections/2024/03/e":
+      "Employer Sponsored Insurance and Premium Assistance – New York 2024 – CARTS",
+    "/sections/2024/03/f": "Program Integrity – New York 2024 – CARTS",
+    "/sections/2024/03/g": "Dental Benefits – New York 2024 – CARTS",
+    "/sections/2024/03/h": "CAHPS Survey Results – New York 2024 – CARTS",
+    "/sections/2024/03/i":
+      "Health Services Initiatives (HSI) Programs – New York 2024 – CARTS",
+    "/sections/2024/04":
+      "State Plan Strategic Objectives and Performance Goals – New York 2024 – CARTS",
+    "/sections/2024/05": "Program Financing – New York 2024 – CARTS",
+    "/sections/2024/06":
+      "Challenges and Accomplishments – New York 2024 – CARTS",
+    "/sections/2024/certify-and-submit":
+      "Certify and Submit – New York 2024 – CARTS",
+  };
+
+  for (const [path, title] of Object.entries(expected)) {
+    test(`${path}`, () => {
+      expect(titleFor(path)).toBe(title);
+    });
+  }
+
+  test("admin /views/sections route resolves the same section title", () => {
+    expect(titleFor("/views/sections/NY/2024/03/a")).toBe(
+      "Program Outreach – New York 2024 – CARTS"
+    );
+  });
+
+  test("falls back to state + year while formData is still loading", () => {
+    expect(
+      getPageTitle({
+        pathname: "/sections/2024/01",
+        hasUser: true,
+        formData: [],
+        stateName: "New York",
+      })
+    ).toBe("New York 2024 – CARTS");
+  });
+});
+
+describe("selectFormRouteTitle()", () => {
+  test("returns null when formData is empty", () => {
+    expect(selectFormRouteTitle([], 1)).toBeNull();
+  });
+
+  test("prefers subsection title when the subsection has one", () => {
+    expect(selectFormRouteTitle(formData, 3, "c")).toBe(
+      "Renewal, Denials, and Retention"
+    );
+  });
+
+  test("falls back to section title for untitled subsections", () => {
+    expect(selectFormRouteTitle(formData, 1, "a")).toBe(
+      "Program Fees and Policy Changes"
+    );
+  });
+});

--- a/services/ui-src/src/util/pageTitles.test.js
+++ b/services/ui-src/src/util/pageTitles.test.js
@@ -102,43 +102,21 @@ describe("getPageTitle() - static routes", () => {
 });
 
 describe("getPageTitle() - form section routes (driven by JSON)", () => {
-  const expected = {
-    "/sections/2024/00": "Basic State Information – New York 2024 – CARTS",
-    "/sections/2024/01":
-      "Program Fees and Policy Changes – New York 2024 – CARTS",
-    "/sections/2024/02":
-      "Enrollment and Uninsured Data – New York 2024 – CARTS",
-    "/sections/2024/03/a": "Program Outreach – New York 2024 – CARTS",
-    "/sections/2024/03/b": "Substitution of Coverage – New York 2024 – CARTS",
-    "/sections/2024/03/c":
-      "Renewal, Denials, and Retention – New York 2024 – CARTS",
-    "/sections/2024/03/d":
-      "Cost Sharing (Out-of-Pocket Costs) – New York 2024 – CARTS",
-    "/sections/2024/03/e":
-      "Employer Sponsored Insurance and Premium Assistance – New York 2024 – CARTS",
-    "/sections/2024/03/f": "Program Integrity – New York 2024 – CARTS",
-    "/sections/2024/03/g": "Dental Benefits – New York 2024 – CARTS",
-    "/sections/2024/03/h": "CAHPS Survey Results – New York 2024 – CARTS",
-    "/sections/2024/03/i":
-      "Health Services Initiatives (HSI) Programs – New York 2024 – CARTS",
-    "/sections/2024/04":
-      "State Plan Strategic Objectives and Performance Goals – New York 2024 – CARTS",
-    "/sections/2024/05": "Program Financing – New York 2024 – CARTS",
-    "/sections/2024/06":
-      "Challenges and Accomplishments – New York 2024 – CARTS",
-    "/sections/2024/certify-and-submit":
-      "Certify and Submit – New York 2024 – CARTS",
-  };
+  test("top-level section uses the section title", () => {
+    expect(titleFor("/sections/2024/00")).toBe(
+      "Basic State Information – New York 2024 – CARTS"
+    );
+  });
 
-  for (const [path, title] of Object.entries(expected)) {
-    test(`${path}`, () => {
-      expect(titleFor(path)).toBe(title);
-    });
-  }
-
-  test("admin /views/sections route resolves the same section title", () => {
-    expect(titleFor("/views/sections/NY/2024/03/a")).toBe(
+  test("titled subsection uses the subsection title", () => {
+    expect(titleFor("/sections/2024/03/a")).toBe(
       "Program Outreach – New York 2024 – CARTS"
+    );
+  });
+
+  test("certify-and-submit uses a fixed lead", () => {
+    expect(titleFor("/sections/2024/certify-and-submit")).toBe(
+      "Certify and Submit – New York 2024 – CARTS"
     );
   });
 
@@ -196,8 +174,8 @@ describe("selectFormRouteTitle()", () => {
 });
 
 describe("title/route registry stays in sync", () => {
-  // This test helps guard against drift: if a route is added to ROUTE_PATHS 
-  // (and therefore the router) without a matching title entry this fails, 
+  // This test helps guard against drift: if a route is added to ROUTE_PATHS
+  // (and therefore the router) without a matching title entry this fails,
   // so a new route can't silently fall through to "Page not found".
   test("every ROUTE_PATHS pattern has exactly one title entry and vice versa", () => {
     const declared = Object.values(ROUTE_PATHS).sort();

--- a/services/ui-src/src/util/pageTitles.test.js
+++ b/services/ui-src/src/util/pageTitles.test.js
@@ -1,4 +1,5 @@
-import { getPageTitle, selectFormRouteTitle } from "./pageTitles";
+import { getPageTitle, selectFormRouteTitle, titleRoutes } from "./pageTitles";
+import { ROUTE_PATHS } from "./routePaths";
 
 // Minimal formData mirroring the 2024 section JSON (only fields the
 // resolver reads: section ordinal/title and subsection id/title).
@@ -160,5 +161,16 @@ describe("selectFormRouteTitle()", () => {
     expect(selectFormRouteTitle(formData, 1, "a")).toBe(
       "Program Fees and Policy Changes"
     );
+  });
+});
+
+describe("title/route registry stays in sync", () => {
+  // Guards against drift: if a route is added to ROUTE_PATHS (and therefore the
+  // router) without a matching title entry — or vice versa — this fails, so a
+  // new route can't silently fall through to "Page not found".
+  test("every ROUTE_PATHS pattern has exactly one title entry and vice versa", () => {
+    const declared = Object.values(ROUTE_PATHS).sort();
+    const titled = titleRoutes.map((route) => route.path).sort();
+    expect(titled).toEqual(declared);
   });
 });

--- a/services/ui-src/src/util/routePaths.js
+++ b/services/ui-src/src/util/routePaths.js
@@ -1,0 +1,30 @@
+/**
+ * Single source of truth for the app's route path patterns.
+ *
+ * Both the router (`AppRoutes.jsx`) and the document-title resolver
+ * (`pageTitles.js`) import these constants, so a path can only be defined or
+ * renamed in one place. `pageTitles.test.js` asserts that every entry here has
+ * a corresponding title, which fails the build if the two ever drift apart.
+ *
+ * Patterns use React Router syntax (`:param`, `*`). Order does not matter:
+ * React Router ranks matches by specificity, so e.g. the static
+ * `certify-and-submit` segment always wins over `:sectionOrdinal`.
+ */
+export const ROUTE_PATHS = {
+  home: "/",
+  userProfile: "/user/profile",
+  print: "/print",
+  getHelp: "/get-help",
+  // State user form URLs
+  sectionSubsection: "/sections/:year/:sectionOrdinal/:subsectionMarker",
+  section: "/sections/:year/:sectionOrdinal",
+  certifyAndSubmit: "/sections/:year/certify-and-submit",
+  // Admin / CMS user form URLs
+  viewsSectionSubsection:
+    "/views/sections/:state/:year/:sectionOrdinal/:subsectionMarker",
+  viewsSection: "/views/sections/:state/:year/:sectionOrdinal",
+  stateReports: "/state-reports",
+  templates: "/templates",
+  // Catch-all (404)
+  notFound: "*",
+};

--- a/services/ui-src/src/util/routePaths.js
+++ b/services/ui-src/src/util/routePaths.js
@@ -1,15 +1,6 @@
-/**
- * Single source of truth for the app's route path patterns.
- *
- * Both the router (`AppRoutes.jsx`) and the document-title resolver
- * (`pageTitles.js`) import these constants, so a path can only be defined or
- * renamed in one place. `pageTitles.test.js` asserts that every entry here has
- * a corresponding title, which fails the build if the two ever drift apart.
- *
- * Patterns use React Router syntax (`:param`, `*`). Order does not matter:
- * React Router ranks matches by specificity, so e.g. the static
- * `certify-and-submit` segment always wins over `:sectionOrdinal`.
- */
+// Single source of route path patterns, shared by AppRoutes.jsx and
+// pageTitles.js so a path is defined once. React Router syntax (:param, *);
+// order doesn't matter since matches are ranked by specificity.
 export const ROUTE_PATHS = {
   home: "/",
   userProfile: "/user/profile",

--- a/services/ui-src/src/util/routePaths.js
+++ b/services/ui-src/src/util/routePaths.js
@@ -1,6 +1,5 @@
 // Single source of route path patterns, shared by AppRoutes.jsx and
-// pageTitles.js so a path is defined once. React Router syntax (:param, *);
-// order doesn't matter since matches are ranked by specificity.
+// pageTitles.js so a path is defined once.
 export const ROUTE_PATHS = {
   home: "/",
   userProfile: "/user/profile",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11186,7 +11186,6 @@ __metadata:
     prop-types: "npm:^15.8.1"
     react: "npm:^19.2.5"
     react-dom: "npm:^19.2.5"
-    react-helmet: "npm:^6.1.0"
     react-multi-select-component: "npm:4.3.4"
     react-redux: "npm:^9.2.0"
     react-router: "npm:^7.15.1"
@@ -13330,7 +13329,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.6.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -13516,27 +13515,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-fast-compare@npm:^3.1.1":
-  version: 3.2.2
-  resolution: "react-fast-compare@npm:3.2.2"
-  checksum: 10c0/0bbd2f3eb41ab2ff7380daaa55105db698d965c396df73e6874831dbafec8c4b5b08ba36ff09df01526caa3c61595247e3269558c284e37646241cba2b90a367
-  languageName: node
-  linkType: hard
-
-"react-helmet@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "react-helmet@npm:6.1.0"
-  dependencies:
-    object-assign: "npm:^4.1.1"
-    prop-types: "npm:^15.7.2"
-    react-fast-compare: "npm:^3.1.1"
-    react-side-effect: "npm:^2.1.0"
-  peerDependencies:
-    react: ">=16.3.0"
-  checksum: 10c0/1d2831d9c3b4f5c91f020076aeb6502437a4788077d0c438421e466eb9633d5dc2aacedf7b779a970b807d61cf87793c5ff76ee3190a185d71c90b5cfb367e96
-  languageName: node
-  linkType: hard
-
 "react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -13600,15 +13578,6 @@ __metadata:
     react-dom:
       optional: true
   checksum: 10c0/3daff5404c7de1429447e735f1ee7e070d4f11632f589cec70c5171f2357be9cada2162f780bc9061eb153646109ad6e80c2d10a6b27256593f28a66945f4c76
-  languageName: node
-  linkType: hard
-
-"react-side-effect@npm:^2.1.0":
-  version: 2.1.2
-  resolution: "react-side-effect@npm:2.1.2"
-  peerDependencies:
-    react: ^16.3.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/5d934cae438f701ce646f566750ae6a445e99185ce1a026108f9db728147f7962a22ecf8db79ff26089953a3799b3607766904f4f10194ce42bcd5a1aa0215e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
When navigating to different pages, the title of the pages never change. Each page should have a unique title, so lets change that!

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4851

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary